### PR TITLE
NEXT-12717 - Add guide on using assets storefront

### DIFF
--- a/guides/plugins/plugins/administration/add-custom-module.md
+++ b/guides/plugins/plugins/administration/add-custom-module.md
@@ -17,7 +17,7 @@ The first step is creating a new directory `<plugin root>/src/Resources/app/admi
 
 Your custom module directory isn't known to Shopware 6 yet. As mentioned earlier, the only entry point of your plugin is the `main.js` file. That's the file you need to change now, so that it loads your new module. For this, simply add the following line to your `main.js` file:
 
-{% code title="<plugin root>src/Resources/app/administration/src/main.js" %}
+{% code title="<plugin root>/src/Resources/app/administration/src/main.js" %}
 ```javascript
 import './module/swag-example';
 ```

--- a/guides/plugins/plugins/storefront/add-custom-assets.md
+++ b/guides/plugins/plugins/storefront/add-custom-assets.md
@@ -1,2 +1,100 @@
 # Add custom assets
 
+## Overview
+
+When working with an own plugin, the usage of own custom images or other assets is
+a natural requirement. So of course you can do that in Shopware. In this guide we will discover together how it's 
+possible to add and use custom assets in your Shopware plugin.
+
+## Prerequisites
+
+In order to be able to start with this guide, you need to have an own plugin running. As to most guides, this guide 
+is also built upon the Plugin base guide:
+
+{% page-ref page="../plugin-base-guide.md" %}
+
+Needless to say, you should have your image or another asset at hand to work with.
+
+## Adding custom assets to your plugin
+
+In order to add custom assets to your theme, you need to create a new folder called public inside the `src/Resources` 
+directory of your plugin. Here you're able to store your assets files, so please feel free to save your image there -
+we'll do the same thing in our example plugin. 
+
+```bash
+# PluginRoot
+.
+├── composer.json
+└── src
+    ├── Resources
+    │   ├── public
+    │   │   └── your-image.png <-- Asset file here
+    └── SwagBasicExample.php
+```
+
+Afterwards, you need to make sure your plugin assets are copied over to the public/bundles folder. However, don't 
+to this by hand - the command `bin/console assets:install` will take care of it.
+
+```
+# shopware-root/public/bundles
+.
+├── administration
+├── framework
+├── storefront
+└── SwagBasicExample
+    └── your-image.png <-- Your asset is copied here
+```
+
+## Linking to assets
+
+### Using custom assets in your template
+
+Let's think about a simple example, displaying our image right in the base template of the storefront. In there we're
+able to link our assets by simply using the [asset](https://symfony.com/doc/current/templates.html#linking-to-css-javascript-and-image-assets) 
+function Symfony provides:
+
+{% code title="<plugin root>/src/Resources/views/storefront/base.html.twig" %}
+```twig
+{% sw_extends '@Storefront/storefront/base.html.twig' %}
+
+{% block base_main %}
+    <h2>Asset:</h2>
+    
+    {# Using asset function to display our custom asset #}
+    <img src="{{ asset('bundles/SwagBasicExample/image.png') }}"
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+That's basically all you need to do to link your plugin's custom assets.
+
+### Using custom assets in your CSS files
+
+There's one more interesting possibility though. If you want, you can use your custom asset in your CSS files. Look
+at the following example:
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/scss/base.scss" %}
+```scss
+body {
+    background-image: url("/bundles/SwagBasicExample/image.png");
+}
+```
+{% endcode %}
+
+You see, we can use our custom assets by using the asset path provided by the `bundle` directory.
+
+### Adding custom assets in themes
+
+Of course, you're able to use custom assets in themes as well. In this context there's another way on integration 
+custom assets into your theme. Please take a look on the guide about adding assets to a theme for further detail:
+
+{% page-ref page="./../../themes/add-assets-to-theme.md" %}
+
+## Next steps
+
+In this guide, you learnt how to add and use your own assets in your plugin. How about customizing your plugin even
+more? Take a look at the following articles to learn more ways to customize your plugin:
+* [Add custom styling](./add-custom-styling.md)
+* [Add custom JavaScript](./add-custom-javascript.md)
+* [Customize templates](./customize-templates.md)

--- a/guides/plugins/themes/add-assets-to-theme.md
+++ b/guides/plugins/themes/add-assets-to-theme.md
@@ -8,35 +8,54 @@ Your theme can include custom assets like images. This short guide will show you
 
 This guide is built upon the [Create a first theme](./create-a-theme.md) guide.
 
-## Using custom assets
+## Using custom assets 
 
-To add custom assets to your theme, create a new folder called `public` inside the `src/Resources` directory of your theme. Here you can store your assets files.
+There are basically two ways of adding custom assets to your theme. The first one is using the `theme.json` to define 
+the path to your custom assets, the second being the default way of using custom assets in plugins. We'll take a closer
+look at them in the following sections.
 
-```bash
-# PluginRoot
-.
-├── composer.json
-└── src
-    ├── Resources
-    │   ├── public
-    │   │   └── your-image.png <-- Asset file here
-    └── SwagBasicExampleTheme.php
+### Adding assets in theme.json file
+
+While working with your own theme, you might already came across the [theme configuration](./theme-configuration.md).
+In there, you have the possibility to configure your paths to your custom assets like images, fonts, etc. This way,
+please configure your asset path accordingly.
+
+{% code title="<plugin root>/src/Resources/theme.json" %}
+```json
+# src/Resources/theme.json
+{
+  ...
+  "asset": [
+     "app/storefront/src/assets"
+   ]
+  ...
+}
 ```
+{% endcode %}
 
-Next, please run the `bin/console assets:install` command. This will copy your plugin assets over to the 
-`public/bundles` folder:
+Next, please run the bin/console assets:install command. This will copy your plugin assets over to the public/bundles folder:
 
+{% code title="<shopware root>/public/bundles" %}
 ```
-# shopware-root/public/bundles
+# 
 .
 ├── administration
 ├── framework
 ├── storefront
-└── swagbasicexampletheme
-    └── your-image.png <-- Your asset is copied here
+└── theme
+    └── <your-theme-id>
+        └── your-image.png <-- Your asset is copied here
 ```
+{% endcode %}
 
-## Linking to assets:
+### Adding assets the plugin way
+
+This way of adding custom assets refers to the default was of dealing with assets. For more detail on this way, please
+check out the article that specifically addresses this topic: 
+
+{% page-ref page="./../plugins/storefront/add-custom-assets.md" %}
+
+## Linking to assets
 
 You can link to the asset with the twig 
 [asset](https://symfony.com/doc/current/templates.html#linking-to-css-javascript-and-image-assets) function:
@@ -49,7 +68,7 @@ In SCSS you can link to the asset like the following:
 
 ```css
 body {
-    background-image: url("/bundles/swagbasicexampletheme/your-image.png");
+    background-image: url("bundles/swagbasicexampletheme/your-image.png");
 }
 ```
 


### PR DESCRIPTION
What should be done?
Create a new article on our GitBook instance which explains how to add custom assets via a plugin, such as images, fonts, ....

This article should mention:

* The prerequisite, a working plugin (Refer to the plugin base guide)
* Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
* A short code example, including an explanation, on how to do it
* Maybe this should be built upon the "Plugin base guide" - in that case, reference it as a prerequisite.
Category: Extensions > Plugins > Storefront

Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.