### PR TITLE
NEXT-12552 - Add libraries

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -92,6 +92,8 @@
       * [Database migrations](guides/plugins/plugins/plugin-fundamentals/database-migrations.md)
       * [Add scheduled task](guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md)
       * [Using custom fields of type media](guides/plugins/plugins/plugin-fundamentals/custom-fields-of-type-media.md)
+      * [Adding NPM dependencies](guides/plugins/plugins/plugin-fundamentals/using-npm-dependencies.md)
+      * [Adding Composer dependencies](guides/plugins/plugins/plugin-fundamentals/using-composer-dependencies.md)
     * [Checkout](guides/plugins/plugins/checkout/README.md)
       * [Cart](guides/plugins/plugins/checkout/cart/README.md)
         * [Add cart items](guides/plugins/plugins/checkout/cart/add-cart-items.md)

--- a/concepts/extensions/plugins-concept.md
+++ b/concepts/extensions/plugins-concept.md
@@ -11,7 +11,7 @@ You can do nearly *everything* with plugins, like "new User Provider" or "custom
 
 {% hint style="warning" %}
 Plugins are not compatible with Shopware Cloud!
-If you want to extend Showpare Cloud you need an [App](apps-concept.md)
+If you want to extend Shopware Cloud you need an [App](apps-concept.md)
 {% endhint %}
 
 Learn more

--- a/guides/plugins/plugins/plugin-fundamentals/using-composer-dependencies.md
+++ b/guides/plugins/plugins/plugin-fundamentals/using-composer-dependencies.md
@@ -1,0 +1,89 @@
+# Use Composer dependencies
+
+In this guide you'll learn how to add Composer dependencies to your project.
+
+## Prerequisites
+
+All you need for this guide is a running Shopware 6 instance and full access to both the files and a running plugin. Of course you'll have to understand PHP, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation. Further a basic understanding Node and NPM is required.
+
+## Adding a composer plugin to the `composer.json` file
+
+In this guide we will install [`exporter`](https://github.com/sebastianbergmann/exporter), which provides the functionality to export PHP variables for visualization.
+
+We have to manually remove all of the references to Shopware itself from the `composer.json` file, that was created in the [Plugin base guide](../plugin-base-guide.md),
+before we add our own dependencies to it. This is done to prevent `composer` from downloading Shopware into the `vendor` folder.
+
+Now we can simply install `exporter` by running `composer require sebastian/exporter` in your plugin directory.
+
+After that we have to add our dependency to shopware back in.
+
+{% hint style="warning" %}
+The `vendor` directory, where the composer saves the dependencies, has to be included in the plugin bundle.
+The plugin bundle size is not allowed to exceed 5 MB.
+{% endhint %}
+
+## Loading the `autoload.php`
+
+The `composer require` command created the `autoload.php` that we now need to require in our plugin.
+
+{% code title="<plugin root>/src/SwagBasicExample.php" %}
+```php
+if (file_exists(dirname(__DIR__) . '/vendor/autoload.php')) {
+    require_once dirname(__DIR__) . '/vendor/autoload.php';
+}
+```
+{% endcode %}
+
+## Using the composer plugin
+
+PHP doesn't require a build system, which means that we can just add `use` statements and then use the composer dependency directly.
+
+The following code sample imports `SebastianBergmann\Exporter\Exporter` and logs `hello, world!` to the Symfony profiler logs whenever the `NavigationPageLoadedEvent` is fired.
+Learn how to register this listener [here](./listening-to-events.md).
+
+{% code title="<plugin root>/src/SwagBasicExample.php" %}
+```php
+<?php
+namespace SwagBasicExample\Subscriber;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Storefront\Page\Navigation\NavigationPageLoadedEvent;
+
+use Psr\Log\LoggerInterface;
+use SebastianBergmann\Exporter\Exporter;
+
+class MySubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+     private $logger;
+    
+    public function __construct(
+        LoggerInterface $logger
+    ) {
+        $this->logger = $logger;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        // Return the events to listen to as array like this:  <event to listen to> => <method to execute>
+        return [
+            NavigationPageLoadedEvent::class => 'onNavigationPage'
+        ];
+    }
+
+    public function onNavigationPage(NavigationPageLoadedEvent $event)
+    {
+        $exporter = new Exporter;
+        $this->logger->info($exporter->export('hello, world!'));
+    }
+}
+```
+{% endcode %}
+
+
+## Next steps
+
+Now that you know how to include new `composer` dependencies you might want to [install `npm` dependencies](./using-npm-dependencies.md) or even add [dependencies to other plugins](./add-plugin-dependencies.md)

--- a/guides/plugins/plugins/plugin-fundamentals/using-npm-dependencies.md
+++ b/guides/plugins/plugins/plugin-fundamentals/using-npm-dependencies.md
@@ -1,0 +1,83 @@
+# Use NPM dependencies
+
+In this guide you'll learn how add NPM dependencies to your project.
+
+## Prerequisites
+
+All you need for this guide is a running Shopware 6 instance and full access to both the files and a running plugin. Of course you'll have to understand JavaScript, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation. Further a basic understanding Node and NPM is required.
+
+## Video
+
+This guide is also available as a video:
+
+{% embed url="https://www.youtube.com/watch?v=wfBuWdff35c" %}
+
+## Adding a npm package to the Administration or the Storefront
+
+Presuming you have `npm` installed, run `npm init -y` in the `<plugin root>src/Resources/app/administration/` folder or the `<plugin root>src/Resources/app/storefront/` folder. This command creates a `package.json` file in the respective folder, depending on the environment you're working in. To add a package to the `package.json` file simply run the `npm install` command. In this example we will be installing [`missionlog`](https://www.npmjs.com/package/missionlog).
+
+So in order to install `missionlog`, run `npm install missionlog` in the folder you have created your `package.json` file in.
+
+## Registering a package in the build system
+
+Shopware's storefront as well as for administration is based on the build system [Webpack](https://webpack.js.org/). Webpack is a source file bundler: In essence it bundles all the source files into a single `bundle.js` to be shipped to a browser. So in order to make Webpack aware of the new dependency, we have to register it and give it an alias/pseudonym so that the package can be bundled correctly.
+
+To do this we put a new “build” folder below the current area: Either `Resources/app/storefront` or `Resources/app/administration`. We then create a new file with the name `webpack.config.js`. We thereby make it possible to extend the Webpack configuration of Shopware.
+
+{% code title="<plugin root>/src/Resources/app/administration/webpack.config.js" %}
+```javascript
+const { join, resolve } = require('path'); 
+module.exports = () => { 
+    return { 
+        resolve: { 
+           alias: { 
+               '@missionlog': resolve( 
+                    join(__dirname, '..', 'node_modules', 'missionlog') 
+               ) 
+           } 
+       } 
+   }; 
+}
+```
+{% endcode %}
+
+Let us take a closer look at the code. In the first line, we import the two functions `join` and `resolve` for the path module of Node.js. In the second line, we export a so-called arrow function. The build system from Shopware calls this function when either the administration or storefront is being built.
+
+After that, there comes the exciting part for us: registering the alias. The alias for `missionlog` is given the prefix `@`, so it is possible to recognize later on in the source files. We will use the result of the two functions of the path module previously imported as a value.
+
+We proceed from the inside to the outside. We use [`join`](https://nodejs.org/api/path.html#path_path_join_paths) to reflect the path to the package inside the `node_modules` folder. The `node_modules` folder contains all the packages that we have installed via `npm install`. After we identified the relevant path to the package, we use the [`resolve`](https://nodejs.org/api/path.html#path_path_resolve_paths) function to transform this path into an absolute path.
+
+## Using the dependency
+
+Once we have installed all the dependencies and registered the package in the build system with an alias, we can use the package in our own code.
+
+{% code title="<plugin root>/src/Resources/app/src/main.js" %}
+```javascript 
+import Plugin from 'src/plugin-system/plugin.class';
+
+// Import logger
+import { log } from '@missionlog';
+
+// Initializing the logger
+log.init({ initializer: 'INFO' }, (level, tag, msg, params) => {
+    console.log(`${level}: [${tag}] `, msg, ...params);
+});
+
+// The plugin skeleton
+export default class ExamplePlugin extends Plugin {
+    init() {
+        console.log('init');
+      
+        // Use logger
+        log.info('initializer', 'example plugin got started', this);
+    }
+}
+```
+{% endcode %}
+
+We import the function log as well as the constants tag via `destructuring` in the specified code. Through the use of the alias, we keep the paths short and recognize that this is an alias at first glance via the prefix.
+
+## Next steps
+
+Now that you know how to include new `npm` dependencies you might want to create a service with them.
+Learn how to do that in this guide: [How to add a custom-service](../administration/add-custom-service.md)


### PR DESCRIPTION
## What should be done?

Create a new article on our [GitBook instance|https://app.gitbook.com/@shopware/s/shopware/] which explains how to add libraries (composer, NPM) to your plugin.

This article should mention:
- The prerequisite, a working plugin (Refer to the plugin base guide)
- A note about the maximum size of plugins when you want to publish to the store (Maybe even refer to the plugin publishing guide. If this doesn't exist yet, use the [PLACEHOLDER-LINK: Subject X] pattern)
- A short example how to add and use a library via composer
- A short example how to add and use a library via npm
- Registering custom CSS that comes from e.g. a npm package 

Category: Extensions > Plugins > Plugin fundamentals

## Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our [example guide|https://app.gitbook.com/@shopware/s/shopware/guides/plugins/plugins/plugin-base-guide](e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the [Writing guidelines|https://app.gitbook.com/@shopware/s/shopware/resources/guidelines/documentation/writing].

For more information, ask me, @PaddyS.