### PR TITLE
NEXT-12722 - Using a modal window

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -203,6 +203,7 @@
       * [Add custom field in the storefront](guides/plugins/plugins/storefront/using-custom-fields-storefront.md)
       * [Add custom sorting for product listing](guides/plugins/plugins/storefront/add-custom-sorting-product-listing.md)
       * [Add SCSS variables](guides/plugins/plugins/storefront/add-scss-variables.md)
+      * [Using a modal window](guides/plugins/plugins/storefront/using-a-modal-window.md)
     * [Testing](guides/plugins/plugins/testing/README.md)
       * [End-to-end testing](guides/plugins/plugins/testing/end-to-end-testing.md)
       * [Jest unit tests in Shopware's administration](guides/plugins/plugins/testing/jest-admin.md)

--- a/guides/plugins/plugins/storefront/using-a-modal-window.md
+++ b/guides/plugins/plugins/storefront/using-a-modal-window.md
@@ -1,0 +1,368 @@
+# Using a modal window
+
+## Overview
+
+This guide explains how you can use a modal window in your plugin in different szenarios.
+
+## Prerequisites
+
+This guide requires you to already have a basic plugin running. This guide **does not** explain how to create a new plugin for Shopware 6. Head over to our Plugin base guide to learn how to create a plugin at first:
+
+{% page-ref page="./../plugin-base-guide.md" %}
+
+While this is not mandatory, having read the guide about adding custom JavaScript plugins beforehand might help you understand this guide a bit further:
+
+{% page-ref page="./add-custom-javascript.md" %}
+
+
+## Create a modal manually from the DOM using Boostrap
+
+The simples solution to create a modal is by using Boostrap. More info: [Modal Boostrap](https://getbootstrap.com/docs/4.0/components/modal/#live-demo)
+Here is a basic implementation as an example. We override the `base_main_inner` from the `@Storefront/storefront/page/content/index.html.twig` template to insert the modal specific DOM elements.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```text
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+    <!-- Button trigger modal -->
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
+        Launch demo modal
+    </button>
+
+    <!-- Modal -->
+    <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <!-- insert your content here -->
+                    ...
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary">Save changes</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+## Create a modal using AJAX Modal Utility
+
+When setting a `data-url` in addition to `data-toggle="modal"` shopware automatically uses the `PseudoModalUtil` and the pseudo modal template from the `base.html.twig` to render a modal:
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```text
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+    <!-- This uses `AjaxModalExtensionUtil` -->
+    <button class="btn"
+            data-toggle="modal"
+            data-url="https://example.org/ajax-url">
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+{% hint style="warning" %}
+This does not work when the trigger selector is being changed via JavaScript, e.g. because of an AJAX call which replaces the content.
+{% endhint %}
+
+## Advanced / manual using Pseudo Modal Utility
+
+To create a modal window you can use the `PseudoModalUtil` in your plugin.
+
+As explained in the guide on [adding custom javascript](./add-custom-javascript.md) we load our JavaScript plugin by creating `index.html.twig` template in the `<plugin root>/src/Resources/views/storefront/page/content/` folder.
+Inside this template, extend from the `@Storefront/storefront/page/content/index.html.twig` and overwrite the `base_main_inner` block. After the parent content of the blog, add a template tag with the `data-example-plugin` attribute.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```text
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+    {{ parent() }}
+
+    <template data-example-plugin></template>
+{% endblock %}
+```
+{% endcode %}
+
+Now we need to register the plugin which should create a modal in the `PluginManager`. To achieve this you can add the following code to the `main.js` file.
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/main.js" %}
+```javascript
+ // Import all necessary Storefront plugins
+ import ExamplePlugin from './example-plugin/example-plugin.plugin';
+
+ // Register your plugin via the existing PluginManager
+ const PluginManager = window.PluginManager;
+ PluginManager.register('ExamplePlugin', ExamplePlugin, '[data-example-plugin]');
+```
+{% endcode %}
+
+Now let's get started with the modal window. First we have to import the `PseudoModalUtil` class in our plugin.
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+export default class ExamplePlugin extends Plugin {
+    init() {
+        // ...
+    }
+}
+```
+{% endcode %}
+
+Now we create a new modal instance using `new PseudoModalUtil()` and assign to a property of our plugin for later usage.
+We also call the method `open()` to make it visible. 
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+export default class ExamplePlugin extends Plugin {
+    init() {
+        this.openModal();
+    }
+    
+    openModal() {
+        // create a new modal instance
+        this.modal = new PseudoModalUtil();
+        
+        // open the modal window and make it visible
+        this.modal.open();
+    }
+}
+```
+{% endcode %}
+
+To see your changes you have to build the storefront. Use the following command to build your storefront and reload it afterwards:
+
+{% tabs %}
+{% tab title="Development template" %}
+```bash
+./psh.phar storefront:build
+```
+{% endtab %}
+{% tab title="Production template" %}
+```bash
+./bin/build-storefront.sh
+```
+{% endtab %}
+{% endtabs %}
+
+You can now see a blank modal which contains `undefined`. This is because we have not added any content to show inside the modal.
+
+The constructor method of `PseudoModalUtil()` expects some HTML `content` to display. To keep this guide simple, we are only including sample code here.
+Of course, the content can also be generated via an API and inserted via AJAX requests.
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+export default class ExamplePlugin extends Plugin {
+    init() {
+        // declaring some basic content
+        const content = `
+            <div class="js-pseudo-modal-template">
+                <div class="js-pseudo-modal-template-title-element">Modal title</div>
+                <div class="js-pseudo-modal-template-content-element">Modal content</div>
+            </div>
+        `;
+        
+        this.openModal(content);
+    }
+    
+    openModal(content) {
+        // create a new modal instance
+        this.modal = new PseudoModalUtil(content);
+        
+        // open the modal window and make it visible
+        this.modal.open();
+    }
+}
+```
+{% endcode %}
+
+## Closing the modal
+
+The `PseudoModalUtil` class also provide a `close()` method. Same as with opening the modal by calling `this.modal.open()`, you can simply close the modal with `this.modal.close()`.
+
+## Callback when opening a modal
+
+The `open()` method of the `PseudoModalUtil` class supports a callback function as an argument. So if you need to perform some action when your modal opens, you can implement a callback like this:
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+export default class ExamplePlugin extends Plugin {
+    init() {
+        // declaring some basic content
+        const content = `
+            <div class="js-pseudo-modal-template">
+                <div class="js-pseudo-modal-template-title-element">Modal title</div>
+                <div class="js-pseudo-modal-template-content-element">Modal content</div>
+            </div>
+        `;
+        
+        this.openModal(content);
+    }
+    
+    openModal(content) {
+        // create a new modal instance
+        this.modal = new PseudoModalUtil(content);
+        
+        // open the modal window and fire a callback function
+        this.modal.open(this.onOpenModal.bind(this));
+    }
+    
+    onOpenModal() {
+        console.log('the modal is opened');
+    }
+}
+```
+{% endcode %}
+
+## Updating the modal content
+
+To update the content of a modal, `PseudoModalUtil` provides a method `updateContent()` to which you can pass the updated template string. The method also accepts a callback function as a second argument, which is called after the content has been updated.
+Here is an example how to use it:
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+export default class ExamplePlugin extends Plugin {
+    init() {
+        // declaring some basic content
+        const content = `
+            <div class="js-pseudo-modal-template">
+                <div class="js-pseudo-modal-template-title-element">Modal title</div>
+                <div class="js-pseudo-modal-template-content-element">Modal content</div>
+            </div>
+        `;
+        
+        this.openModal(content);
+        
+        // ... do some stuff
+
+        const updatedContent = `
+            <div class="js-pseudo-modal-template">
+                <div class="js-pseudo-modal-template-title-element">Modal title</div>
+                <div class="js-pseudo-modal-template-content-element">Updated content</div>
+            </div>
+        `;
+        
+        this.modal.updateModal(updatedContent, this.onUpdateModal.bind(this));
+    }
+    
+    openModal(content) {
+        // create a new modal instance
+        this.modal = new PseudoModalUtil(content);
+        
+        // open the modal window and fire a callback function
+        this.modal.open(this.onOpenModal.bind(this));
+    }
+    
+    onOpenModal() {
+        console.log('the modal is opened');
+    }
+
+    onUpdateModal() {
+        console.log('the modal was updated');
+    }
+    
+}
+```
+{% endcode %}
+
+## Customize the modal appearance
+
+The constructor method of `PseudoModalUtil` provides optional configuration. If you don't need backdrop of the modal for example just turn it off by instantiating the modal like this
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+import Plugin from 'src/plugin-system/plugin.class';
+import PseudoModalUtil from 'src/utility/modal-extension/pseudo-modal.util';
+
+export default class ExamplePlugin extends Plugin {
+    init() {
+        // declaring some basic content
+        const content = `
+            <div class="js-pseudo-modal-template">
+                <div class="js-pseudo-modal-template-title-element">Modal title</div>
+                <div class="js-pseudo-modal-template-content-element">Modal content</div>
+            </div>
+        `;
+        
+        this.openModal(content);
+    }
+    
+    openModal(content) {
+        // disable backdrop
+        const useBackrop = false;
+        
+        // create a new modal instance
+        this.modal = new PseudoModalUtil(content, useBackrop);
+        
+        // open the modal window and make it visible
+        this.modal.open();
+    }
+}
+```
+{% endcode %}
+
+As you can see in the sample code, we are using the `js-pseudo-modal-template-title-element` class to style the title text of the modal.
+It also tells the `PseudoModalUtil` class that the content of the `div` holds the title text.
+Furthermore there are two more css selectors `js-pseudo-modal-template` and `js-pseudo-modal-template-content-element` to define the structure of the template string.
+
+If want to customize your modal by using different style classes, you can do that by overriding the defaults while instantiating `PseudoModalUtil`.
+
+Here is an example which shows how to override the CSS class names.
+
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
+```javascript
+// ...
+export default class ExamplePlugin extends Plugin {
+    init() {
+        // ...
+    }
+
+    openModal(content) {
+        // enable backdrop
+        const useBackrop = true;
+
+        // create a new modal instance
+        this.modal = new PseudoModalUtil(
+            content,
+            useBackrop,
+            'custom-js-pseudo-modal-template',
+            'custom-js-pseudo-modal-template-content-element',
+            'custom-js-pseudo-modal-template-title-element'
+        );
+
+        // open the modal window and make it visible
+        this.modal.open();
+    }
+}
+```
+{% endcode %}


### PR DESCRIPTION
**What should be done?**
Create a new article on our GitBook instance which explains how to use a modal window in both types: Static modal and AJAX modal.
This article should mention:
The prerequisite, a working plugin (Refer to the plugin base guide)
Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
A short code example, including an explanation, on how to do it
An example each for static and ajax modal windows
Category: Extensions > Plugins > Storefront
