### PR TITLE
NEXT-12767 [MIGRATE] Administration: Add new route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.vscode

--- a/guides/plugins/apps/administration/add-custom-route.md
+++ b/guides/plugins/apps/administration/add-custom-route.md
@@ -1,0 +1,33 @@
+# Overview
+Routes in the Shopware 6 Administration are essentially the same as in any other [Vue Router] (https://router.vuejs.org/) This guide will teach you the basics of creating your very first route from scratch.
+
+## Prerequisites
+All you need for this guide is a running Shopware 6 instance and full access to both the files and preferably a registered module.
+Of course you'll have to understand JavaScript, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation.
+
+## Configuring the route
+In order to add routes to a module you simply add a routes property, which expects an object containing multiple route configuration objects. Each route configuration object needs to have a name, which is set using the configuration object's key, a component to render and a path.
+
+```javascript
+// routes: {
+//     nameOfTheRoute: {
+//         component: 'example',
+//         path: 'actualPathInTheBrowser'
+//     }
+// }
+routes: {
+    overview: {
+        component: 'sw-product-list',
+        path: 'overview'
+    },
+},
+```
+The component represents the technical name of the component, which is then rendered when this route is matched. Routes can be matched by name and path. This configuration results in this route's full name being `custom.module.overview` and the URL being `/overview` relative to the Administration's default URL.
+Usually you want to render your custom component here, which is explained [PLACEHOLDER-LINK: Creating a component in the Administration] here.
+But that is not all! Routes can have parameters, to then be handed to the components being rendered and much more. Learn more about what the Vue Router can do in its official [Documentation] (https://router.vuejs.org/guide/essentials/dynamic-matching.html#reacting-to-params-changes).
+
+## Next steps
+As you might have noticed, your route is just rendering a Shopware made component.
+But here's a list of things you can do now:
+* Creating a new administration component [PLACEHOLDER-LINK: Creating administration module]
+* Extending an existing administration component to display [PLACEHOLDER-LINK: Plugin configuration]

--- a/guides/plugins/apps/administration/customizing-components.md
+++ b/guides/plugins/apps/administration/customizing-components.md
@@ -1,0 +1,48 @@
+# Overview
+The Shopware 6 Administration allows you to override twig blocks to change its content. This guide will teach you the basics of overriding parts of the Administration.
+
+## Prerequisites
+All you need for this guide is a running Shopware 6 instance and full access to both the files, as well as the command line and preferably registered module.
+Of course you'll have to understand JavaScript and a basic familiarity with TwigJS, the templating engine, used in the Administration, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation.
+
+## Finding the block to override
+In this guide we want to change the heading of the Shopware 6 dashboard to be `Welcome to a customized component` instead of `Welcome to Shopware 6`. To do this we first need to find a appropriate twig block to override to not replace to much but also to not override to little of the administration.
+In this case we only want to override the headline and not links or anything else on the page. Looking at the twig markup for the dashboard [here] (https://github.com/shopware/platform/blob/master/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/sw-dashboard-index.html.twig), suggests that we only need to override the Twig block with the name `sw_dashboard_index_content_intro_content_headline` to achieve our goal.
+
+## Preparing the override
+Now that we now where to place our override, we now need to decide what to override it with. In this very simple example it suffices to create a twig file, declare a block with the name we previously found and to insert our new heading in the block
+
+```twig
+{% block sw_product_settings_form_content %}
+    <h1>
+        Welcome to a customized component
+    </h1>
+{% endblock %}
+```
+
+This overrides the entire Twig block with our new markup. If we however want to retain the original content of the Twig block and just add our markup to the existing markup, then we can do that by including a `{% parent %}` somewhere in the Twig block. Learn more about the capabilities of twig.js [here] (https://github.com/twigjs/twig.js/wiki)
+
+As you might have noticed the heading we just replaced had a `{ $tc() }` insertion wich is used to make it multilingual. Learn more about internationalization here and about adding your own snippets to the administration here.
+
+## Appling the override
+The main entry point to customize the administration via plugin is the main.js file. It has to be placed into the `<plugin root>/src/Resources/app/administration/src` directory in order to be automatically found by Shopware 6.
+Then you just need to add the override of the Vue component, using the override method, to our ComponentFactory.
+
+``` javascript
+import template from './src/extension/sw-product-settings-form/sw-product-settings-form.html.twig';
+
+Shopware.Component.override('sw-product-settings-form', {
+    template
+});
+```
+
+The first parameter matches the component to override, the second parameter has to be an object containing the actually overridden properties , e.g. the new twig template extension for this component.
+
+## Loading the JavaScript File
+The only thing now left to just load the `main.js` of our plugin code, learn how to to that [PLACEHOLDER-LINK: Creating administration plugin]
+
+## Next steps
+As you might have noticed, your route is just rendering static markup.
+But here's a list of things you can do now:
+* Creating a new administration component [PLACEHOLDER-LINK: Creating administration component]
+* Extending an existing administration component to display [PLACEHOLDER-LINK: Plugin configuration]


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to add a new route to the administration.
This can be migrated from our previous documentation.

This article should mention:

    The prerequisite, a working plugin (Refer to the plugin base guide)
    Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
    A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/custom-module#routes
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/indepth-guide-bundle/administration#setting-up-routes

For more information, ask me, Patrick Stahl.