### PR TITLE
NEXT-12774  [MIGRATE] Administration: Add translations

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -142,6 +142,7 @@
       * [Add menu entry](guides/plugins/plugins/administration/add-menu-entry.md)
       * [Add tab to existing module](guides/plugins/plugins/administration/add-new-tab.md)
       * [Customizing components](guides/plugins/plugins/administration/customizing-components.md)
+      * [Adding snippets](guides/plugins/plugins/administration/adding-snippets.md)
     * [Storefront](guides/plugins/plugins/storefront/README.md)
       * [Add custom controller](guides/plugins/plugins/storefront/add-custom-controller.md)
       * [Override existing routes](guides/plugins/plugins/storefront/override-existing-routes.md)

--- a/guides/plugins/plugins/administration/add-custom-field.md
+++ b/guides/plugins/plugins/administration/add-custom-field.md
@@ -84,13 +84,13 @@ Your plugin has to be activated for this to work.
 {% endhint %}
 
 Make sure to also include that file when publishing your plugin!
-A copy of this file will then be put into the directory `<shopware root>/public/bundles/administrationnewfield/administration/js/administration-new-field.js`.
+A copy of this file will then be put into the directory `<shopware root>/public/bundles/administration/newfield/administration/js/administration-new-field.js`.
 
 Your minified javascript file will now be loaded in production environments.
 
 ## Next steps:
 
-The possibility to customise the administration via `main.js` file provides more options than just the addition of a
+The possibility to customize the administration via `main.js` file provides more options than just the addition of a
 custom input field. You can check out following guides to get to know more possibilities:
   * [PLACEHOLDER-LINK: Add custom tab to existing module]
   *  [PLACEHOLDER-LINK: Add custom module to administration]

--- a/guides/plugins/plugins/administration/adding-snippets.md
+++ b/guides/plugins/plugins/administration/adding-snippets.md
@@ -1,0 +1,61 @@
+# Adding snippets
+
+## Overview
+
+By default Shopware 6 uses the [Vue I18n](https://kazupon.github.io/vue-i18n/started.html#html) plugin in the `Administration` to deal with translation.
+
+## Creating snippet files
+
+Normally you want to use snippets in you custom module. To keep things organized, create a new directory named `snippet` inside 
+your module directory `<plugin root>/src/Resources/app/administration/src/module/<your-module>/snippet`.
+For each language you want to support, you need a JSON file inside here, e.g. `de-DE.json` and of course `en-GB.json`.
+
+Each language then receives a nested object of translations, so let's have a look at an example `snippet/en-GB.json`:
+
+```json
+{
+    "swag-example": {
+        "nested": {
+            "value": "example"
+        },
+        "foo": "bar"
+    }
+}
+```
+
+In this example you would have access the two translations by the following paths: `swag-example.nested.value` to get the value 'example' and `swag-example.foo` to get the
+value 'bar'. You can nest those objects as much as you want.
+
+By default, Shopware 6 will collect those files automatically when your plugin is activated.
+
+## Using the snippets in JavaScript
+
+Since snippets are automatically registered in the scope of your module, you can use them directly:
+
+```js
+Component.register('my-custom-page', {
+    ...
+
+    methods: {
+        createdComponent() {
+            // call the $tc helper function provided by Vue I18n 
+            const myCustomText = this.$tc('swag-example.general.myCustomText');
+
+            console.log(myCustomText);
+        }
+    }
+    ...
+});
+```
+
+## Using the snippets in templates
+
+The same `$tc` helper function can be used in the templates to access translations.
+
+```twig
+{% block my_custom_block %}
+    <p>
+       {{ $tc('swag-example.general.myCustomText') }}
+    </p>
+{% endblock %}
+```


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to add translations to an administration module.
This can be migrated from our previous documentation.

This article should mention:

- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it
- Maybe should be built upon the "Add custom module" guide, so reference it in the prerequisites.

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new writing guidelines!
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/add-snippets

For more information, ask me, Patrick Stahl.