### PR TITLE
NEXT-13139 - Add installation overview

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -73,7 +73,7 @@
 ## Guides
 
 * [Installation](guides/installation/README.md)
-  * [Overview](guides/installation/overview.md)
+  * [Installation overview](guides/installation/overview.md)
   * [Dockware](guides/installation/dockware.md)
   * [Docker](guides/installation/docker.md)
   * [from scratch](guides/installation/from-scratch.md)

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -1,13 +1,111 @@
-# Overview
+# Installation overview
 
-## Setup Templates
+There are a couple of ways to get Shopware running on your system. Depending on what best suits your development 
+environment, you have the following choices:
+
+* [PLACEHOLDER-LINK: Docker]: The docker installation is the easiest way to get a running Shopware 6.
+* [PLACEHOLDER-LINK: MAMP]: For quick and easy installation you can also use MAMP tool on mac.
+* [PLACEHOLDER-LINK: Vagrant]: Vagrant is another great technology to quickly get a local Shopware up and running.
+* [PLACEHOLDER-LINK: Valet+]: You can install Shopware with the epl of Valet+, which is a fork of laravel/valet. 
+* [PLACEHOLDER-LINK: Dockware]: This is a managed docker setup for Shopware 6 by shopware agency dasistweb.
+* [PLACEHOLDER-LINK: Installation from Scratch]: You can install Shopware 6 locally. However, be aware that this will 
+be the more complex solution since additional or changed system requirements need to be managed by you.
+
+## Prerequisites
+
+### System requirements
+
+Before installing Shopware 6, you should take a quick look at the requirements to check if your local environment 
+is capable of running it.
+
+You can use these commands for checking your actual environment:
+- `php -v`: Show CLI PHP version
+- `php -m`: Show CLI PHP modules
+- `php -i | grep memory_limit`: Show your actual CLI PHP memory limit
+- `composer -v`: Show your actual composer version
+- `node -v`: Show you actual Node version
+- `npm -v`: Show you actual NPM version
+
+To get more information about your server PHP setup, you can create a `phpinfo.php` file with this content:
+```php
+<?php phpinfo(); ?>
+```
+When you now open your Browser and go to the `phpinfo.php` page then you can see all information about
+your actual PHP setup. Check if they also match with the requirements.
+
+#### Operating System
+
+Although Shopware 6 supports most UNIX like environments, we recommend using **Ubuntu 18.04 LTS** or  
+**macOS Mojave 10.14** to get the best experience.
+
+#### Environment
+
+PHP
+*  7.2 or higher
+* `memory_limit` 512M minimum
+* `max_execution_time` 30 seconds minimum
+* Extensions:
+    * ext-curl
+    * ext-dom  
+    * ext-fileinfo  
+    * ext-gd  
+    * ext-iconv  
+    * ext-intl  
+    * ext-json  
+    * ext-libxml  
+    * ext-mbstring  
+    * ext-openssl  
+    * ext-pcre  
+    * ext-pdo  
+    * ext-pdo_mysql  
+    * ext-phar  
+    * ext-simplexml  
+    * ext-xml  
+    * ext-zip  
+    * ext-zlib
+* Composer 1.6 or higher
+
+SQL
+* MySQL 5.7.21 or higher
+* MariaDB 10.3.22 or higher
+
+JavaScript
+* Node.js 10.13.0 or higher
+* NPM 6.5.0 or higher
+
+Various
+* Apache 2.4 or higher with mod-rewrite enabled
+* Bash
+* Git
+
+### Recommendations
+
+- Zend Opcache (256M or more)
+- APCu (128M or more)
+- Webserver with HTTP2 support
+
+Adminer (https://www.adminer.org/) is our recommended database administration tool since it has better support for 
+binary data types.
+
+### Requirements for docker setup
+
+If you are working on Linux there is a curated docker setup, that takes care of setting up the environment for you.
+
+In this case you need:
+
+* PHP 7.2+ CLI
+* docker
+* docker-compose
+* bash
+
+### Setup Templates
 
 Depending on your goal you can choose from **two different** so-called templates for your local Shopware setup. 
 
 * Shopware Production Template
 * Shopware Development Template
 
-Let's discuss their differences so you can make an informed decision.
+Let's discuss their differences, so you can make an informed decision.
 
 | Task | shopware/production | shopware/development |
 | :--- | :--- | :--- |
@@ -16,7 +114,47 @@ Let's discuss their differences so you can make an informed decision.
 | Build a custom project / deployment | ✅ | ❌ |
 | Manage dependencies / bundles | ✅ | ❌ |
 
+## Preparatory steps
 
+Either installation method requires you to check out the sources first.
+Shopware 6 is split into two repositories the [development template](https://github.com/shopware/development) 
+and the [platform](https://github.com/shopware/platform) itself.
 
+Let's start by cloning the development template:
 
+```bash
+> git clone https://github.com/shopware/development.git
+```
 
+You now have the application template for Shopware 6 in the directory `development`, we now navigate into it:
+
+```bash
+> cd development
+```
+
+Per default the development template has `shopware/platform` in the version `dev-master` as requirement in its 
+`composer.json` file.
+This always corresponds to the latest commit on the master branch on GitHub. If you want to use a specific version 
+change `dev-master` to `6.1` for example. Now Shopware 6.1 will be installed instead of the latest master state.
+
+Only if you want to work with the Shopware platform code itself, e.g. in order to create a pull request for it, 
+you should clone the `platform` code manually. Before doing so, remove the existing platform directory.
+
+```bash
+> rm -rf platform
+> git clone https://github.com/shopware/platform.git
+```
+
+Otherwise, the Shopware platform code would be placed into a `vendor/shopware/platform` directory, where you 
+don't want to change any code. There's a good reason why many IDEs try to prevent you from changing code in 
+the `vendor` directory.
+
+## Next steps
+
+As already mentioned, there are several ways to install Shopware. So we got you covered, no matter which 
+operation system or environment you like to use. Head over to whatever way you like:
+* [PLACEHOLDER-LINK: Docker]
+* [PLACEHOLDER-LINK: Dockware]
+* [PLACEHOLDER-LINK: Valet+]
+* [PLACEHOLDER-LINK: Vagrant guide]
+* [PLACEHOLDER-LINK: MacOS using MAMP installation guide]


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains an overview of Shopware installation.
This can be migrated from our previous documentation.

This article should mention:

    List all possible installation ways (Docker, MAMP, Vagrant, Valet+, Dockware, from Scratch, ...)
    List the system requirements
    Difference Production vs Dev Template

Category: Installation
Are there already guides in the previous documentation for this?

Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!
https://docs.shopware.com/en/shopware-platform-dev-en/system-guide/system-requirements
https://docs.shopware.com/en/shopware-platform-dev-en/system-guide/installation

For more information, ask me, Patrick Stahl.