### PR TITLE
NEXT-12793 - [MIGRATE] Administration: Modify dynamic product groups blacklist

### DIFF
--- a/guides/plugins/plugins/administration/modify-blacklist-for-dynamic-product-groups.md
+++ b/guides/plugins/plugins/administration/modify-blacklist-for-dynamic-product-groups.md
@@ -1,0 +1,83 @@
+# Modify dynamic product groups blacklist
+
+## Overview
+
+The module "Dynamic product groups" includes a condition builder to properly configure your dynamic product groups.
+You might have noticed though, that this condition builder does not show all available properties,
+since some of them are blacklisted in the code, such as e.g. `createdAt`.
+
+In this guide you'll get two quick examples on how to either add new properties to this blacklist or even remove
+properties from the blacklist, so they're actually shown in the administration and thus can be used.
+
+## Prerequisites
+
+This guide **will not** explain in detail how to override an existing component.
+For this guide you'll have to extend the component [sw-product-stream-field-select](https://github.com/shopware/platform/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-field-select/index.js) though, since it's the one [actually checking for the properties in the computed property options](https://github.com/shopware/platform/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-field-select/index.js#L41).
+
+An example on how to override a component can be found [here](./customizing-components.md).
+
+## Adding properties to blacklist
+
+As already mentioned in the prerequisites, the check for properties in the blacklist is done in the computed property `options`.
+Therefore you'll have to make sure your modifications are done **before** the check happens.
+
+{% code title="<plugin-root>/src/Resources/app/administration/app/src/component/sw-product-stream-field-select/index.js" %}
+```javascript
+const { Component } = Shopware;
+
+Component.override('sw-product-stream-field-select', {
+    computed: {
+        options() {
+            this.conditionDataProviderService.addToGeneralBlacklist(['deliveryTimeId']);
+            return this.$super('options');
+        }
+    }
+});
+```
+{% endcode %}
+
+This example will simply add the property `deliveryTimeId` to the blacklist, so it's not configurable using the Administration anymore.
+There are also nested properties, so called 'entity properties', which are selectable once you've chosen a property such as `Categories`.
+Those entity properties can also be added to the blacklist by using the method `addToEntityBlacklist` instead:
+
+{% code title="<plugin-root>/src/Resources/app/administration/app/src/component/sw-product-stream-field-select/index.js" %}
+```javascript
+const { Component } = Shopware;
+
+Component.override('sw-product-stream-field-select', {
+    computed: {
+        options() {
+            this.conditionDataProviderService.addToEntityBlacklist('category', ['breadcrumb']);
+            return this.$super('options');
+        }
+    }
+});
+```
+{% endcode %}
+
+This example would forbid the usage of `breadcrumb` from the `category` entity.
+
+## Removing properties from the blacklist
+
+Most likely you'd want to do the opposite and enable properties by removing entries from the blacklist.
+This can be done exactly like adding properties to the blacklist:
+* Remove a property from the "general blacklist", which is the first dropdown
+* Remove from the "entity blacklist" which contains the properties of the previously selected entity.
+
+{% code title="<plugin-root>/src/Resources/app/administration/app/src/component/sw-product-stream-field-select/index.js" %}
+```javascript
+const { Component } = Shopware;
+
+Component.override('sw-product-stream-field-select', {
+    computed: {
+        options() {
+            this.conditionDataProviderService.removeFromGeneralBlacklist(['createdAt']);
+            this.conditionDataProviderService.removeFromEntityBlacklist('category', ['path']);
+            return this.$super('options');
+        }
+    }
+});
+```
+{% endcode %}
+
+This example enables both the general `createdAt` property, as well as the category property `path`.


### PR DESCRIPTION
## What should be done?

Create a new article on our [GitBook instance|https://app.gitbook.com/@shopware/s/shopware/] which explains how to modify the dynamic product groups blacklist.
This can be migrated from our previous documentation.

This article should mention:
- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Administration

## Are there already guides in the previous documentation for this?
Yes! But please, don't just copy & paste. Make sure it still works and rewrite it to fit our new [writing guidelines|https://app.gitbook.com/@shopware/s/shopware/resources/guidelines/documentation/writing]!
https://github.com/shopware/platform/blob/master/src/Docs/Resources/current/50-how-to/770-modify-blacklist-dynamic-product-groups.md

For more information, ask me, [~p.stahl].