### PR TITLE
NEXT-12778 [NEW] Using base components

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -153,6 +153,7 @@
       * [Customizing components](guides/plugins/plugins/administration/customizing-components.md)
       * [Add custom component](guides/plugins/plugins/administration/add-custom-component.md)
       * [Add custom input field to existing component](guides/plugins/plugins/administration/add-custom-field.md)
+      * [Using base components](guides/plugins/plugins/administration/using-base-components.md)
       * [Adding snippets](guides/plugins/plugins/administration/adding-snippets.md)
       * [Add custom styles](guides/plugins/plugins/administration/add-custom-styles.md)
       * [Using the data handling](guides/plugins/plugins/administration/using-data-handling.md)

--- a/guides/plugins/plugins/administration/using-base-components.md
+++ b/guides/plugins/plugins/administration/using-base-components.md
@@ -1,0 +1,41 @@
+# Using base components
+
+The Shopware 6 Administration comes with a bunch of tailored Vue components, already accessible in all of your templates via the `component registry`.
+This guide will show you how you can use Shopware-made components in your templates, 
+if you want to learn more about the `component registry` and how you can register your own components to it have a look at the [corresponding guide](./add-custom-component.md)
+
+## Prerequisites
+
+All you need for this guide is a running Shopware 6 instance, the files and preferably a registered module. Of course you'll have to understand JavaScript and have a basic familiarity with [Vue](https://vuejs.org/), the framework used in the Administration. However, that's a prerequisite for Shopware as a whole and will not be taught as part of this documentation.
+
+## Finding the base component needed
+
+All Shopware 6 Administration components can be found in the [Component Library](https://component-library.shopware.com/). 
+There you can see what each of the components does and looks like, it also shows you what props they can work with and which slots they have.
+
+## Using the base component
+
+As mentioned before in the introduction, all components used in the Shopware 6 Administration are first registered to the `component registry`.
+This `component registry` is just a map of all components, which then get registered to Vue during the `Administrations boot process`.
+Since all of the components are registered as [global `Vue` components](https://vuejs.org/v2/guide/components-registration.html#Global-Registration),
+they are accessible in all templates of the Administration.
+
+Using base components in your own administration templates is rather simple. In the example below we will use the `sw-text-field` in our template, which simply renders a `text` input tag, but also supports some fancy functionality, like inheritance, etc:
+
+{% code title="<plugin-root>/src/Resources/app/administration/app/src/component/example-component/example.html.twig" %}
+```html
+<div>
+    <sw-text-field />
+</div>
+```
+{% endcode %}
+
+That's basically it. To continue building beautiful custom components, learn how to write templates and how to include them in your components [here](./writing-templates.md).
+
+## Next steps
+
+Now that you know that all components are accessible through the component registry, you might want to learn more about the following things:
+
+* [How to create custom templates](./writing-templates.md)
+* [How to add your own components](./add-custom-component.md)
+* [Customizing components](./add-custom-route.md)


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to use base administration components.

This article should mention:

- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Administration
Are there already guides in the previous documentation for this?

Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.