### PR TITLE
NEXT-13184 - Theme - Override Boostrap variables in a theme

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -174,6 +174,7 @@
   * [Themes](guides/plugins/README.md)
     * [Create a first theme](guides/plugins/themes/create-a-theme.md)
     * [Theme configuration](guides/plugins/themes/theme-configuration.md)
+    * [Override Bootstrap variables in a Theme](guides/plugins/themes/override-bootstrap-variables-in-a-theme.md)
     * [Add assets to a Theme](guides/plugins/themes/add-assets-to-theme.md)
     * [Theme inheritance](guides/plugins/themes/add-theme-inheritance.md)
   * [Apps](guides/plugins/apps/README.md)

--- a/guides/plugins/themes/override-bootstrap-variables-in-a-theme.md
+++ b/guides/plugins/themes/override-bootstrap-variables-in-a-theme.md
@@ -1,0 +1,87 @@
+# Override Bootstrap variables in a Theme
+
+## Overview
+
+The storefront theme is implemented as a skin on top of the [Boostrap](https://getbootstrap.com/).
+
+Sometimes it is necessary to adjust SCSS variables if you want to change the look of the Storefront for example default variables like `$border-radius` which is defined by Boostrap.
+This guide will show how you can override those SCSS variables.
+
+## Prerequisites
+
+All you need for this guide is a running Shopware 6 instance and full access to both the files, as well as the command line. You also need to have an installed and activated theme which is assigned to a sales channel.
+Checkout the [PLACEHOLDER-LINK: Create a first theme] guide if you have not yet a working theme setup.
+
+## Override default SCSS variables
+
+Bootstrap 4 is using the `!default` flag for it's own default variables. Variable overrides have to be declared beforehand.
+
+More information can be found [here](https://getbootstrap.com/docs/4.0/getting-started/theming/#variable-defaults).
+
+To be able to override Bootstrap variables there is an additional SCSS entry point defined in your `theme.json` which is declared before `@Storefront`.
+
+This entry point is called `overrides.scss`:
+
+{% code title="<plugin root>/src/Resources/theme.json" %}
+{
+  "name": "SwagBasicExampleTheme",
+  "author": "Shopware AG",
+  "views": [
+        "@Storefront",
+        "@Plugins"
+  ],
+  "style": [
+    "app/storefront/src/scss/overrides.scss", <-- Variable overrides
+    "@Storefront",
+    "app/storefront/src/scss/base.scss"
+  ],
+  "script": [
+    "@Storefront",
+    "app/storefront/dist/storefront/js/just-another-theme.js"
+  ],
+  "asset": [
+    "@Storefront",
+    "app/storefront/src/assets"
+  ]
+}
+{% endcode %}
+
+In the `<plugin root>/src/Resources/app/storefront/src/scss/overrides.scss` you can now override default variables like `$border-radius` globally and set its value to `0` to reset it in this case:
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/scss/overrides.scss" %}
+/*
+Override variable defaults
+==================================================
+This file is used to override default SCSS variables from the Shopware Storefront or Bootstrap.
+
+Because of the !default flags, theme variable overrides have to be declared beforehand.
+https://getbootstrap.com/docs/4.0/getting-started/theming/#variable-defaults
+*/
+
+$border-radius: 0;
+
+// some other override examples
+$icon-base-color: #f00;
+$modal-backdrop-bg: rgba(255, 0, 0, 0.5);
+$disabled-btn-bg: #f00;
+$disabled-btn-border-color: #fc8;
+$font-weight-semibold: 300;
+{% endcode %}
+
+After saving the `overrides.scss` file and running `bin/console theme:compile` go and check out the Storefront in the browser. The `border-radius` should be removed for every element.
+
+{% hint style="warning" %}
+Please only add variable overrides in this file. You should not write CSS code like `.container { background: #f00 }` in this file.
+{% endhint %}
+
+{% hint style="info" %}
+When running `./psh.phar storefront:hot-proxy` SCSS variables will be injected dynamically by webpack. When writing selectors and properties in the `overrides.scss` the code can appear multiple times in your built CSS.
+{% endhint %}
+
+## Next steps
+
+Now that you know how to override Boostrap variables, here is a list of related topics which might be interesting for you.
+
+* Theme configuration [PLACEHOLDER-LINK: Theme configuration] 
+* Add SCSS Styling and JavaScript to a Theme [PLACEHOLDER-LINK: Add SCSS Styling and JavaScript to a Theme] 
+* Add assets to a theme [PLACEHOLDER-LINK: Add assets to a Theme]


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains Shopware Themes and give a base guide for Theme developers.
This article should mention:
Explain how to override bootstrap variables in a theme
Category: Extensions > Themes > Override bootstrap variables in a theme