### PR TITLE
NEXT-12759  [MIGRATE] Administration: Add vue templates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -123,6 +123,7 @@
     * [Administration](guides/plugins/plugins/administration/README.md)
       * [Adding permissions](guides/plugins/plugins/administration/add-acl-rules.md)
       * [Add custom route](guides/plugins/plugins/administration/add-custom-route.md)
+      * [Writing templates](guides/plugins/plugins/administration/writing-templates.md)
       * [Customizing components](guides/plugins/plugins/administration/customizing-components.md)
     * [Storefront](guides/plugins/plugins/storefront/README.md)
       * [Add custom controller](guides/plugins/plugins/storefront/add-custom-controller.md)

--- a/guides/plugins/plugins/administration/writing-templates.md
+++ b/guides/plugins/plugins/administration/writing-templates.md
@@ -1,0 +1,52 @@
+# Writing templates
+
+## Overview
+The Shopware 6 Administration uses a combination of [twig](https://twig.symfony.com/) and [Vue](https://vuejs.org/) templates in its administration to provide easy extendibility. This guide will teach you how to use templates to extend the Administration with twig and Vue and how import them into a component.  
+
+## Prerequisites
+All you need for this guide is a running Shopware 6 instance and full access to both the files and a registered module. Of course you'll have to understand JavaScript, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation.
+
+## Writing a template
+Templates in Shopware are usually defined in a separate `.twig` file, named after the component, in the component's directory. Each module's page should start with the `sw-page` component, because it provides a search bar, a page header and a `content` slot for your content. Components in general should also include twig blocks, in order to be extendable by other plugins. 
+
+Let's look at all of this in practice, with the example of a component statically printing `'Hello World'`:
+
+```html
+{% block swag_basic_example_page %}
+    <sw-page class="swag-example-list">
+        <template slot="content">
+            <h2>Hello world!</h2>
+        </template>
+    </sw-page>
+{% endblock %}
+```
+
+## Setting the Template
+Each component has a template property, which is used to set the template. To use the previously created template file, import it and assign it to the `template` property of the component.
+
+```javascript
+import template from './swag-basic-example.html.twig';
+
+Shopware.Component.register('swag-basic-example', {
+    template, // ES6 shorthand for: 'template: template'  
+
+    metaInfo() {
+        return {
+            title: this.$createTitle()
+        };
+    },
+});
+```
+Note: The meta info is part of [vue-meta](https://vue-meta.nuxtjs.org/) and is used to set the title of the whole page. The `this.$createTitle()` generates a title.
+
+## Theory: Vue vs Twig
+The Shopware 6 Administration mixes, as mentioned in the beginning, [twig](https://twig.symfony.com/) and [Vue](https://vuejs.org/) to provide extensibility. But for what is twig used and for what is Vue used? 
+
+Generally speaking, twig is used for **extending** from another template and adjusting it to your needs. For example overriding a twig block could provide a hook to place your own markup. But be careful overrides apply to all occurrences of this template.
+
+Vue is used to link the data and the DOM in order to make them reactive. Learn about Vue and its capabilities [here](https://vuejs.org/v2/guide/index.html).
+
+## Next steps
+As you might have noticed, we are just rendering static text, so maybe you want to try the following things:
+* How to override parts of existing components [PLACEHOLDER-LINK: how to override parts of existing components]
+* How to use the admin API to fetch data in the administration [PLACEHOLDER-LINK: how to use the admin API to fetch data in the administration]


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to add vue templates, e.g. to a component.
This can be migrated from our previous documentation.

This article should mention:

    The prerequisite, a working plugin (Refer to the plugin base guide)
    Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
    A short code example, including an explanation, on how to do it
    Also add: TwigJS != PHP Twig

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/indepth-guide-bundle/administration#the-list-component
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/indepth-guide-bundle/administration#the-detail-component

For more information, ask me, Patrick Stahl.