### PR TITLE
NEXT-12785 - [NEW] Administration: Add shortcuts

### DIFF
--- a/guides/plugins/plugins/administration/add-shortcuts.md
+++ b/guides/plugins/plugins/administration/add-shortcuts.md
@@ -45,6 +45,8 @@ Component.register('swag-basic-example', {
 The first keyboard shortcut reacts to the key combination of `SYSTEMKEY+S`, only if the the user has the privilege `product.editor`, with the invocation of the component method with the name `myEditProductFunction`.
 The second keyboard shortcut defines that, upon the `ESCAPE` key being pressed, the function with the name `myCancelEditProductFunction` should be invoked.
 
+The before mentioned `SYSTEMKEY` is `CTRL` on macOS and `ALT` on windows, other system-keys like `CTRL` on windows or `⌥` on macOS are not supported.
+
 Since ACL is used in the first keyboard shortcut you might want to learn more about ACL and how to add your own ACL rules [here](./add-acl-rules.md).
 
 ## Next steps

--- a/guides/plugins/plugins/administration/add-shortcuts.md
+++ b/guides/plugins/plugins/administration/add-shortcuts.md
@@ -1,0 +1,57 @@
+# Adding Shortcuts
+
+## Overview 
+
+Shortcuts in Shopware 6 are defined on a Component basis. This guide will show you how to add your own ones.
+
+## Prerequisites
+
+All you need for this guide is a running Shopware 6 instance and full access to both the files and preferably a registered module and custom component.
+Of course you'll have to understand JavaScript, but that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation.
+
+## Configuring the Shortcuts
+
+The following code sample will show you how to register shortcuts in your components with help of the `shortcuts` attribute.
+
+{% code title="<plugin root>/src/Resources/app/administration/src/module/swag-example/index.js" %}
+```javascript
+const { Component } = Shopware;
+
+Component.register('swag-basic-example', {
+    
+    shortcuts: {
+        'SYSTEMKEY+S': {
+            active() {
+                return this.acl.can('product.editor');
+            },
+            method: 'myEditProductFunction'
+        },
+        ESCAPE: 'myCancelEditProductFunction'
+    },
+
+   
+    methods: {
+        myEditProductFunction() {
+            console.log("myEditProductFunction")
+        },
+        myCancelEditProductFunction() {
+            console.log("myCancelEditProductFunction")
+        }
+    }
+});
+```
+{% endcode %}
+
+The first keyboard shortcut reacts to the key combination of `SYSTEMKEY+S`, only if the the user has the privilege `product.editor`, with the invocation of the component method with the name `myEditProductFunction`.
+The second keyboard shortcut defines that, upon the `ESCAPE` key being pressed, the function with the name `myCancelEditProductFunction` should be invoked.
+
+Since ACL is used in the first keyboard shortcut you might want to learn more about ACL and how to add your own ACL rules [here](./add-acl-rules.md).
+
+## Next steps
+
+Now you that know how to add shortcuts to your components, you may want to learn more about [ACL](./add-acl-rules.md). Furthermore, if you want to learn about other possibilities to extend the Administration, we got you covered with other guides:
+
+* [Writing templates](writing-templates.md)
+* [Add custom module](add-custom-module.md)
+* [Add menu entry](./add-menu-entry.md)
+* [Add custom routes](./add-custom-route.md)


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to add a new shortcut to a module.

This article should mention:

-The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it
- Maybe this should be built upon the "Add module" guide. If so, please add this reference as a prerequisite.

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.