### PR TITLE
NEXT-12540 - [NEW] Plugins for Symfony Developers

### DIFF
--- a/guides/plugins/plugins/plugin-base-guide.md
+++ b/guides/plugins/plugins/plugin-base-guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Plugins in Shopware are essentially an extension of [Symfony bundles](https://symfony.com/doc/current/bundles.html#creating-a-bundle). Such bundles and plugins can provide their own resources like assets, controllers, services or tests, which you'll learn in the next guides.  
+Plugins in Shopware are essentially an extension of [Symfony bundles](./plugins-for-symfony-developers.md). Such bundles and plugins can provide their own resources like assets, controllers, services or tests, which you'll learn in the next guides.  
 A plugin is the main way to extend your Shopware 6 instance programmatically.
 
 This guide will teach you the basics of creating your very first plugin from scratch, which then can be installed to your Shopware 6 instance. A guide to install Shopware 6 in the first place can be found [here](../../installation/overview.md).

--- a/guides/plugins/plugins/plugins-for-symfony-developers.md
+++ b/guides/plugins/plugins/plugins-for-symfony-developers.md
@@ -1,2 +1,77 @@
 # Plugins for Symfony developers
 
+## Overview
+
+This guide serves as an entry point for developers familiar with the concepts of `Symfony bundles`.
+
+## Prerequisites
+
+This guide handles some base concepts of Shopware plugins. 
+You may want to have a look at [plugin base guide](./plugin-base-guide.md) first.
+
+As this guide also references the functionality of Symfony bundles,
+you should have at least a basic knowledge of it.
+You may want to have a look or refresh your knowledge with help of Symfony's [bundle documentation](https://symfony.com/doc/current/bundles.html).
+
+## Symfony bundles
+
+A bundle is the Symfony's preferred way to provide additional third-party features to any Symfony application.
+Those bundles are everywhere: Symfony even outsources many of its core features into external bundles.
+The template engine `Twig`, the `Security` bundle, the `WebProfiler`, 
+as well as many other third-party bundles can be installed on demand to extend your Symfony application in any way.
+The Bundle System is Symfony's way of providing an extendable framework with plugin capabilities.
+
+## Shopware plugins
+
+Shopware is building upon the `Symfony Bundle System` to extend its functionality even more.
+This allows the `Shopware Plugin System` to function as a traditional plugin system
+with features like plugin lifecycles and more.
+
+Whenever you create a Shopware plugin, you have to extend the `Shopware\Core\Framework\Plugin` class.
+If you investigate this class, you will see that this class extends `Shopware\Core\Framework\Bundle`,
+which in return extends the Symfony's `Bundle` class:
+
+{% code %}
+```php
+class YourNamespace\PluginName extends
+
+    // plugin lifecycles
+    abstract class Shopware\Core\Framework\Plugin extends
+
+        // adds support for migrations, filesystem, events, themes
+        abstract class Shopware\Core\Framework\Bundle extends
+            
+            // Symfony base bundle
+            abstract class Symfony\Component\HttpKernel\Bundle
+```
+{% endcode %}
+
+As you can see, any Shopware plugin is also a Symfony bundle internally as well, and will be handled as such by Symfony.
+A plugin adds support for some cases, specific to the Shopware environment.
+These include, for example, handling plugin migrations and registering Shopware business events.
+
+### Plugin lifecycle
+
+As mentioned before, Shopware extends the `Symfony Bundle System` with some functionality to adjust its use for the Shopware ecosystem.
+For you as plugin developer, the most important addition is the extended plugin lifecycle.
+
+A Shopware plugin runs through a lifecycle.
+Your plugin's base class can implement the following methods to execute any sort of installation or maintenance tasks.  
+
+| Lifecycle         | Description                                   |
+| :---              | :---                                          |
+| `install()`       | Executed on plugin install                    |
+| `postInstall()`   | Executed **after** successful plugin install  |
+| `update`          | Executed on plugin update                     |
+| `postUpdate()`    | Executed **after** successful plugin update   |
+| `uninstall()`     | Executed on plugin uninstallation             |
+| `activate()`      | Executed **before** plugin activation         |
+| `deactivate()`    | Executed **before** plugin deactivation       |
+
+## Next steps
+
+Now that you know about the differences between a Symfony bundle and a Shopware plugin,
+you might also want to have a look into the following Symfony-specific topics and how they are integrated in Shopware 6:
+
+* [Dependency Injection](./plugin-fundamentals/dependency-injection.md)
+* [Listening to events](./plugin-fundamentals/listening-to-events.md)

--- a/guides/plugins/plugins/plugins-for-symfony-developers.md
+++ b/guides/plugins/plugins/plugins-for-symfony-developers.md
@@ -24,7 +24,7 @@ The Bundle System is Symfony's way of providing an extendable framework with plu
 ## Shopware plugins
 
 Shopware is building upon the `Symfony Bundle System` to extend its functionality even more.
-This allows the `Shopware Plugin System` to function as a traditional plugin system
+This allows the Shopware Plugin System to function as a traditional plugin system
 with features like plugin lifecycles and more.
 
 Whenever you create a Shopware plugin, you have to extend the `Shopware\Core\Framework\Plugin` class.

--- a/guides/plugins/plugins/plugins-for-symfony-developers.md
+++ b/guides/plugins/plugins/plugins-for-symfony-developers.md
@@ -7,7 +7,7 @@ This guide serves as an entry point for developers familiar with the concepts of
 ## Prerequisites
 
 This guide handles some base concepts of Shopware plugins. 
-You may want to have a look at [plugin base guide](./plugin-base-guide.md) first.
+Therefore, you may want to have a look at [plugin base guide](./plugin-base-guide.md) first.
 
 As this guide also references the functionality of Symfony bundles,
 you should have at least a basic knowledge of it.


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains Shopware plugins to Symfony developers.

Mostly this is about the differences between Shopware Plugins and a simple Symfony Bundle.

This article should mention:

The fact, that every Shopware plugin is basically a Symfony Bundle, but with extras
The differences
The Plugin lifecycle in short (Can be installed, activated, ...) and a reference to the plugin lifecycle concept / reference
It could also mention, that we also have "Shopware Bundles". So basically "Shopware Plugins vs Shopware Bundles vs Symfony Bundles"
Category: Extensions > Plugins > Plugins for Symfony Developers

Please check the code for differences or ask someone who knows.