### PR TITLE
NEXT-12789 - Administration: Handling media

### DIFF
--- a/guides/plugins/plugins/administration/handling-media.md
+++ b/guides/plugins/plugins/administration/handling-media.md
@@ -17,12 +17,12 @@ This is done through the `sw-media-upload-v2` component as seen below:
         :allowMultiSelect="false"
         variant="regular"
         :autoUpload="true"
-		label="My image-upload">
+        label="My image-upload">
     </sw-media-upload-v2>
 </div>
 ```
 
-As you saw in the code sample, the `sw-media-upload-v2` is pretty configurable trough props.
+As you can see in the code sample below, the `sw-media-upload-v2` is pretty configurable through properties.
 To get an overview of all the options, here is a list:   
 
 | Property           | Function                                                                                                                        |
@@ -40,7 +40,7 @@ To get an overview of all the options, here is a list:
 
 ## Keeping track of uploads
 
-The `sw-upload-listener` component, can as seen below, be used in conjunction with an `sw-media-upload-v2` component.
+As seen below, the `sw-upload-listener` component can be used in conjunction with an `sw-media-upload-v2` component.
 
 ```html
 <div>
@@ -48,7 +48,7 @@ The `sw-upload-listener` component, can as seen below, be used in conjunction wi
         uploadTag="my-upload-tag"
         :allowMultiSelect="false"
         variant="regular"
-		label="My image-upload">
+        label="My image-upload">
     </sw-media-upload-v2>
     <sw-upload-listener
         @media-upload-finish="onUploadFinish" 
@@ -64,7 +64,7 @@ Beyond the `media-upload-finish` event there are a few more events:
 |-----------------------|----------------------------------------------------|
 | `media-upload-add`    | This event is triggered when an upload is added    |
 | `media-upload-finish` | This event is triggered when an upload finishes    |
-| `media-upload-fail`   | This is triggered on an upload failing             |
+| `media-upload-fail`   | This event is triggered on an upload failing       |
 | `media-upload-cancel` | This event is triggered when an upload is canceled |
 
 
@@ -78,13 +78,13 @@ Media can be previewed with the `sw-media-preview-v2` component as seen below:
 </sw-media-preview-v2>
 ```
 
-As previously mention this component is already embedded within the `sw-media-upload-v2`.
-But using it as a separate component you get access to the following configuration options:
+As previously mentioned this component is already embedded within the `sw-media-upload-v2`.
+However, using it as a separate component you get access to the following configuration options:
 
 | Property         | Function                                                                            |
 |------------------|-------------------------------------------------------------------------------------|
 | `source`         | The `id` or alternately the path to the media to be previewed                       |
 | `showControls`   | Controls whether media such as videos or audio shows controls                       |
 | `autoplay`       | Controls whether media such as videos or audio autoplays                            |
-| `hideTooltip`    | Hides the tooltip witch the filename of the media in at the bottom of the component |
+| `hideTooltip`    | Hides the the filename tooltip of the media in at the bottom of the component       |
 | `mediaIsPrivate` | If set to true displays various lock symbols                                        |

--- a/guides/plugins/plugins/administration/handling-media.md
+++ b/guides/plugins/plugins/administration/handling-media.md
@@ -1,5 +1,10 @@
 # Handling media
 
+## Overview
+
+The Shopware 6 Administration provides many components to work with media.
+This guide will show you how to use the most important of them.
+
 ## The media upload component
 
 The Shopware 6 Administration media upload component makes it relatively easy to upload media of various kinds such as images, videos and audio files.

--- a/guides/plugins/plugins/administration/handling-media.md
+++ b/guides/plugins/plugins/administration/handling-media.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Shopware 6 Administration provides many components to work with media.
+The Shopware 6 Administration provides many components to work with, when it comes to handle media. For example, imagine you want to provide an opportunity to upload files.
 This guide will show you how to use the most important of them.
 
 ## The media upload component

--- a/guides/plugins/plugins/administration/handling-media.md
+++ b/guides/plugins/plugins/administration/handling-media.md
@@ -1,0 +1,85 @@
+# Handling media
+
+## The media upload component
+
+The Shopware 6 Administration media upload component makes it relatively easy to upload media of various kinds such as images, videos and audio files.
+This is done through the `sw-media-upload-v2` component as seen below:
+
+```html
+<div>
+    <sw-media-upload-v2
+        uploadTag="my-upload-tag"
+        :allowMultiSelect="false"
+        variant="regular"
+        :autoUpload="true"
+		label="My image-upload">
+    </sw-media-upload-v2>
+</div>
+```
+
+As you saw in the code sample, the `sw-media-upload-v2` is pretty configurable trough props.
+To get an overview of all the options, here is a list:   
+
+| Property           | Function                                                                                                                        |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `source`           | The source that will be used for the internal `sw-media-preview-v2` if the component is not used in the `allowMultiSelect` mode |
+| `variant`          | This can be used to choose between the `regular` and the `compact` variants                                                     |
+| `uploadTag`        | This is used to coordinate with the `sw-upload-listener` component                                                              |
+| `allowMultiSelect` | Sets whether multiple files can be uploaded at once                                                                             |
+| `label`            | The text that is displayed in the header                                                                                        |
+| `defaultFolder`    | The path where the file will be put                                                                                             |
+| `targetFolderId`   | The `targetFolderId` that will be used as a backup to the `defaultFolder`                                                       |
+| `helpText`         | Sets the `helpText` displayed in the header of the component                                                                    |
+| `fileAccept`       | Sets what the underlying <input>, accepts standard is `image/*`                                                                 |
+| `disabled`         | Disables the whole component                                                                                                    |
+
+## Keeping track of uploads
+
+The `sw-upload-listener` component, can as seen below, be used in conjunction with an `sw-media-upload-v2` component.
+
+```html
+<div>
+    <sw-media-upload-v2
+        uploadTag="my-upload-tag"
+        :allowMultiSelect="false"
+        variant="regular"
+		label="My image-upload">
+    </sw-media-upload-v2>
+    <sw-upload-listener
+        @media-upload-finish="onUploadFinish" 
+        uploadTag="my-upload-tag">
+    </sw-upload-listener>
+</div>
+```
+
+Notice that the `uploadTag` needs to be the same in the `sw-media-upload-v2` and the `sw-upload-listener` for them to communicate properly.
+Beyond the `media-upload-finish` event there are a few more events:
+
+| Event                 | Description                                        |
+|-----------------------|----------------------------------------------------|
+| `media-upload-add`    | This event is triggered when an upload is added    |
+| `media-upload-finish` | This event is triggered when an upload finishes    |
+| `media-upload-fail`   | This is triggered on an upload failing             |
+| `media-upload-cancel` | This event is triggered when an upload is canceled |
+
+
+## Previewing Media
+
+Media can be previewed with the `sw-media-preview-v2` component as seen below:
+
+```html
+<sw-media-preview-v2
+    :source="some-id">
+</sw-media-preview-v2>
+```
+
+As previously mention this component is already embedded within the `sw-media-upload-v2`.
+But using it as a separate component you get access to the following configuration options:
+
+| Property         | Function                                                                            |
+|------------------|-------------------------------------------------------------------------------------|
+| `source`         | The `id` or alternately the path to the media to be previewed                       |
+| `showControls`   | Controls whether media such as videos or audio shows controls                       |
+| `autoplay`       | Controls whether media such as videos or audio autoplays                            |
+| `hideTooltip`    | Hides the tooltip witch the filename of the media in at the bottom of the component |
+| `mediaIsPrivate` | If set to true displays various lock symbols                                        |


### PR DESCRIPTION
## What should be done?

Create a new article on our [GitBook instance|https://app.gitbook.com/@shopware/s/shopware/] which explains how to handle medias in the administration.

This article should mention:
- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it
- For example: How to load (and show) a media, how to implement a media picker or smth like this

Category: Extensions > Plugins > Administration

## Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our [example guide|https://app.gitbook.com/@shopware/s/shopware/guides/plugins/plugins/plugin-base-guide](e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the [Writing guidelines|https://app.gitbook.com/@shopware/s/shopware/resources/guidelines/documentation/writing].

For more information, ask me, [~p.stahl].