### PR TITLE
NEXT-12779 - Using custom assets administration guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -147,6 +147,7 @@
       * [Adding Mixins](guides/plugins/plugins/administration/add-mixins.md)
       * [Adding Services](guides/plugins/plugins/administration/add-custom-service.md)
       * [Adding permissions](guides/plugins/plugins/administration/add-acl-rules.md)
+      * [Using assets](guides/plugins/plugins/administration/using-assets.md)
       * [Add custom route](guides/plugins/plugins/administration/add-custom-route.md)
       * [Writing templates](guides/plugins/plugins/administration/writing-templates.md)
       * [Add custom module](guides/plugins/plugins/administration/add-custom-module.md)

--- a/guides/plugins/plugins/administration/add-custom-component.md
+++ b/guides/plugins/plugins/administration/add-custom-component.md
@@ -1,4 +1,4 @@
-# Add own component
+# Add own component 
 
 ## Overview
 

--- a/guides/plugins/plugins/administration/add-custom-field.md
+++ b/guides/plugins/plugins/administration/add-custom-field.md
@@ -1,4 +1,4 @@
-# Add custom input field to existing component
+# Add custom input field to existing component 
 
 ## Overview
 

--- a/guides/plugins/plugins/administration/add-custom-module.md
+++ b/guides/plugins/plugins/administration/add-custom-module.md
@@ -1,4 +1,4 @@
-# Add custom module
+# Add custom module 
 
 In the `Administration` core code, each module is defined in a directory called `module`. Inside the `module` directory lies the list of several modules, each having their own directory named after the module itself.
 

--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -1,4 +1,4 @@
-# Add menu entry
+# Add menu entry 
 
 ## Overview
 

--- a/guides/plugins/plugins/administration/using-assets.md
+++ b/guides/plugins/plugins/administration/using-assets.md
@@ -64,9 +64,9 @@ added your own asset to the administration.
 
 ## Next steps
 
-If you're already working with assets in your administration plugin, maybe you want to customise the administration 
+If you're already working with assets in your administration plugin, maybe you want to customize the administration 
 even more? Head over to the following guides to learn about even more customization possibilities:
 * [Add custom component](./add-custom-component.md)
-* [Customising components](./customizing-components.md)
-* [Customising modules](./customizing-modules.md)
+* [Customizing components](./customizing-components.md)
+* [Customizing modules](./customizing-modules.md)
 * [Add custom styles](./add-custom-styles.md)

--- a/guides/plugins/plugins/administration/using-assets.md
+++ b/guides/plugins/plugins/administration/using-assets.md
@@ -1,0 +1,72 @@
+# Using assets
+
+## Overview
+
+When working with an own plugin, the usage of own custom images or other assets is a natural requirement. 
+So of course you can do that in Shopware as well. In this guide we will explore how you can
+add custom assets in your plugin in order to use them in the administration.
+
+## Prerequisites
+
+In order to be able to start with this guide, you need to have an own plugin running. As to most guides, this guide
+is also built upon the Plugin base guide:
+
+{% page-ref page="../plugin-base-guide.md" %}
+
+Needless to say, you should have your image or another asset at hand to work with.
+
+## Add custom assets
+
+In order to add your own custom assets, you need to save your assets in the `Resources/app/administration/static` folder.
+```bash
+# PluginRoot
+.
+├── composer.json
+└── src
+    ├── Resources
+    │   ├── app
+    │       └── administration
+    │             └── static
+    │                   └── your-image.png <-- Asset file here
+    └── SwagBasicExample.php
+```
+
+Similar as in [using custom assets in Storefront](./../storefront/add-custom-assets.md), you need to execute the 
+following command:
+{% code %}
+```bash
+bin/console assets:install
+```
+{% endcode %}
+
+This way, your plugin assets are copied to the `public/bundles` folder:
+
+```bash
+# shopware-root/public/bundles
+.
+├── administration
+├── framework
+├── storefront
+└── swagbasicexample
+    └── your-image.png <-- Your asset is copied here
+```
+
+## Use custom assets in the administration
+
+After adding your assets to the `public/bundles` folder, you can start using your assets in the administration. 
+Basically, you just need to use the Vue [filter](https://vuejs.org/v2/guide/filters.html) `asset`.
+```html
+<img :src="'/<plugin root>/static/your-image.png' | asset">
+```
+
+You're able to use this line in your `twig`/`html` files as you please and that's basically it. You successfully 
+added your own asset to the administration.
+
+## Next steps
+
+If you're already working with assets in your administration plugin, maybe you want to customise the administration 
+even more? Head over to the following guides to learn about even more customization possibilities:
+* [Add custom component](./add-custom-component.md)
+* [Customising components](./customizing-components.md)
+* [Customising modules](./customizing-modules.md)
+* [Add custom styles](./add-custom-styles.md)

--- a/guides/plugins/plugins/content/cms/add-cms-element.md
+++ b/guides/plugins/plugins/content/cms/add-cms-element.md
@@ -1,4 +1,4 @@
-# Adding a custom CMS element
+# Adding a custom CMS element 
 
 ## Overview
 

--- a/guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md
@@ -1,4 +1,4 @@
-# Add custom CLI commands
+# Add custom CLI commands 
 
 To ease development tasks, Shopware contains the Symfony commands functionality. This allows \(plugin-\) developers to define new commands executable via the Symfony console at `bin/console`. The best thing about commands is, that they're more than just simple standalone PHP scripts - they integrate into Symfony and Shopware, so you've got access to all the functionality offered by both of them.
 

--- a/guides/plugins/plugins/storefront/remove-unnecessary-js-plugin.md
+++ b/guides/plugins/plugins/storefront/remove-unnecessary-js-plugin.md
@@ -1,4 +1,4 @@
-# Remove Javascript plugin
+# Remove Javascript plugin 
 
 ## Overview
 

--- a/guides/plugins/plugins/storefront/use-media-thumbnails.md
+++ b/guides/plugins/plugins/storefront/use-media-thumbnails.md
@@ -1,4 +1,4 @@
-# Working with media and thumbnails
+# Working with media and thumbnails 
 
 ## Overview
 

--- a/guides/plugins/plugins/testing/end-to-end-testing.md
+++ b/guides/plugins/plugins/testing/end-to-end-testing.md
@@ -1,4 +1,4 @@
-# End-to-end testing
+# End-to-end testing 
 
 ## Overview
 

--- a/guides/plugins/plugins/testing/jest-admin.md
+++ b/guides/plugins/plugins/testing/jest-admin.md
@@ -1,4 +1,4 @@
-# Jest unit tests in Shopware's administration
+# Jest unit tests in Shopware's administration 
 
 ## Overview
 

--- a/guides/plugins/plugins/testing/jest-storefront.md
+++ b/guides/plugins/plugins/testing/jest-storefront.md
@@ -1,4 +1,4 @@
-# Jest unit tests in Shopware's storefront
+# Jest unit tests in Shopware's storefront 
 
 ## Overview
 
@@ -28,7 +28,6 @@ template, as we will to use some scripts provided by it.
 
 For one example, we use a Javascript plugin. In oder to follow this example, you need to know how to build a Javascript
 plugin in the first place. You can learn about it in the corresponding [guide](./../storefront/add-custom-javascript.md).
-
 
 ## Test structure
 


### PR DESCRIPTION
Create a new article on our GitBook instance which explains how to use assets in the administration.

This article should mention:

* The prerequisite, a working plugin (Refer to the plugin base guide)
* Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
* A short code example, including an explanation, on how to do it
Category: Extensions > Plugins > Administration

Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.

---

The whitespaces in the second commit are used to update the broken articles, in hope the gitbook fix will be applied. 