### PR TITLE
NEXT-12742 - [NEW] Administration: Using the Shopware object

### DIFF
--- a/guides/plugins/plugins/administration/the-shopware-object.md
+++ b/guides/plugins/plugins/administration/the-shopware-object.md
@@ -1,0 +1,82 @@
+# The Shopware Objekt
+
+
+## Overview
+
+The global `Shopware` object is the bridge between the Shopware Administration and your plugin as third party code.
+It provides utility functions to interface to the rest of the Administration.
+
+{% hint style="warning" %}
+  Don't try to access other parts of the administration directly, always use the `Shopware` object.
+{% endhint %}
+
+It is bound to a window object in order to be accessible everywhere and can therefore be inspected with the browser console in the developer tools. 
+To take a look at it, open the `Administration` in your browser and run this in the dev-tools console:
+ 
+```js
+// run this command in the dev-tools of your browser
+console.log(Shopware);
+```
+
+There are lots of things bound to this object. So here is a short overview of the most commonly used parts. 
+
+## Component
+
+The `Component` property of the global `Shopware` contains the component registry, wich is responsible for handling the VueJS components.
+If you want to write your own components you have to register them with the `Component.register()` method.
+Those components are small reusable building blocks which you can use to implement your features.
+
+```javascript
+const { Component } = Shopware;
+
+Component.register('sw-dashboard-index', {
+    template
+});
+```
+
+Learn more about them here: \[PLACEHOLDER-LINK: Creating administration component\]
+
+## Module
+
+The `Module` property of the global `Shopware` contains the module registry.
+A `Module` is an encapsulated unit of routes and pages, which implements a whole feature. 
+For example there are modules for customers, orders, settings, etc.
+
+```javascript
+const { Module } = Shopware;
+
+Module.register('your-module', {});
+```
+
+Learn more about them here: \[PLACEHOLDER-LINK: Creating administration module\]
+
+## A more general overview
+
+We now have discussed the most commonly used parts of the `Shopware` object, but there is much more to discover. Take a look at all these options in a brief overview below:
+
+| Property   | Description                                                                                  |
+|------------|----------------------------------------------------------------------------------------------|
+| ApiService | Registry which holds services to fetch data from the api                                     |
+| Component  | A registry for VueJS `components`                                                            |
+| Context    | A set of contexts for the `app` and the `api`                                                |
+| Defaults   | A collection of default values                                                               |
+| Directive  | A registry for (VueJS `directives`)[https://vuejs.org/v2/guide/custom-directive.html]        |
+| Filter     | A registry for (VueJS template `filters`)[https://vuejs.org/v2/guide/filters.html]           |
+| Helper     | A collection of helpers, e.g. the `DeviceHelper` where you can listen on the `resize` event  |
+| Locale     | A registry for `locales`                                                                     |
+| Mixin      | A registry for `mixins`                                                                      |
+| Module     | A registry for `modules`                                                                     |
+| Plugin     | An interface to add `promise`based hooks to run when the administration launches             |
+| Service    | A helper to get quick access to service, e.g. `Shopware.Service('snippetService')`           |
+| Shortcut   | A registry for keyboard shortcuts                                                            |
+| State      | A wrapper for the (VueX)[https://vuex.vuejs.org/] store to manage state                      |
+| Utils      | A collection of utility methods like `createId`                                              |
+
+
+## Next steps
+
+As you might have noticed, the `Shopware` object can be used in a lot of cases. See it in action here:
+
+* Creating a new administration component \[PLACEHOLDER-LINK: Creating administration component\]
+* Creating a new administration module \[PLACEHOLDER-LINK: Creating administration module\]
+* Internationalization in the Shopware 6 Administration \[PLACEHOLDER-LINK: Creating and using Snippets in the Shopware 6 Administration\]


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to use the Shopware Global object in the administration.

This article should mention:

    The prerequisite, a working plugin (Refer to the plugin base guide)
    Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
    A short code example, including an explanation, on how to do it
    Explain: No other imports from core allowed! Use Shopware object!

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.