### PR TITLE
NEXT-12772 - Add guide on adding custom styles to components

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -149,6 +149,7 @@
       * [Customizing components](guides/plugins/plugins/administration/customizing-components.md)
       * [Add own component](guides/plugins/plugins/administration/add-custom-component.md)
       * [Adding snippets](guides/plugins/plugins/administration/adding-snippets.md)
+      * [Add custom styles](guides/plugins/plugins/administration/add-custom-styles.md)
     * [Storefront](guides/plugins/plugins/storefront/README.md)
       * [Add custom controller](guides/plugins/plugins/storefront/add-custom-controller.md)
       * [Override existing routes](guides/plugins/plugins/storefront/override-existing-routes.md)

--- a/guides/plugins/plugins/administration/add-custom-styles.md
+++ b/guides/plugins/plugins/administration/add-custom-styles.md
@@ -1,0 +1,102 @@
+# Add custom styles to your component
+
+## Overview
+
+All components contain own templates and some style. Of course, you may want to use your custom styles in your
+component or module. In this guide, we got you covered on how to add those custom styles to your components.
+
+## Prerequisites
+
+However, this guide does not explain how to create a custom component, so head over to the official guide about
+[PLACEHOLDER-LINK: creating a custom component] to learn this first.
+
+In addition, you need to have a basic knowledge of CSS and SCSS in order to use custom styles. This is though
+considered a basic requirement and won't be taught in this guide.
+
+### Example: custom cms block
+
+We will base our guide on an example: Let's use a custom component printing out "Hello world!". So first of all, 
+create a new directory for your`sw-hello-world`. As said before, more information about that topic, such as wehere to create this drectory, can be found in [PLACEHOLDER-LINK: Add a custom component]. 
+
+In your component's directory, create a new `index.js` file and register your custom component `sw-hello-world`:
+
+```javascript
+Shopware.Component.register('sw-hello-world', {
+    template
+});
+```
+
+Just like most components, it has a custom template. First we create the template file named `sw-hello-world.html.twig`:
+
+This template now has to define the basic structure of your component. In this simple case, you only need a parent 
+container and two sub-elements, whatever those are.
+```html
+{% block example_block %}
+    <div class="sw-hello-world">
+        <p>Hello world!</p>
+    </div>
+{% endblock %}
+```
+
+You've got a parent `div` containing the content of your template, an abstract with the text "Hello world!" in this 
+case. Next up, you need to import that template in your `index.js` file of your component:
+
+```javascript
+// Import for your template
+import template from './sw-hello-world.html.twig';
+
+Shopware.Component.register('sw-sw-hello-world', {
+    template
+});
+```
+
+## Add custom styles to your component
+
+Your component should come with a custom `.scss` file, which you need to create now. Don't forget to import it in
+your `index.js` file, if not done yet:
+
+```javascript
+import template from './sw-hello-world.html.twig';
+
+// Import for your custom styles
+import './sw-hello-world.scss';
+
+Shopware.Component.register('sw-sw-hello-world', {
+    template
+});
+```
+
+In there, simply use a grid to display your elements next to each other. You set a CSS class for your block, which is 
+named after the component. In there, you can set your styles as you need. To mention an example, we want the
+text in the `div` with the class `sw-hello-world` to have a blue color:
+
+```css
+.sw-hello-world {
+    color: blue;
+}
+```
+
+That's it for this component! This way, you're able to add your own styles to your component now.
+
+### Import variables
+
+Because of [Sass](https://sass-lang.com/) usage, you are able to import external variables and use them in your classes. Below you see an example which
+uses Shopware's SCSS variables to color the text of the component in shopware's shade of blue.
+
+```scss
+/* Import statement */
+@import "~scss/variables";
+
+.sw-hello-world {
+  /* Usage of variable */
+  color: $color-shopware-brand-500;
+}
+```
+
+## Next steps
+
+As you might have noticed, we are just adding custom styles to the component. However, there's a lot more possible
+when it comes to extending the Administration. You may want to continue to explore these possibilities:
+* [PLACEHOLDER-LINK: Customizing contents]
+* [PLACEHOLDER-LINK: Add custom input fields]
+* [PLACEHOLDER-LINK: Add custom tab to existing module]


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains how to add styles to a component in the administration.
This can be migrated from our previous documentation.

This article should mention:

The prerequisite, a working plugin (Refer to the plugin base guide)
* Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
* A short code example, including an explanation, on how to do it
* Maybe should be built upon the "Add custom component" guide, so reference it in the prerequisites
Category: Extensions > Plugins > Administration

Are there already guides in the previous documentation for this?
Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/custom-cms-block#rendering-the-block

For more information, ask me, Patrick Stahl.