### PR TITLE
NEXT-12794 - [NEW] Administration: Extend webpack configuration

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -166,6 +166,7 @@
       * [Using base components](guides/plugins/plugins/administration/using-base-components.md)
       * [Add custom styles](guides/plugins/plugins/administration/add-custom-styles.md)
       * [Using the data grid component](guides/plugins/plugins/administration/using-the-data-grid-component.md)
+      * [Extending Webpack](guides/plugins/plugins/administration/extending-webpack.md)
       * [Using Utility functions](guides/plugins/plugins/administration/using-utils.md)
       * [The Shopware object](guides/plugins/plugins/administration/the-shopware-object.md)
       * [Add filter](guides/plugins/plugins/administration/add-filter.md)

--- a/guides/plugins/plugins/administration/extending-webpack.md
+++ b/guides/plugins/plugins/administration/extending-webpack.md
@@ -9,11 +9,11 @@ this guide will show you how it's done.
 
 ## Extending the Webpack configuration
 
-The Webpack configuration can be extended by creating the file `<plugin root>src/Resources/app/administration/build/webpack.config.js`
-and exporting a function from it, that returns an [webpack configuration object](https://webpack.js.org/configuration/). 
-As seen below:
+The Webpack configuration can be extended by creating the file `<plugin root>/src/Resources/app/administration/build/webpack.config.js`
+and exporting a function from it. This will return a [webpack configuration object](https://webpack.js.org/configuration/),
+as seen below:
 
-{% code title="<plugin root>src/Resources/app/administration/build/webpack.config.js" %}
+{% code title="<plugin root>/src/Resources/app/administration/build/webpack.config.js" %}
 ```javascript
 const path = require('path');
 
@@ -29,6 +29,9 @@ module.exports = () => {
 ```
 {% endcode %}
 
-The configuration is then automatically loaded and then merged with the Shopware provided webpack configuration and all other plugin webpack configurations.
+This way, the configuration is automatically loaded and then merged with the Shopware provided webpack configuration, including all other plugin webpack configurations.
 Merging is done with the [webpackMerge](https://github.com/survivejs/webpack-merge) library.
+
+{% hint style="danger" %}
 This merging makes it technically possible to override the Shopware provided configuration, although it is generally advised against.
+{% endhint %}

--- a/guides/plugins/plugins/administration/extending-webpack.md
+++ b/guides/plugins/plugins/administration/extending-webpack.md
@@ -32,6 +32,6 @@ Merging is done with the [webpackMerge](https://github.com/survivejs/webpack-mer
 
 {% hint style="danger" %}
 This merging makes it technically possible to override the Shopware provided configuration, 
-but you shouldn't change the default configurations output,
+but you shouldn't change the default configurations so that the builded core code will differ from the original builded code without your configuration,
 because this could break the administration, your plugin or other third-party plugins.
 {% endhint %}

--- a/guides/plugins/plugins/administration/extending-webpack.md
+++ b/guides/plugins/plugins/administration/extending-webpack.md
@@ -1,0 +1,34 @@
+# Extending Webpack
+
+## Overview
+
+The Shopware 6 Administration uses [Webpack](https://webpack.js.org/) as a static module bundler.
+The default configuration should work for most plugins, 
+but if you really need to extend the webpack configuration,
+this guide will show you how it's done.
+
+## Extending the Webpack configuration
+
+The Webpack configuration can be extended by creating the file `<plugin root>src/Resources/app/administration/build/webpack.config.js`
+and exporting a function from it, that returns an [webpack configuration object](https://webpack.js.org/configuration/). 
+As seen below:
+
+{% code title="<plugin root>src/Resources/app/administration/build/webpack.config.js" %}
+```javascript
+const path = require('path');
+
+module.exports = () => {
+    return {
+        resolve: {
+            alias: {
+                SwagBasicExample: path.join(__dirname, '..', 'src')
+            }
+        }
+    };
+};
+```
+{% endcode %}
+
+The configuration is then automatically loaded and then merged with the Shopware provided webpack configuration and all other plugin webpack configurations.
+Merging is done with the [webpackMerge](https://github.com/survivejs/webpack-merge) library.
+This merging makes it technically possible to override the Shopware provided configuration, although it is generally advised against.

--- a/guides/plugins/plugins/administration/extending-webpack.md
+++ b/guides/plugins/plugins/administration/extending-webpack.md
@@ -3,9 +3,7 @@
 ## Overview
 
 The Shopware 6 Administration uses [Webpack](https://webpack.js.org/) as a static module bundler.
-The default configuration should work for most plugins, 
-but if you really need to extend the webpack configuration,
-this guide will show you how it's done.
+Normally you don't need to change the Webpack configuration, but if you need to here is how to do it.
 
 ## Extending the Webpack configuration
 
@@ -33,5 +31,7 @@ This way, the configuration is automatically loaded and then merged with the Sho
 Merging is done with the [webpackMerge](https://github.com/survivejs/webpack-merge) library.
 
 {% hint style="danger" %}
-This merging makes it technically possible to override the Shopware provided configuration, although it is generally advised against.
+This merging makes it technically possible to override the Shopware provided configuration, 
+but you shouldn't change the default configurations output,
+because this could break the administration, your plugin or other third-party plugins.
 {% endhint %}


### PR DESCRIPTION
## What should be done?

Create a new article on our [GitBook instance|https://app.gitbook.com/@shopware/s/shopware/] which explains how to extend the webpack configuration.

This article should mention:
- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it
- Might want to talk to Jannis Leifeld about this

Category: Extensions > Plugins > Administration

## Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our [example guide|https://app.gitbook.com/@shopware/s/shopware/guides/plugins/plugins/plugin-base-guide](e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the [Writing guidelines|https://app.gitbook.com/@shopware/s/shopware/resources/guidelines/documentation/writing].

For more information, ask me, [~p.stahl].