### PR TITLE
NEXT-12768 - [MIGRATE] Administration: Add custom service

### DIFF
--- a/guides/plugins/plugins/administration/add-custom-service.md
+++ b/guides/plugins/plugins/administration/add-custom-service.md
@@ -78,6 +78,11 @@ Service decoration can be us in a variety of ways.
 Services can be initialized right after their creation and single methods can get an altered behavior.
 Like in the service registration, a script that is part of the `main.js` is needed.
 
+{% hint style="warning" %}
+Decorators are just simple functions, which intercept a service in the provider phase.
+This means that a service can only be decorated in the timeframe between it being created and it being accessed for the first time.
+{% endhint %}
+
 If you need to alter a service method return value or add an additional parameter you can also do this using decoration.
 For this example a `funny` attribute is added to the requested jokes by the previously registered `JokeService`:
 


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains how to add a custom service to the administration.
 This can be migrated from our previous documentation.
This article should mention:
The prerequisite, a working plugin (Refer to the plugin base guide)
Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
A short code example, including an explanation, on how to do it
Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?
Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!
 https://docs.shopware.com/en/shopware-platform-dev-en/how-to/decorate-administration-js-service#register-a-new-service