### PR TITLE
NEXT-12571 - Add storefront jest guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -161,6 +161,7 @@
     * [Testing](guides/plugins/plugins/testing/README.md)
       * [End-to-end testing](guides/plugins/plugins/testing/end-to-end-testing.md)
       * [Jest unit tests in Shopware's administration](guides/plugins/plugins/testing/jest-admin.md)
+      * [Jest unit tests in Shopware's storefront](guides/plugins/plugins/testing/jest-storefront.md)
       * [PHP unit testing](guides/plugins/plugins/testing/php-unit.md)
   * [Themes](guides/plugins/themes/README.md)
     * [Theme base guide](guides/plugins/themes/theme-base-guide.md)

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -1,14 +1,18 @@
 # Installation overview
 
+## Overview
+
 There are a couple of ways to get Shopware running on your system. Depending on what best suits your development environment, you have the following choices:
 
 * [Docker](./docker.md): The docker installation is the easiest way to get a running Shopware 6.
 * [MAMP](./mamp.md): For quick and easy installation you can also use MAMP tool on mac.
 * [Valet+](./valet.md): You can install Shopware with the epl of Valet+, which is a fork of laravel/valet. 
 * [Dockware](./dockware.md): This is a managed docker setup for Shopware 6 by shopware agency dasistweb.
-* [Installation from scratch](./from-scratch.md): You can install Shopware 6 locally. However, be aware that this will 
+* [Installation from scratch](./from-scratch.md): You can install Shopware 6 locally. However, be aware that this will be the more complex solution since additional or changed system requirements need to be managed by you.
 
-  be the more complex solution since additional or changed system requirements need to be managed by you.
+Did you know that there's a video available to this topic? Please take a look:
+
+{% embed url="https://www.youtube.com/watch?v=nWUBK3fjwVg" %}
 
 ## Prerequisites
 

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -12,7 +12,7 @@ There are a couple of ways to get Shopware running on your system. Depending on 
 
 Did you know that there's a video available to this topic? Please take a look:
 
-{% embed url="https://www.youtube.com/watch?v=nWUBK3fjwVg" %}
+{% embed url="https://www.youtube.com/watch?v=ML1QyUr0wsk" %}
 
 ## Prerequisites
 

--- a/guides/plugins/plugins/testing/end-to-end-testing.md
+++ b/guides/plugins/plugins/testing/end-to-end-testing.md
@@ -1,6 +1,8 @@
 # End-to-end testing
 
-In end-to-end testing \(E2E testing in short\) real user workflows are simulated, whereby as many as possible functional areas and parts of the technology stack used in the application should be included. This way, we are able to put our UI under constant stress and ensure that Shopware's main functionalities are always working correctly. As we are using Cypress as testing framework, please take a look at [official Cypress Dokumentation](https://docs.cypress.io) for further documentation.
+## Overview
+
+In end-to-end testing \(E2E testing in short\) real user workflows are simulated, whereby as many as possible functional areas and parts of the technology stack used in the application should be included. This way, we are able to put our UI under constant stress and ensure that Shopware's main functionalities are always working correctly. 
 
 ## Prerequisites
 
@@ -11,6 +13,11 @@ The easiest way to clean up your installation is the initialization. Using the c
 Since our tests should run on an installation that is as close as possible to a release package, we use production mode. If you run the tests on a development environment, the test results may vary.
 
 On top of that, please make sure your shop has a theme assigned. When using `./psh.phar e2e:open` or `run`, this is done automatically.
+
+This guide also won't teach you how to write Cypress tests in general. Please take a look at the official Cypress documentation for further guidance.
+
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="http://docs.cypress.io" %}
 
 ### Using our testsuite
 
@@ -23,6 +30,10 @@ This test suite is built on top of [Cypress](https://www.cypress.io/) as well as
 * [cypress-select-tests](https://github.com/bahmutov/cypress-select-tests)
 * [cypress-log-to-output](https://github.com/flotwig/cypress-log-to-output)
 * [cypress-file-upload](https://github.com/abramenal/cypress-file-upload)
+
+Here you can find the npm package of our testsuite:
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="http://www.npmjs.com/package/@shopware-ag/e2e-testsuite-platform" %}
 
 ## Setup steps
 
@@ -132,7 +143,10 @@ CYPRESS_baseUrl=<your-url> npm run open
 
 `<your-url>` means the Storefront-URL of your Shopware environment.
 
-It opens up the Cypress test runner which allows you to run and debug your tests, similar to the `e2e:open` command. However, don't forget that you might need to adjust test cleanup and other environment-related things according to your plugin's setup.
+It opens up the Cypress test runner which allows you to run and debug your tests, similar to the `e2e:open` command. 
+
+{% hint style="danger" %} Don't forget that you might need to adjust test cleanup and other environment-related things according to your plugin's setup.
+{% endhint %}
 
 ## Writing your first test
 
@@ -166,7 +180,7 @@ In the `cypress` folder, all test related folders are located. Most things will 
 
   contains a sequence of tests, performed in the order defined in it.
 
-* `plugins`: Contains extensions or plugins. By default Cypress will automatically include the plugins file before
+* `plugins`: Contains extensions or plugins. By default, Cypress will automatically include the plugins file before
 
   every single spec file it runs.
 
@@ -200,7 +214,7 @@ If you want to contribute to Shopware platform's tests, please ensure to place y
   `-- settings
 ```
 
-This is important because otherwise your test is not considered by our CI.
+{% hint style="warning" %} This is important because otherwise your test is not considered by our CI. {% endhint %}
 
 ### Test layout and syntax
 
@@ -305,7 +319,7 @@ One test should only test one workflow, the one it's written for. For example, i
 
 In Shopware platform, we use Shopware's REST API to create the data we need. As a result, our tests are able to focus on one single workflow without having to test the workflows which normaly need to be done to provide the data we need. Another aspect of handling it this way is, that creating test data via API is faster than doing it inside the test.
 
-## Cypress' fixtures
+### Cypress' fixtures
 
 To define the request you send to Shopware and to set first test data, store as `json` file in the folder `e2e/cypress/fixtures`. You can use those files to provide fixed test data which can be used directly to create the desired entity without any further searching or processing. Fortunately, Cypress provides a way to handle those fixtures by default. The command `cy.fixture()` loads this fixed set of data located in a json file.
 
@@ -327,17 +341,21 @@ In the example file below, this file is used in order to define and create a cus
 }
 ```
 
-Note: Use only fields, which you can access in the UI / Storefront. Keep in mind that all tests in the file may use the fixture. So keep an eye on compatibility. Plus, a little word on ID usage: Using ids may be easier for finding, but it isn't a proper way for testing in every case. t depends on your application. You need to be 100% sure that the id is persistant over all builds and won't change inbetween. At our case at Shopware, Ids on UUID basis tend to change installation to installation, so they are not suitable to be used as selector in your test. Never use ids here if you cannot be 100% sure they will not change at all, e.g. in another build.
+{% hint style="info" %} Use only fields, which you can access in the UI / Storefront. Keep in mind that all tests in the file may use the fixture. So keep an eye on compatibility. {% endhint %}
 
-## API implementation
+A small note on ID usage: Using ids may be easier for finding elements, but it isn't a proper way for testing in every case - It depends on your application. You need to be 100% sure that the id is persistent and won't change between builds. Never use ids here if you cannot be 100% sure they will not change at all, e.g. in another build.
+
+{% hint style="info" %} At our case at Shopware, Ids on UUID basis tend to change from one installation to the next, so they are not always suitable to be used as selector in your test. {% endhint %}
+
+### API implementation
 
 Analogue to the administration itself, the api access of the e2e test is based on [axios](https://www.npmjs.com/package/axios), a promise based HTTP client for the browser and node.js.
 
-Just like the administration, we use services to access Shopware's REST API. Therefore we use the ApiService to provide the basic methods for accessing the api. Located in `e2e/cypress/support/service/api.service.js`, ApiService is shared between all repositories and acts as a basis for all your next steps of creating fixtures. That implies that the axios implementation of all important api methods can be found there. This service acts as an interface: Next to the basic functions like get, post etc the request method is specified here as well as some Shopware-related methods which have to be available in all repositories.
+Just like the administration, we use services to access Shopware's REST API. Therefore, we use the ApiService to provide the basic methods for accessing the api. Located in `e2e/cypress/support/service/api.service.js`, ApiService is shared between all repositories and acts as a basis for all your next steps of creating fixtures. That implies that the axios implementation of all important api methods can be found there. This service acts as an interface: Next to the basic functions like get, post etc the request method is specified here as well as some Shopware-related methods which have to be available in all repositories.
 
-Important: Cypress provides an own axios-based way to handle requests in its command `cy.request`. However, Cypress commands are not real promises, see [Commands are not Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises). As we aim to parallelize the promises to fetch test data, we use our own implementation instead.
+{% hint style="info" %} Cypress provides an own axios-based way to handle requests in its command `cy.request`. However, Cypress commands are not real promises, see [Commands are not Promises](https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Are-Not-Promises). As we aim to parallelize the promises to fetch test data, we use our own implementation instead. {% endhint %}
 
-## Services and commands
+### Services and commands
 
 In order to get all test fixture data applied to our Shopware installation, we use services to send the API requests to find, create or update the data we need. To access these services conveniently, we provide custom commands, which we'll cover a bit later. Let's continue with the general things first.
 
@@ -359,7 +377,7 @@ service
 
 If you want to use all known services, you can access them using custom commands. These commands can be found in `cypress/support/commands/api-commands.js` for general operation and `cypress/support/commands/fixture-commands.js` specifically for fixture handling.
 
-### Default fixture command
+#### Default fixture command
 
 The stationary fixtures mentioned in the paragraph "Cypress' fixtures" can be sent to Shopware's REST API directly: In most cases Shopware does not need any additional data, like IDs or other data already stored in Shopware. That means the request can be sent, and the desired entity can be created immediately: You just need to use the `createDefaultFixture(endpoint, options = [])` command, as seen below:
 
@@ -392,7 +410,7 @@ Cypress.Commands.add('createDefaultFixture', (endpoint, data = {}, jsonPath) => 
 });
 ```
 
-### Commands of customised services
+#### Commands of customised services
 
 You will notice soon that some entities need data which has already been created. That means you have to find out specific IDs or employ a completely different handling. In this case, your own service has to be created, located in `e2e/cypress/support/service`. Some examples for these services are:
 
@@ -401,9 +419,9 @@ You will notice soon that some entities need data which has already been created
 * Languages
 * Products
 
-In most cases, the usage of these services is similar to the basic ones already implemented. There are commands for each of those services provided by our E2E testsuite package. You don't need to define the API endpoint when using those commands. As these services are extending the FixturesService, all methods of it can be used in all other services as well.
+In most cases, the usage of these services is similar to the basic ones already implemented. There are commands for each of those services provided by our E2E testsuite package. You don't need to define the API endpoint when using those commands. As these services are extending the `FixturesService`, all methods of it can be used in all other services as well.
 
-### Writing your own customised service
+#### Writing your own customised service
 
 Let's look at the custom service `shipping.fixture.js`. This service is a rather simple example - It depicts a service in need of some customization for creating a shipping method correctly. With that being said, let's start.
 
@@ -452,39 +470,19 @@ return Promise.all([
 });
 ```
 
-That's it! And there you go: You have successfully created a customised service that sets up a shipping method in Shopware. Actually, we use this service in our platform test to create our shipping method as well. You can find the full service [here](https://github.com/shopware/e2e-testsuite-platform/blob/master/cypress/support/service/administration/fixture/shipping.fixture.js). So please look at this example to see the whole class.
+That's it! There you go: You have successfully created a customised service that sets up a shipping method in Shopware. Actually, we use this service in our platform test to create our shipping method as well. You can find the full service [here](https://github.com/shopware/e2e-testsuite-platform/blob/master/cypress/support/service/administration/fixture/shipping.fixture.js). So please look at this example to see the whole class.
 
 Below you will find some best practices and tricks we explored to help you with your testing tasks:
 
-* A source of information can be found in FieldCollection of the several EntityDefinition files.
+* A source of information can be found in FieldCollection of the several EntityDefinition files. All fields belonging to an entity are defined there. For example, if you're searching for customer related data, please search for the `CustomerDefinition` in Shopware platform.
+* If you want to extract mandatory data that is not covered by the error message received with the API's response, it's useful to reproduce your workflow manually: E.g. if you need to find out what data is mandatory for creating a customer, try to save an empty one in the administration. Keep an eye on the developer tools of your browser while doing so, especially on the preview and response section of your request. As you get your response, you can see what data is still missing.
+* If you need to set non-mandatory data, reproducing the above mentioned workflow is recommended as well: Even if the error response does not contain a readable error, you can still inspect it: All the relevant information is stored in 'data'. IDs can be found there directly, other relevant data is stored in "attributes".
+* Cypress' test runner can help you a lot with inspecting API requests. Just click on the request in the test runner's log to get a full print of it in your console.
 
-  All fields belonging to an entity are defined there. For example, if you're searching for customer related data,
+## Next steps
 
-  please search for the `CustomerDefinition` in Shopware platform.
-
-* Furthermore, you can always look at our Swagger UI every Shopware installation is coming with to
-
-  find out the correct data structure besides looking up the EntityDefinitions. The UI can be found via
-
-  `http://<your-installation>/api/v3/_info/swagger.html`.
-
-* If you want to extract mandatory data that is not covered by the error message received with the API's response,
-
-  it's useful to reproduce your workflow manually: E.g. if you need to find out what data is mandatory for creating
-
-  a customer, try to save an empty one in the administration. Keep an eye on the developer tools of your browser while
-
-  doing so, especially on the preview and response section of your request. As you get your response,
-
-  you can see what data is still missing.
-
-* If you need to set non-mandatory data, reproducing the above mentioned workflow is recommended as well:
-
-  Even if the error response does not contain a readable error, you can still inspect it: All the relevant information
-
-  is stored in 'data'. IDs can be found there directly, other relevant data is stored in "attributes".
-
-* Cypress' test runner can help you a lot with inspecting API requests. Just click on the request in the test runner's
-
-  log to get a full print of it in your console.
-
+Our guides on testing don't stop here. You might to write more tests for your plugin, so we got you covered with even more
+guides on testing:
+* [Unit testing with PHPUnit](./php-unit.md)
+* [Jest unit tests in Shopware's administration](./jest-admin.md)
+* [Jest unit tests in Shopware's storefront](./jest-storefront.md)

--- a/guides/plugins/plugins/testing/jest-admin.md
+++ b/guides/plugins/plugins/testing/jest-admin.md
@@ -1,16 +1,27 @@
 # Jest unit tests in Shopware's administration
 
+## Overview
+
 You should write a unit test for every functional change. It should guarantee that your written code works and that a third developer can't break the functionality with their code.
 
 With a good test coverage we can have the confidence to deploy a stable software without needing to manually test the software in its entirety. This little guide will guide you how to write unit tests for the administration in Shopware 6.
 
-We are using [Jest](https://jestjs.io/) as our testing framework. It's a solid foundation and widely used by many developers. Before you are reading this guide you have to make sure you understand the basics of unit tests and how Jest works.
+We are using [Jest](https://jestjs.io) as our testing framework. It's a solid foundation and widely used by many developers. Before you are reading this guide you have to make sure you understand the basics of unit tests and how Jest works.
 
-You can find a good source for best practices in this Github Repo: [https://github.com/goldbergyoni/javascript-testing-best-practices](https://github.com/goldbergyoni/javascript-testing-best-practices)
+## Video
+
+Did you know that there's a video available to this topic? Please take a look:
+
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="https://www.youtube.com/watch?v=nWUBK3fjwVg" %}
 
 ## Prerequisites
 
 This tutorial will have a strong focus on how unit tests should be written when it comes to components in the administration. So please make sure you already know what a unit test is and why we are doing it. Furthermore, you should know what components tests are and what we want to achieve with them.
+You can find a good source for best practices in this Github Repo:
+
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="https://github.com/goldbergyoni/javascript-testing-best-practices" %}
 
 In addition, you need a running Shopware 6 installation. Your repository used for that should be based on development template, as we need to use some scripts provided by it.
 
@@ -29,17 +40,16 @@ Resources
               `-- sw-alert.spec.js
 ```
 
-Please note that in this example, `<environment>` is a placeholder for the environment you are working in. In your context, that should be `administration` or `storefront` in most cases.
+Please note that in this example, `<environment>` is a placeholder for the environment you are working in. In your context, that should be `administration`.
 
-## Setup for testing services and ES modules
+## Testing services and ES modules
 
 Services and isolated ECMAScript modules are well testable because you can import them directly without mocking or stubbing dependencies. A service can be used isolated and therefore is easy to test.
 
 Let's have a look at an example:
 
+{% code title="sanitizer.helper.spec.js" %}
 ```javascript
-// sanitizer.helper.spec.js
-
 import Sanitizer from 'src/core/helper/sanitizer.helper';
 
 describe('core/helper/sanitizer.helper.js', () => {
@@ -66,17 +76,23 @@ describe('core/helper/sanitizer.helper.js', () => {
     // ...more tests 
 });
 ```
+{% endcode %}
+
+You see, you are able to write the test the same way you're used to, writing Jest unit tests in general.
 
 ## Write tests for components
 
-After setting up your component test you need to write your tests. A good way to write them is to test input and output. The most common tests are:
+After setting up your component test, you need to write your tests. A good way to write them is to test input and output. The most common tests are:
 
 * set Vue Props and check if component looks correctly
 * interact with the DOM and check if the desired behaviour is happening
 
+However, when it comes to writing component tests for Shopware's administration, there are some further steps to go.
+We will take a look at them in the following paragraphs.
+
 ## Setup for testing Vue components
 
-We are using the [Vue Test Utils](https://vue-test-utils.vuejs.org/) for easier testing of Vue components. If you don't have experience with testing Vue components it is useful to read some basic guides on this topic. The main part of testing components is similar in Shopware 6.
+We are using the [Vue Test Utils](https://vue-test-utils.vuejs.org) for easier testing of Vue components. If you don't have experience with testing Vue components it is useful to read some basic guides on this topic. The main part of testing components is similar in Shopware 6.
 
 However, there are some important differences. We can't test components that easily like in other Vue projects because we are supporting template inheritance and extendability for third party developers. This causes overhead which we need to bear in mind.
 
@@ -86,7 +102,10 @@ We are using a global object as an interface for the whole administration. Every
 
 Before you are using the commands make sure that you installed all dependencies for your administration. If you haven't done this already, then you can do it running the following PSH command: `./psh.phar administration:install-dependencies`
 
-In order to run jest unit tests of the administration, you can use the psh commands provided by our development template. Beware: This only applies to the Shopware provided Administration! If you use unit tests in your Plugin, you might need to write your own scripts for that.
+In order to run jest unit tests of the administration, you can use the psh commands provided by our development template. 
+
+{% hint style="info" %} This only applies to the Shopware provided Administration! If you use unit tests in your plugin, you might need to write your own scripts for that.
+{% endhint %}
 
 This command executes all unit tests and shows you the complete code coverage.  
 `./psh.phar administration:unit`
@@ -100,33 +119,34 @@ For better understanding how to write component tests for Shopware 6 let's write
 
 When you want to mount your component it needs to be imported first:
 
+{% code title="test/app/component/form/select/base/sw-multi-select.spec.js" %}
 ```javascript
-// test/app/component/form/select/base/sw-multi-select.spec.js
-
 import 'src/app/component/form/select/base/sw-multi-select';
 ```
+{% endcode %}
 
 You see that we import the `sw-multi-select` without saving the return value. This blackbox import only executes code. However, this is important because this registers the component to the Shopware object:
 
+{% code title="test/app/component/form/select/base/sw-multi-select.spec.js" %}
 ```javascript
-// src/app/component/form/select/base/sw-multi-select.js
-
 Shopware.Component.register('sw-multi-select', {
     // The vue component
 });
 ```
+{% endcode %}
 
 ### Mounting components
 
 In the next step we can mount our Vue component which we get from the global Shopware object:
 
+{% code title="test/app/component/form/select/base/sw-multi-select.spec.js" %}
 ```javascript
-// test/app/component/form/select/base/sw-multi-select.spec.js
 
 import 'src/app/component/form/select/base/sw-multi-select';
 
 shallowMount(Shopware.Component.build('sw-multi-select'));
 ```
+{% endcode %}
 
 When we’re testing our vue.js components, we need a way to mount and render the component. Therefore, we use the following methods:
 
@@ -141,8 +161,8 @@ This way, we create a new `wrapper` before each test. The `build` method resolve
 
 Now you can test the component like any other component. Let's try to write our first test:
 
+{% code title="test/app/component/form/select/base/sw-multi-select.spec.js" %}
 ```javascript
-// test/app/component/form/select/base/sw-multi-select.spec.js
 
 import { shallowMount } from '@vue/test-utils';
 import 'src/app/component/form/select/base/sw-multi-select';
@@ -163,6 +183,7 @@ describe('components/sw-multi-select', () => {
     });
 });
 ```
+{% endcode %}
 
 This contains our component. In our first test we only check if the wrapper is a Vue instance.
 
@@ -187,6 +208,7 @@ wrapper = shallowMount(Shopware.Component.build('sw-multi-select'), {
 
 Now you should only see the last warning with an unknown custom element. The reason for this is that most components contain other components. In our case the `sw-multi-select` needs the `sw-select-base` component. Now we have several solutions to solve this. The two most common ways are stubbing or using the component.
 
+{% code title="test/app/component/form/select/base/sw-multi-select.spec.js" %}
 ```javascript
 import 'src/app/component/form/select/base/sw-select-base';
 
@@ -200,12 +222,12 @@ wrapper = shallowMount(Shopware.Component.build('sw-multi-select'), {
     }
 });
 ```
+{% endcode %}
 
 You need to choose which way is needed: Many tests do not need the real component, but in our case we need the real implementation. You will see that if we import another component that they can create also warnings. Let's look at the code that solve all warnings, then we should have a code like this:
 
+{% code title="test/app/component/form/select/base/sw-multi-select.spec.js" %}
 ```javascript
-// test/app/component/form/select/base/sw-multi-select.spec.js
-
 import { shallowMount } from '@vue/test-utils';
 import 'src/app/component/form/select/base/sw-multi-select';
 import 'src/app/component/form/select/base/sw-select-base';
@@ -255,10 +277,11 @@ describe('components/sw-multi-select', () => {
     });
 });
 ```
+{% endcode %}
 
 ## Second example: Testing of message inside the sw-alert component
 
-Of course, the complexity and structure of your test depends on what you are trying to achieve with your component. Here is one little example concerning the component `sw-alert`: Actually, he task of an alert is displaying a message for the user in most cases. So in this example, let's write a test for this text located in a slot. You can find this example in the [linked video](https://www.youtube.com/watch?v=nWUBK3fjwVg) as well.
+Of course, the complexity and structure of your test depends on what you are trying to achieve with your component. Here is one little example concerning the component `sw-alert`: Actually, he task of an alert is displaying a message for the user in most cases. So in this example, let's write a test for this text located in a slot. You can find this example in the linked video above as well.
 
 We will start with an already written test similar to the first example:
 
@@ -444,7 +467,23 @@ productRepository() {
 
 Now let's say you want to test the repository request which fetches the product list. You can mock the search method of the created repository and return an array of dummy data. By returning a Promise which immediately resolves you can test the .then\(\) branch of the actual implementation.
 
-provide: { repositoryFactory: { create: \(\) =&gt; \({ search: \(\) =&gt; { return Promise.resolve\(\[ { name: 'Foo bar', manufacturer: 'Test' }, { name: 'Lorem ipsum', manufacturer: 'Jest party' } \]\); } }\) } }
+```javascript
+provide: {
+    repositoryFactory: {
+        create: () => ({ 
+            search: () => ({
+              return Promise.resolve([{
+                  name: 'Foo bar', 
+                  manufacturer: 'Test' 
+              }, {
+                  name: 'Lorem ipsum', 
+                  manufacturer: 'Jest party' 
+              }])
+            })
+        }) 
+    }
+}
+```
 
 This is the equivalent to:
 
@@ -510,3 +549,13 @@ provide: {
 }
 ```
 
+## Next steps
+
+Do you want to see these examples in practise? Head over to our [video tutorial](https://youtu.be/nWUBK3fjwVg) on how
+to write component tests in jest for the Shopware administration. 
+
+However, it doesn't stop there. You might to write more tests for your plugin, so we got you covered with even more
+guides on testing:
+* [Unit testing with PHPUnit](./php-unit.md)
+* [Jest unit tests in Shopware's storefront](./jest-storefront.md)
+* [End-to-End testing in Shopware](./end-to-end-testing.md)

--- a/guides/plugins/plugins/testing/jest-storefront.md
+++ b/guides/plugins/plugins/testing/jest-storefront.md
@@ -1,0 +1,153 @@
+# Jest unit tests in Shopware's storefront
+
+## Overview
+
+You should write a unit test for every functional change. Writing tests will ensure that your written code works and 
+that another change can't break your code's functionality with their code.
+
+With a good test coverage you gain confidence to deploy a stable software without the requirement to manually test 
+every change. This little guide will guide you how to write unit tests for the administration in Shopware 6.
+
+We are using [Jest](https://jestjs.io/) as our testing framework. It's a solid foundation and widely used by many 
+developers.
+
+## Prerequisites
+
+Before you are reading this guide you have to make sure you understand the basics of unit tests and how Jest works.
+You can find a good source for best practices in this Github Repo: [https://github.com/goldbergyoni/javascript-testing-best-practices](https://github.com/goldbergyoni/javascript-testing-best-practices)
+
+## Test structure
+
+When it comes to the path to the test folder, you are quite free to use your own requirements. You could even build up
+a separate test suite if you need. The following configuration matches our core configuration to give you a 
+little starting point. In Shopware's platform repository, you will find the storefront unit tests in the following 
+directory: `platform/src/Storefront/Resources/app/storefront/test`
+It may be a good idea to resemble this directory structure, but it's no fixed requirement.
+
+The exact test folder structure looks like seen below, starting in `Storefront` bundle:
+```bash
+Resources
+  `-- app
+    `-- <environment>
+      `-- test
+        `-- plugin
+          `-- <plugin-name>
+            `-- js-plugin-test.spec.js  
+```
+
+Please note that in this example, `<environment>` is a placeholder for the environment you are working in. 
+In this context, that should be `storefront`.
+
+## Writing a basic test
+
+When writing jest unit tests in the storefront, you will soon realize that it's not that much different from 
+writing jest unit tests in general. Unlike the [Jest unit tests in the Administration](./jest-admin.md), you
+basically don't need to go an extra mile to write your unit tests. Services, helper and isolated ECMAScript modules 
+are well testable because you can import them directly without mocking or stubbing dependencies. 
+They can be used isolated and therefore are easy to test.
+
+Let's start from scratch with a simple example: Imagine we want to write a test for a helper class, e.g. the 
+`feature.helper` of our Storefront, handling the feature flag usage. We want to test, if our feature helper can
+indeed handle active feature flags.
+
+At first, you need to create your test file, e.g. `feature.helper.test.js`. With your new created test file, 
+let's create the test structure for it:
+
+{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+```javascript
+// descrube is meant for grouping and structure
+describe('feature.helper.js', () => {
+
+    // This is your actual test
+    test('checks the flags', () => {
+        // Assertions come here
+    });
+});
+```
+{% endcode %}
+
+Now, let's fill this empty test with life. Our first step is importing the helper under test - the `feature.helper` class.
+However, there one more step to be done for preparation.
+
+{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+```javascript
+// Import for the helper to test
+import Feature from 'src/helper/feature.helper';
+
+describe('feature.helper.js', () => {
+    test('checks the flags', () => {
+        // Assertions come here
+    });
+});
+```
+{% endcode %}
+
+In order to be able to test our feature flag integration, we of course need some fixtures to be present - some active and
+inactive feature flags. So we need to ensure their presence before running the tests, ideally in a setup step. 
+As you might know from other frameworks, it's convenient to use[lifecycle hooks](https://jestjs.io/docs/en/setup-teardown)
+for that purpose. 
+
+To sum it up, we need a feature flag fixture and the implementation of it in the `beforeEach` hook of our test.
+In our example, that looks like below:
+
+{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+```javascript
+import Feature from 'src/helper/feature.helper';
+
+// One flag should be active, the other shouldn't.
+const default_flags = {
+    test1: true,
+    test2: false
+};
+
+describe('feature.helper.js', () => {
+    
+    // This hook is executed before every test
+    beforeEach(() => {
+        // Applying the flag fixture
+        Feature.init(default_flags);
+    });
+
+    test('checks the flags', () => {
+        // Assertions come here
+    });
+});
+```
+{% endcode %}
+
+Alright, let's get to the point now, writing the actual test. Remember we want to make sure we have active and 
+inactive feature flags. In addition, it may be useful to check the behavior if a third, non-existent feature flag is
+introduced. Using [Jest's matchers](https://jestjs.io/docs/en/using-matchers) for these assertions, we get the 
+following test:
+
+{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+```javascript
+import Feature from 'src/helper/feature.helper';
+
+const default_flags = {
+    test1: true,
+    test2: false
+};
+
+describe('feature.helper.js', () => {
+    beforeEach(() => {
+        Feature.init(default_flags);
+    });
+
+    test('checks the flags', () => {
+        expect(Feature.isActive('test1')).toBeTruthy();
+        expect(Feature.isActive('test2')).toBeFalsy();
+        expect(Feature.isActive('test3')).toBeFalsy();
+    });
+});
+```
+{% endcode %}
+
+That's basically it! We wrote our first jest unit test in the Storefront.
+
+## Next steps
+
+You might to write more tests for your plugin, so we got you covered with even more guides on testing:
+* [Unit testing with PHPUnit](./php-unit.md)
+* [Jest unit tests in Shopware's administration](./jest-admin.md)
+* [End-to-End testing in Shopware](./end-to-end-testing.md)

--- a/guides/plugins/plugins/testing/jest-storefront.md
+++ b/guides/plugins/plugins/testing/jest-storefront.md
@@ -8,21 +8,38 @@ that another change can't break your code's functionality with their code.
 With a good test coverage you gain confidence to deploy a stable software without the requirement to manually test 
 every change. This little guide will guide you how to write unit tests for the administration in Shopware 6.
 
-We are using [Jest](https://jestjs.io/) as our testing framework. It's a solid foundation and widely used by many 
-developers.
+We are using JestJS as our testing framework as it's a solid foundation and widely used by many developers.
+
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="https://jestjs.io" %}
 
 ## Prerequisites
 
 Before you are reading this guide you have to make sure you understand the basics of unit tests and how Jest works.
-You can find a good source for best practices in this Github Repo: [https://github.com/goldbergyoni/javascript-testing-best-practices](https://github.com/goldbergyoni/javascript-testing-best-practices)
+You can find a good source for best practices in this Github Repo:
+
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="https://github.com/goldbergyoni/javascript-testing-best-practices" %}
+
+In addition, you need a running Shopware 6 installation. Your repository used for that should be based on development 
+template, as we will to use some scripts provided by it.
+
+For one example, we use a Javascript plugin. In oder to follow this example, you need to know how to build a Javascript
+plugin in the first place. You can learn about it in the corresponding [guide](./../storefront/add-custom-javascript.md).
+
 
 ## Test structure
 
-When it comes to the path to the test folder, you are quite free to use your own requirements. You could even build up
-a separate test suite if you need. The following configuration matches our core configuration to give you a 
-little starting point. In Shopware's platform repository, you will find the storefront unit tests in the following 
+{% hint style="warning" %} When it comes to the path to the test folder, you are quite free to use your own requirements. You could even build up
+a separate test suite if you need. There's one limitation though: Please take care you place your tests according your `package.json` file! {% endhint %}
+
+The following configuration matches our core configuration in order to give you a starting point. In Shopware's platform 
+repository, you will find the storefront unit tests in the following 
 directory: `platform/src/Storefront/Resources/app/storefront/test`
-It may be a good idea to resemble this directory structure, but it's no fixed requirement.
+It may be a good convention to resemble this directory structure, but it's no fixed requirement.
+
+Inside the test directory, you add a test for a file in the same path as the source path. You see: 
+When creating the file, the name should also be the same as the component has with an additional `test`.
 
 The exact test folder structure looks like seen below, starting in `Storefront` bundle:
 ```bash
@@ -53,7 +70,7 @@ indeed handle active feature flags.
 At first, you need to create your test file, e.g. `feature.helper.test.js`. With your new created test file, 
 let's create the test structure for it:
 
-{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+{% code title="<plugin root>/src/Resources/app/storefront/test/helper/feature.helper.test.js" %}
 ```javascript
 // descrube is meant for grouping and structure
 describe('feature.helper.js', () => {
@@ -69,7 +86,7 @@ describe('feature.helper.js', () => {
 Now, let's fill this empty test with life. Our first step is importing the helper under test - the `feature.helper` class.
 However, there one more step to be done for preparation.
 
-{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+{% code title="<plugin root>/src/Resources/app/storefront/test/helper/feature.helper.test.js" %}
 ```javascript
 // Import for the helper to test
 import Feature from 'src/helper/feature.helper';
@@ -84,13 +101,13 @@ describe('feature.helper.js', () => {
 
 In order to be able to test our feature flag integration, we of course need some fixtures to be present - some active and
 inactive feature flags. So we need to ensure their presence before running the tests, ideally in a setup step. 
-As you might know from other frameworks, it's convenient to use[lifecycle hooks](https://jestjs.io/docs/en/setup-teardown)
+As you might know from other frameworks, it's convenient to use [lifecycle hooks](https://jestjs.io/docs/en/setup-teardown)
 for that purpose. 
 
 To sum it up, we need a feature flag fixture and the implementation of it in the `beforeEach` hook of our test.
 In our example, that looks like below:
 
-{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+{% code title="<plugin root>/src/Resources/app/storefront/test/helper/feature.helper.test.js" %}
 ```javascript
 import Feature from 'src/helper/feature.helper';
 
@@ -120,7 +137,7 @@ inactive feature flags. In addition, it may be useful to check the behavior if a
 introduced. Using [Jest's matchers](https://jestjs.io/docs/en/using-matchers) for these assertions, we get the 
 following test:
 
-{% code title="Resources/app/storefront/test/helper/feature.helper.test.js" %}
+{% code title="<plugin root>/src/Resources/app/storefront/test/helper/feature.helper.test.js" %}
 ```javascript
 import Feature from 'src/helper/feature.helper';
 
@@ -144,6 +161,293 @@ describe('feature.helper.js', () => {
 {% endcode %}
 
 That's basically it! We wrote our first jest unit test in the Storefront.
+
+## Executing the tests
+
+Before you are using the commands make sure that you installed all dependencies for your storefront. If you haven't
+done this already, then you can do it running the following PSH command:
+
+```bash
+> ./psh.phar administration:install-dependencies
+```
+
+In order to run jest unit tests of the storefront, you can use the psh commands provided by our development template.
+This command executes all unit tests and shows you the complete code coverage.
+
+```bash
+> ./psh.phar administration:unit
+```
+
+{% hint style="info" %} This only applies to the Shopware provided Storefront! If you use unit tests in your Plugin,
+you might need to write your own scripts for that. {% endhint %}
+
+## Mocking JavaScript plugins
+
+Now, let's have a look at a intermediate example: As you're writing JavaScript plugins, you may want to test those. 
+As you need to mock some things in this case, this kind of test might be a bit more complex.
+
+{% hint style="info" %} The folder structure, and the corresponding file locations of the following example will resemble the one used in `platform` repository. {% endhint %}
+
+Let's start with the plugin we want to test later. For the sake of simplicity, we will use a plugin which returns
+"Hello world":
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/plugin/hello-world/hello-world.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class'
+
+export default class HelloWorldPlugin extends Plugin {
+    static options = {};
+
+    init() {
+        console.log('Hello World!', this.el);
+    }
+
+    sayHello() {
+        return "Hello World!"
+    }
+}
+```
+{% endcode %}
+
+Of course, you need to make sure that your plugin is registered, more details in the guide on [Javascript plugins](./../storefront/add-custom-javascript.md). 
+
+In the beginning, writing plugin tests is still similar to other jest unit tests: You import your plugin's 
+class and use the familiar test structure:
+
+{% code title="<plugin root>/src/Resources/app/storefront/test/plugin/hello-world/hello-world.plugin.test.js" %}
+```javascript
+/**
+ * @jest-environment jsdom
+ */
+
+// import your plugin here
+import HelloWorldPlugin from 'src/plugin/hello-world/hello-world.plugin';
+
+describe('HelloWorldPlugin tests', () => {
+
+    beforeEach(() => {
+        // Here we need to do all the mocking
+    });
+
+    afterEach(() => {
+        // Teardown
+    });
+
+    test('custom plugin exists', () => {
+        // your actual test
+    });
+});
+```
+{% endcode %}
+
+You might notice the lifecycle hook we use in this test. These will be important in the next steps where we begin to
+mock our plugin and clean it up after our tests.
+
+The `beforeEach` hook will be executed before each test. Thus, it's the perfect location for creating our plugin under
+test. Therefore, we need to get an element first. We'll use it to create our plugin - resembling the 
+usage of a plugin on an element.
+
+{% code title="<plugin root>/src/Resources/app/storefront/test/plugin/hello-world/hello-world.plugin.test.js" %}
+```javascript
+/**
+ * @jest-environment jsdom
+ */
+
+import HelloWorldPlugin from 'src/plugin/hello-world/hello-world.plugin';
+
+describe('HelloWorldPlugin tests', () => {
+
+    // Definition of plugin
+    let plugin;
+    
+    beforeEach(() => {
+        // you need to get an element for the plugin
+        const mockedElement = document.createElement('div');
+        plugin = new HelloWorldPlugin(mockedElement);
+        
+    });
+
+    afterEach(() => {
+        // Teardown
+    });
+
+    test('custom plugin exists', () => {
+        // your actual test, temporary filled with a placeholder
+        console.log(plugin);
+    });
+});
+```
+{% endcode %}
+
+If you execute your test now, you'll run into an error:
+
+```bash
+	  HelloWorldPlugin tests
+	    ✕ custom plugin exists (32ms)
+
+	  ● HelloWorldPlugin tests › custom plugin exists
+
+	    TypeError: Cannot read property 'getPluginInstancesFromElement' of undefined
+
+	      119 |      */
+	      120 |     _registerInstance() {
+	    > 121 |         const elementPluginInstances = window.PluginManager.getPluginInstancesFromElement(this.el);
+	          |                                                             ^
+	      122 |         elementPluginInstances.set(this._pluginName, this);
+	      123 |
+	      124 |         const plugin = window.PluginManager.getPlugin(this._pluginName, false);
+```
+
+This was to be expected because you need to mock some more things required for the plugin to run. To solve this issue, 
+you need to mock the `PluginManager` which holds all plugin instances globally in the Storefront. Because our test 
+is just testing the single plugin class, the actual implementation on the real DOM element in the storefront
+isn't too important at this moment.
+
+
+{% code title="<plugin root>/src/Resources/app/storefront/test/plugin/hello-world/hello-world.plugin.test.js" %}
+```javascript
+/**
+ * @jest-environment jsdom
+ */
+
+import HelloWorldPlugin from 'src/plugin/hello-world/hello-world.plugin';
+
+describe('HelloWorldPlugin tests', () => {
+    let plugin;
+
+    beforeEach(() => {
+        
+        // Mocking PluginManager to get the plugin working
+        window.PluginManager = {
+            getPluginInstancesFromElement: () => {
+                return new Map();
+            },
+            getPlugin: () => {
+                return {
+                    get: () => []
+                };
+            }
+        };
+
+        const mockedElement = document.createElement('div');
+        plugin = new HelloWorldPlugin(mockedElement);
+    });
+
+    afterEach(() => {
+        // Set your plugin to null to clean up afterwards
+        plugin = null;
+    });
+
+    test('custom plugin exists', () => {
+        // your actual test, temporary filled with a placeholder
+        console.log(plugin);
+    });
+});
+```
+{% endcode %}
+
+{% hint style="warning" %} Don't forget the cleanup after each test! You need to set your plugin to `null` in your `afterEach` hook to ensure an isolated test. {% endhint %}
+
+Finally, we're ready to write our actual test. Write your assertions as you're used to. In this example, we first want 
+to test if our plugin can be instantiated:
+
+{% code title="<plugin root>/src/Resources/app/storefront/test/plugin/hello-world/hello-world.plugin.test.js" %}
+```javascript
+/**
+ * @jest-environment jsdom
+ */
+
+import HelloWorldPlugin from 'src/plugin/hello-world/hello-world.plugin';
+
+describe('HelloWorldPlugin tests', () => {
+    let plugin;
+
+    beforeEach(() => {
+        window.PluginManager = {
+            getPluginInstancesFromElement: () => {
+                return new Map();
+            },
+            getPlugin: () => {
+                return {
+                    get: () => []
+                };
+            }
+        };
+
+        const mockedElement = document.createElement('div');
+        plugin = new HelloWorldPlugin(mockedElement);
+    });
+
+    afterEach(() => {
+        plugin = null;
+    });
+
+    test('The HelloWorld plugin can be instantiated', () => {
+        
+        // Our assertions will be done here
+        expect(plugin).toBeInstanceOf(HelloWorldPlugin);
+    });
+});
+```
+{% endcode %}
+
+Afterwards, we can add more tests as we want to. To give an example, it's useful to rest if our plugin returns the 
+"Hello World" test as expected:
+
+{% code title="<plugin root>/src/Resources/app/storefront/test/plugin/hello-world/hello-world.plugin.test.js" %}
+```javascript
+    test('Shows text', () => {
+        expect(plugin.sayHello()).toBe('Hello World!')
+    });
+```
+{% endcode %}
+
+Now you're ready to go! Below the full example of our test, for reference:
+
+{% code title="<plugin root>/src/Resources/app/storefront/test/plugin/hello-world/hello-world.plugin.test.js" %}
+```javascript
+/**
+ * @jest-environment jsdom
+ */
+
+import HelloWorldPlugin from 'src/plugin/hello-world/hello-world.plugin';
+
+describe('HelloWorldPlugin tests', () => {
+
+    let plugin;
+
+    beforeEach(() => {
+        window.PluginManager = {
+            getPluginInstancesFromElement: () => {
+                return new Map();
+            },
+            getPlugin: () => {
+                return {
+                    get: () => []
+                };
+            }
+        };
+
+        const mockedElement = document.createElement('div');
+        plugin = new HelloWorldPlugin(mockedElement);
+    });
+
+    afterEach(() => {
+        // Teardown
+        plugin = null;
+    });
+
+    test('The cookie configuration plugin can be instantiated', () => {
+        // your actual test
+        expect(plugin).toBeInstanceOf(HelloWorldPlugin);
+    });
+
+    test('Shows text', () => {
+        expect(plugin.sayHello()).toBe('Hello World!')
+    });
+});
+```
+{% endcode %}
 
 ## Next steps
 


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains how to write storefront unit tests.

This article should mention:

The prerequisite, a working plugin (Refer to the plugin base guide)
How to setup the test environment (PSH commands necessary)
The necessary structure
Reference to jest tests
Test example
How to execute these tests (and just these!)
Category: Extensions > Plugins > Testing

Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.