### PR TITLE
NEXT-12701  [MIGRATE] Using custom fields with media type

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -101,6 +101,7 @@
       * [Add custom CLI commands](guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md)
       * [Database migrations](guides/plugins/plugins/plugin-fundamentals/database-migrations.md)
       * [Add scheduled task](guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md)
+      * [Using custom fields of type media](guides/plugins/plugins/plugin-fundamentals/custom-fields-of-type-media.md)
     * [Checkout](guides/plugins/plugins/checkout/README.md)
       * [Cart](guides/plugins/plugins/checkout/cart/README.md)
         * [Add cart items](guides/plugins/plugins/checkout/cart/add-cart-items.md)

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
@@ -1,0 +1,67 @@
+## Using custom fields of type media
+
+After you have added a custom field of type media, with the administration or via plugin, you can assign media objects to the different entities.
+This is often used for products add more images to the product detail page.
+In the product detail page template, the key `page.product.translated.customFields.xxx`, with the `xxx` replaced with the corresponding custom field, contains the UUID of the media.
+Now the ID has just to be resolved with the function 'searchMedia':
+
+```php
+public function searchMedia(array $ids, Context $context): MediaCollection { ... }
+```
+
+This function resolves out the corresponding media objects for the given IDs in order to continue working with them afterwards.
+Here is an example with a custom field (`custom_sports_media_id`) on the product detail page:
+
+```twig
+{% sw_extends '@Storefront/storefront/page/product-detail/index.html.twig' %}
+
+{% block page_product_detail_media %}
+    {# simplify ID access #}
+    {% set sportsMediaId = page.product.translated.customFields.custom_sports_media_id %}
+
+    {# fetch media as batch - optimized for performance #}
+    {% set mediaCollection = searchMedia([sportsMediaId], context.context) %}
+
+    {# extract single media object #}
+    {% set sportsMedia = mediaCollection.get(sportsMediaId) %}
+
+    {{ dump (sportsMedia) }}
+{% endblock %}
+```
+
+### Avoid loops
+
+This function performs a query against the database on every invocation and should therefore not be used within a loop.
+To resolve multiple ID's at just pass it an  array of ID's instead.
+
+To read the media objects within the product listing we recommend the following procedure:
+
+```twig
+{% sw_extends '@Storefront/storefront/component/product/listing.html.twig' %}
+
+{% block element_product_listing_col %}
+    {# initial ID array #}
+    {% set sportsMediaIds = [] %}
+
+    {% for product in searchResult %}
+        {# simplify ID access #}
+        {% set sportsMediaId = product.translated.customFields.custom_sports_media_id %}
+
+        {# merge IDs to a single array #}
+        {% set sportsMediaIds = sportsMediaIds|merge([sportsMediaId]) %}
+    {% endfor %}
+
+    {# do a single fetch from database #}
+    {% set mediaCollection = searchMedia(sportsMediaIds, context.context) %}
+
+    {% for product in searchResult %}
+        {# simplify ID access #}
+        {% set sportsMediaId = product.translated.customFields.custom_sports_media_id %}
+
+        {# get access to media of product #}
+        {% set sportsMedia = mediaCollection.get(sportsMediaId) %}
+
+        {{ dump(sportsMedia) }}
+    {% endfor %}
+{% endblock %}
+```

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
@@ -12,6 +12,8 @@ public function searchMedia(array $ids, Context $context): MediaCollection { ...
 This function resolves out the corresponding media objects for the given IDs in order to continue working with them afterwards.
 Here is an example with a custom field (`custom_sports_media_id`) on the product detail page:
 
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/product-detail.html.twig" %}
 ```twig
 {% sw_extends '@Storefront/storefront/page/product-detail/index.html.twig' %}
 
@@ -28,6 +30,7 @@ Here is an example with a custom field (`custom_sports_media_id`) on the product
     {{ dump (sportsMedia) }}
 {% endblock %}
 ```
+{% endcode %}
 
 ## Avoid loops
 
@@ -36,6 +39,7 @@ To resolve multiple ID's at just pass it an array of ID's instead.
 
 To read the media objects within the product listing we recommend the following procedure:
 
+{% code title="<plugin root>/src/Resources/views/storefront/component/product/listing.html.twig" %}
 ```twig
 {% sw_extends '@Storefront/storefront/component/product/listing.html.twig' %}
 
@@ -65,3 +69,4 @@ To read the media objects within the product listing we recommend the following 
     {% endfor %}
 {% endblock %}
 ```
+{% endcode %}

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
@@ -1,4 +1,4 @@
-## Using custom fields of type media
+# Using custom fields of type media
 
 After you have added a custom field of type media, with the administration or via plugin, you can assign media objects to the different entities.
 This is often used for products add more images to the product detail page.

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
@@ -5,9 +5,11 @@ This is often used for products add more images to the product detail page.
 In the product detail page template, the key `page.product.translated.customFields.xxx`, with the `xxx` replaced with the corresponding custom field, contains the UUID of the media.
 Now the ID has just to be resolved with the function 'searchMedia':
 
+{% code title="platform/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php" %}
 ```php
 public function searchMedia(array $ids, Context $context): MediaCollection { ... }
 ```
+{% endcode %}
 
 This function resolves out the corresponding media objects for the given IDs in order to continue working with them afterwards.
 Here is an example with a custom field (`custom_sports_media_id`) on the product detail page:

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of type-media.md
@@ -29,10 +29,10 @@ Here is an example with a custom field (`custom_sports_media_id`) on the product
 {% endblock %}
 ```
 
-### Avoid loops
+## Avoid loops
 
 This function performs a query against the database on every invocation and should therefore not be used within a loop.
-To resolve multiple ID's at just pass it an  array of ID's instead.
+To resolve multiple ID's at just pass it an array of ID's instead.
 
 To read the media objects within the product listing we recommend the following procedure:
 

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of-type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of-type-media.md
@@ -1,9 +1,13 @@
 # Using custom fields of type media
 
 After you have added a custom field of type media, with the administration or via plugin, you can assign media objects to the different entities.
-This is often used for products add more images to the product detail page.
-In the product detail page template, the key `page.product.translated.customFields.xxx`, with the `xxx` replaced with the corresponding custom field, contains the UUID of the media.
-Now the ID has just to be resolved with the function 'searchMedia':
+This is often used for products to add more images to the product detail page.
+If you want to learn more about custom fields you might want to take a look at this guide: [Adding custom fields](..\administration\add-custom-field.md)
+## Overview
+
+
+In the product detail page template, the key `page.product.translated.customFields.xxx` with the `xxx`, which is replaced with the corresponding custom field, contains the UUID of the media.
+Now the ID has just to be resolved with the function [searchMedia](https://github.com/shopware/platform/blob/v6.3.4.1/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php#L31-L45):
 
 {% code title="platform/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php" %}
 ```php
@@ -37,7 +41,7 @@ Here is an example with a custom field (`custom_sports_media_id`) on the product
 ## Avoid loops
 
 This function performs a query against the database on every invocation and should therefore not be used within a loop.
-To resolve multiple ID's at just pass it an array of ID's instead.
+To resolve multiple ID's at once just pass it an array of ID's instead.
 
 To read the media objects within the product listing we recommend the following procedure:
 

--- a/guides/plugins/plugins/plugin-fundamentals/custom-fields-of-type-media.md
+++ b/guides/plugins/plugins/plugin-fundamentals/custom-fields-of-type-media.md
@@ -3,8 +3,8 @@
 After you have added a custom field of type media, with the administration or via plugin, you can assign media objects to the different entities.
 This is often used for products to add more images to the product detail page.
 If you want to learn more about custom fields you might want to take a look at this guide: [Adding custom fields](..\administration\add-custom-field.md)
-## Overview
 
+## Overview
 
 In the product detail page template, the key `page.product.translated.customFields.xxx` with the `xxx`, which is replaced with the corresponding custom field, contains the UUID of the media.
 Now the ID has just to be resolved with the function [searchMedia](https://github.com/shopware/platform/blob/v6.3.4.1/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php#L31-L45):


### PR DESCRIPTION
## What should be done?

Create a new article on our [GitBook instance|https://app.gitbook.com/@shopware/s/shopware/] which explains how to use a custom field in combination with the media type.
This can be migrated from our previous documentation.

This article should mention:
- Every prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Framework > Custom field

## Are there already guides in the previous documentation for this?
Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new [writing guidelines|https://app.gitbook.com/@shopware/s/shopware/resources/guidelines/documentation/writing]!
https://docs.shopware.com/en/shopware-platform-dev-en/how-to/custom-fields-media-type

For more information, ask me, [~p.stahl].