### PR TITLE
NEXT-12572 - Add jest testing article

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -123,6 +123,7 @@
       * [Add custom styling](guides/plugins/plugins/storefront/add-custom-styling.md)
     * [Testing](guides/plugins/plugins/testing.md)
       * [End-to-end testing](guides/plugins/plugins/testing/end-to-end-testing.md)
+      * [Jest unit tests in Shopware's administration](guides/plugins/plugins/testing/jest-admin.md)
   * [Themes](guides/plugins/themes.md)
   * [Apps](guides/plugins/apps/README.md)
     * [App Base Guide](guides/plugins/apps/app-base-guide.md)


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to write administration unit tests.

This article should mention:

    The prerequisite, a working plugin (Refer to the plugin base guide)
    How to setup the test environment (PSH commands necessary)
    The necessary structure
    Reference to jest tests
    Example test
    How to execute these tests (and just these!)

Category: Extensions > Plugins > Testing
Are there already guides in the previous documentation for this?

Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.