### PR TITLE
NEXT-12716 - Add guide on how to remove a javascript plugin

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -169,6 +169,7 @@
       * [Add translations](guides/plugins/plugins/storefront/add-translations.md)
       * [Use CSRF protection](guides/plugins/plugins/storefront/use-csrf-protection.md)
       * [Use media and thumbnails](guides/plugins/plugins/storefront/use-media-thumbnails.md)
+      * [Remove unnecessary Javascript plugin](guides/plugins/plugins/storefront/remove-unnecessary-js-plugin.md)
     * [Testing](guides/plugins/plugins/testing/README.md)
       * [End-to-end testing](guides/plugins/plugins/testing/end-to-end-testing.md)
       * [Jest unit tests in Shopware's administration](guides/plugins/plugins/testing/jest-admin.md)

--- a/guides/installation/from-scratch.md
+++ b/guides/installation/from-scratch.md
@@ -1,4 +1,4 @@
-# from scratch
+# Installation from scratch
 
 If it's impossible to get docker up and running on your development environment you can install Shopware 6 locally. However, be aware this will be by far the more complex solution since additional or changed system requirements need to be managed by you.
 

--- a/guides/plugins/plugins/administration/add-custom-module.md
+++ b/guides/plugins/plugins/administration/add-custom-module.md
@@ -1,4 +1,4 @@
-# Add menu module
+# Add custom module
 
 In the `Administration` core code, each module is defined in a directory called `module`, so simply stick to it. Inside of the `module` directory lies the list of several modules, each having their own directory named after the module itself.
 

--- a/guides/plugins/plugins/storefront/remove-unnecessary-js-plugin.md
+++ b/guides/plugins/plugins/storefront/remove-unnecessary-js-plugin.md
@@ -1,0 +1,39 @@
+# Remove Javascript plugin
+
+## Overview
+
+When you develop your own plugin, you might want to exclude Javascript plugins at some occasions. For example, if you 
+don't want a Core plugin to interfere, with your own code. This guide will teach you how to remove this Javascript plugin with
+your own Shopware plugin.
+
+## Prerequisites
+
+While this is not mandatory, having read the guide about [adding custom javascript plugins](./add-custom-javascript.md) beforehand might help you understand this guide a bit further. 
+
+Other than that, this guide just requires you to have a running plugin installed, e.g. our plugin from the 
+[plugin base guide](./../plugin-base-guide.md).
+
+## Unregistering Javascript Plugin
+
+Imagine we wanted to exclude the `OffCanvasCart` plugin, just to get a test case which can be inspected easily.
+In order to remove a Javascript plugin, you only need to add the following line to your `main.js` file:
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/main.js" %}
+```javascript
+window.PluginManager.deregister('OffCanvasCart', '[data-offcanvas-cart]');
+```
+{% endcode %}
+
+After building the storefront anew, you shouldn't be able to open the offcanvas cart anymore. Another useful way of
+testing this is using your browser's devtools. Just open your devtool's console and 
+type in `PluginManager.getPluginList()` in order to get a list of all registered plugins.
+
+In our case, we shouldn't find `OffCanvasCart` in the listed plugins anymore.
+
+## Next steps
+
+Did you already take a look at our other storefront guides? They can give you some neat starting points on how to extend
+and customize Shopware's storefront.
+* [Override existing Javascript in your plugin](./override-existing-javascript.md)
+* [Override existing routes](./override-existing-routes.md)
+* [Reacting to Javascript events](./reacting-to-javascript-events.md)


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains how to remove unwanted javascript plugin / prevent them from being loaded in the first place.

This article should mention:

The prerequisite, a working plugin (Refer to the plugin base guide)
Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
A short code example, including an explanation, on how to do it
Category: Extensions > Plugins > Storefront

Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.