### PR TITLE
NEXT-13185 - Theme - add theme inheritance without resources

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -174,6 +174,7 @@
     * [Theme configuration](guides/plugins/themes/theme-configuration.md)
     * [Add assets to a Theme](guides/plugins/themes/add-assets-to-theme.md)
     * [Theme inheritance](guides/plugins/themes/add-theme-inheritance.md)
+    * [Theme with Bootstrap styling](guides/plugins/themes/add-theme-inheritance-without-resources.md)
   * [Apps](guides/plugins/apps/README.md)
     * [App Base Guide](guides/plugins/apps/app-base-guide.md)
     * [Storefront](guides/plugins/apps/storefront.md)

--- a/guides/plugins/themes/add-theme-inheritance-without-resources.md
+++ b/guides/plugins/themes/add-theme-inheritance-without-resources.md
@@ -1,0 +1,34 @@
+# Theme with Bootstrap styling
+
+## Overview
+
+The Shopware default theme is using [Bootstrap](https://getbootstrap.com/) with additional custom styling. But sometimes you want to develop a theme without the Shopware default styling.
+
+## Theme without Shopware default styling
+
+If you want to build your theme only upon the Bootstrap SCSS you can use the `@StorefrontBootstrap` placeholder instead of the `@Storefront` bundle in the `style` section of your `theme.json`.
+This gives you the ability to use the Bootstrap SCSS without the Shopware Storefront "skin". Therefore all the SCSS from `<plugin root>src/Storefront/Resources/app/storefront/src/scss/skin` will not be available in your theme.
+
+{% code title="<plugin root>/src/Resources/theme.json" %}
+{
+  ...
+  "style": [
+    "@StorefrontBootstrap",
+    "app/storefront/src/scss/base.scss"
+  ]
+}
+{% endcode %}
+
+{% hint style="info" %}
+* This option can only be used in the `style` section of the `theme.json`. You must not use it in `views` or `script`.
+* All theme variables like `$sw-color-brand-primary` are also available when using the Bootstrap option.
+* You can only use either `@StorefrontBootstrap` or `@Storefront`. They should not be used at the same time. The `@Storefront` bundle **includes** the Bootstrap SCSS already.
+{% endhint %}
+
+## Next steps
+
+Here is a list of related topics which might be interesting for you.
+
+* Theme configuration [PLACEHOLDER-LINK: Theme configuration] 
+* Add SCSS Styling and JavaScript to a theme [PLACEHOLDER-LINK: Add SCSS Styling and JavaScript to a theme]
+* Add assets to a theme [PLACEHOLDER-LINK: Add assets to a theme]


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains Shopware Themes and give a base guide for Theme developers.
This article should mention:
Explain how to add theme inheritance without resources
Category: Extensions > Themes > Add theme inheritance without resources