### PR TITLE
NEXT-12769 -  [MIGRATE] Administration: Using services

### DIFF
--- a/guides/plugins/plugins/administration/injecting-services.md
+++ b/guides/plugins/plugins/administration/injecting-services.md
@@ -1,0 +1,43 @@
+# Injecting services
+
+## Overview
+
+This short guide will teach you how to use a service in the Shopware 6 Administration.
+
+Along these lines, this chapter will cover the following topics:
+
+* What is an administration service?
+* How to use a service?
+
+## Prerequisites
+
+All you need for this guide is a running Shopware 6 instance and full access to both the files and a running plugin.
+Of course you'll have to understand JavaScript, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation.
+
+## Definition of an administration service
+
+Shopware 6 uses (bottleJS)[https://github.com/young-steveo/bottlejs] to inject services.
+Services are small self-contained utility classes, like the [repositoryFactory](https://github.com/shopware/platform/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/core/data-new/repository-factory.data.js), which provides a way to talk to the API.
+
+## Injection of a service
+
+A service is typically injected into a vue component and can simply be referenced in the `inject` property.
+This service is then available via its name on the object instance.
+
+```javascript
+Shopware.Component.register('swag-basic-example', {
+    // inject the service
+    inject: ['repositoryFactory'],
+
+    created() {
+        // insatiate the injected repositoryFactory 
+        this.productRepository = this.repositoryFactory.create('product')
+    }
+});
+```
+
+## Next steps
+
+Now that we know what services are, we might want to do one of the following things:
+* Creating your own service [PLACEHOLDER-LINK: Creating your own service]
+* Using the data handling [PLACEHOLDER-LINK: Using the Data handling]


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to use a service in the administration.
This can be migrated from our previous documentation.

This article should mention:

- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!

Search for "Inject": https://docs.shopware.com/en/shopware-platform-dev-en/how-to/indepth-guide-bundle/administration

For more information, ask me, Patrick Stahl.