### PR TITLE
Aligned installation order in menu and overview

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -73,7 +73,6 @@
   * [Docker](guides/installation/docker.md)
   * [from scratch](guides/installation/from-scratch.md)
   * [Valet+](guides/installation/valet.md)
-  * [Vagrant](guides/installation/vagrant.md)
   * [MAMP](guides/installation/mamp.md)
 * [Extensions](guides/plugins/README.md)
   * [Overview](guides/plugins/overview.md)

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -2,12 +2,12 @@
 
 There are a couple of ways to get Shopware running on your system. Depending on what best suits your development environment, you have the following choices:
 
-* [Docker](./docker.md): The docker installation is the easiest way to get a running Shopware 6.
-* [MAMP](./mamp.md): For quick and easy installation you can also use MAMP tool on mac.
-* [Valet+](./valet.md): You can install Shopware with the epl of Valet+, which is a fork of laravel/valet. 
 * [Dockware](./dockware.md): This is a managed docker setup for Shopware 6 by shopware agency dasistweb.
-* [Installation from scratch](./from-scratch.md): You can install Shopware 6 locally. However, be aware that this will 
-
+* [Docker](./docker.md): The docker installation is the easiest way to get a running Shopware 6.
+* [Installation from scratch](./from-scratch.md): You can install Shopware 6 locally. However, be aware that this will
+* [Valet+](./valet.md): You can install Shopware with the epl of Valet+, which is a fork of laravel/valet.
+* [MAMP](./mamp.md): For quick and easy installation you can also use MAMP tool on mac. 
+ 
   be the more complex solution since additional or changed system requirements need to be managed by you.
 
 ## Prerequisites

--- a/guides/installation/vagrant.md
+++ b/guides/installation/vagrant.md
@@ -1,8 +1,0 @@
-# Vagrant
-
-{% hint style="info" %}
-Not officially supported installation method
-{% endhint %}
-
-
-


### PR DESCRIPTION
Vagrant was not documented (-> removed) and order was different in menu and overview article.