### PR TITLE
NEXT-12786 - [NEW] Administration: Add error-handling

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -159,6 +159,7 @@
       * [Adding Services](guides/plugins/plugins/administration/add-custom-service.md)
       * [Adding permissions](guides/plugins/plugins/administration/add-acl-rules.md)
       * [Using the data handling](guides/plugins/plugins/administration/using-data-handling.md)
+      * [Adding error handling](./guides/plugins/plugins/administration/add-error-handling.md)
       * [Customize modules](guides/plugins/plugins/administration/customizing-modules.md)
       * [Override existing routes](guides/plugins/plugins/administration/overriding-routes.md)
       * [Add tab to existing module](guides/plugins/plugins/administration/add-new-tab.md)

--- a/guides/plugins/plugins/administration/add-error-handling.md
+++ b/guides/plugins/plugins/administration/add-error-handling.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The Shopware 6 Administration stores API errors in the [Vuex store](https://vuex.vuejs.org/).
-Where they are centrally accessible to your components, with a flat data structure wich looks like this:
+There they are centrally accessible to your components, with a flat data structure looking like this:
 
 ```
 (state)
@@ -96,7 +96,7 @@ Component.register('sw-product-basic-form', {
 Which then are bound to the inputs like this:
 
 ```html
-<sw-field type="text" v-model="product.name" :error="productNameError"
+<sw-field type="text" v-model="product.name" :error="productNameError">
 ``` 
 ​
 ### Error configuration for pages

--- a/guides/plugins/plugins/administration/add-error-handling.md
+++ b/guides/plugins/plugins/administration/add-error-handling.md
@@ -94,7 +94,7 @@ Component.register('sw-product-basic-form', {
 })
 ```
 
-Wich then are bound to the inputs like this:
+Which then are bound to the inputs like this:
 
 ```html
 <sw-field type="text" v-model="product.name" :error="productNameError"

--- a/guides/plugins/plugins/administration/add-error-handling.md
+++ b/guides/plugins/plugins/administration/add-error-handling.md
@@ -1,0 +1,105 @@
+[titleEn]: <>(Api error handling in administration)
+​
+We reorganized the way we store errors that are received from the api. 
+ 
+We figured out that the binding between an api error and its input field's `v-model` expression is not practicable due to naming conflicts in collections.
+In addition, not every input field is bound to entity data or can/should receive an api error.
+That's why we removed the `error-pointer` property and the `resetFormError` method from fields and replaced it with an `error` property.
+​
+We also decoupled nested association errors to have a flatter store which looks like:
+```
+(state)
+ |- entityNameA
+    |- id1
+        |- property1
+        |- property2
+        ...
+    |- id2
+        |- property1
+        |- property2
+        ...
+ |- entityNameB
+   ...         
+```
+​
+### Read errors from the store
+​
+Errors can be read from the store by calling the getter method `getApiErrorFromPath`.
+​
+```
+function getApiErrorFromPath (state) => (entityName, id, path)
+```
+​
+Where path is an array representing the nested property names of your entity.
+Also we provide a wrapper which can also handle nested fields in object notation 
+​
+```
+function getApiError(state) => (entity, field)
+```
+​
+which is much easier to use for scalar fields.
+In your Vue component, use computed properties to not flood your templates with store calls.
+​
+````
+<script>
+    computed: {
+        propertyError() {
+            return this.$store.getters.getApiError(myEntity, 'myFieldName');
+        }
+        nestedpropertyError() {
+            return this.$store.getters.getApiError(myEntity, 'myFieldName.nested');
+        }
+    }
+</script>
+​
+<template>
+    <sw-field ... :error="propertyError"></sw-field>
+</template>
+````
+​
+### mapErrors Service
+​
+Like every Vuex mapping, fetching the errors from the store may be very repetitive and error-prone.
+Because of this we provide you an Vuex like mapper function
+​
+​
+```
+mapApiErrors(subject, properties)
+```
+​
+where subject is the variable name (not the entity itself) and properties is an array of properties you want to map.
+You can spread its result to create computed properties in your component.
+The functions returned by the mapper are named like a camelcase representation of your input suffixed with `Error`.  
+This is an example from the `sw-product-basic-form` component:
+​
+```
+<script>
+    import { mapApiErrors } from 'src/app/service/map-errors.service';
+    
+    Component.register('sw-product-basic-form', {
+        
+        computed: {
+            ...mapApiErrors('product', ['name', 'active', 'description', 'productNumber', 'manufacturerId', 'tags']),
+        }
+</sript>
+​
+<template>
+    <sw-field type="text" v-model="product.name" :error="productNameError"
+</template>
+​
+``` 
+​
+### Error configuration for pages
+​
+When working with nested views you need a way to tell the user that an error occurred on another view, e.g tab.
+For this you can write a config for your `sw-page` component which (currently) looks like: 
+​
+```
+{
+    "nested.route.name": {
+        "entityVariable": [ prop1, prop2 ...]
+    }
+}
+```
+​
+We provide the `mapPageErrors(errorConfig)` mapper function to create computed properties from it.

--- a/guides/plugins/plugins/administration/add-error-handling.md
+++ b/guides/plugins/plugins/administration/add-error-handling.md
@@ -1,12 +1,10 @@
-[titleEn]: <>(Api error handling in administration)
+# API error handling in administration)
 ​
-We reorganized the way we store errors that are received from the api. 
- 
-We figured out that the binding between an api error and its input field's `v-model` expression is not practicable due to naming conflicts in collections.
-In addition, not every input field is bound to entity data or can/should receive an api error.
-That's why we removed the `error-pointer` property and the `resetFormError` method from fields and replaced it with an `error` property.
-​
-We also decoupled nested association errors to have a flatter store which looks like:
+## Overview
+
+The Shopware 6 Administration stores API errors in the [Vuex](https://vuex.vuejs.org/).
+Where they are centrally accessible to your components, with a flat data structure wich looks like this:
+
 ```
 (state)
  |- entityNameA
@@ -22,84 +20,130 @@ We also decoupled nested association errors to have a flatter store which looks 
    ...         
 ```
 ​
-### Read errors from the store
+## Read errors from the store
 ​
 Errors can be read from the store by calling the getter method `getApiErrorFromPath`.
 ​
-```
+```javascript
 function getApiErrorFromPath (state) => (entityName, id, path)
 ```
 ​
-Where path is an array representing the nested property names of your entity.
-Also we provide a wrapper which can also handle nested fields in object notation 
+Where path is an `array` representing the nested property names of your entity.
+
+Also we provide a wrapper which can also handle nested fields in object notation, which is much easier to use for scalar fields:
 ​
-```
+```javascript
 function getApiError(state) => (entity, field)
 ```
 ​
-which is much easier to use for scalar fields.
+For example an empty product name would result in an error with the path `product.name`, instead of having the array `['product', 'name']`.
+
 In your Vue component, use computed properties to not flood your templates with store calls.
 ​
-````
-<script>
-    computed: {
-        propertyError() {
-            return this.$store.getters.getApiError(myEntity, 'myFieldName');
-        }
-        nestedpropertyError() {
-            return this.$store.getters.getApiError(myEntity, 'myFieldName.nested');
-        }
+```javascript
+computed: {
+    propertyError() {
+        return this.$store.getters.getApiError(myEntity, 'myFieldName');
+    },
+    nestedpropertyError() {
+        return this.$store.getters.getApiError(myEntity, 'myFieldName.nested');
     }
-</script>
-​
-<template>
+}
+```
+
+Those computed properties can then be normally used in your templates:
+
+```html
+<div>
     <sw-field ... :error="propertyError"></sw-field>
-</template>
-````
+</div>
+```
 ​
-### mapErrors Service
+### The mapErrors Service
 ​
 Like every Vuex mapping, fetching the errors from the store may be very repetitive and error-prone.
-Because of this we provide you an Vuex like mapper function
+Because of this we provide you an Vuex like mapper function:
 ​
 ​
+```javascript
+mapPropertyErrors(subject, properties)
 ```
-mapApiErrors(subject, properties)
-```
 ​
-where subject is the variable name (not the entity itself) and properties is an array of properties you want to map.
+where subject is the entity name (not the entity itself) and properties is an array of properties you want to map.
 You can spread its result to create computed properties in your component.
-The functions returned by the mapper are named like a camelcase representation of your input suffixed with `Error`.  
+The functions returned by the mapper are named like a camelCase representation of your input suffixed with `Error`.
+
 This is an example from the `sw-product-basic-form` component:
 ​
-```
-<script>
-    import { mapApiErrors } from 'src/app/service/map-errors.service';
+```javascript
+const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
     
+Component.register('sw-product-basic-form', {    
     Component.register('sw-product-basic-form', {
-        
-        computed: {
-            ...mapApiErrors('product', ['name', 'active', 'description', 'productNumber', 'manufacturerId', 'tags']),
-        }
-</sript>
-​
-<template>
-    <sw-field type="text" v-model="product.name" :error="productNameError"
-</template>
-​
+Component.register('sw-product-basic-form', {    
+    computed: {
+        ...mapPropertyErrors('product', [
+            'name',
+            'description',
+            'productNumber',
+            'manufacturerId',
+            'active',
+            'markAsTopseller'
+        ])
+    }
+})
+```
+
+Wich then are bound to the inputs like this:
+
+```html
+<sw-field type="text" v-model="product.name" :error="productNameError"
 ``` 
 ​
 ### Error configuration for pages
 ​
 When working with nested views you need a way to tell the user that an error occurred on another view, e.g tab.
-For this you can write a config for your `sw-page` component which (currently) looks like: 
+For this you can write a config for your `sw-page` component which looks like: 
 ​
 ```
 {
-    "nested.route.name": {
-        "entityVariable": [ prop1, prop2 ...]
-    }
+  "sw.product.detail.base": {
+    "product": [
+      "taxId",
+      "price",
+      "stock",
+      "manufacturerId",
+      "name"
+    ]
+  },
+  "sw.product.detail.cross.selling": {
+    "product_cross_selling": [
+      "name",
+      "type",
+      "position"
+    ]
+  }
 }
 ```
 ​
-We provide the `mapPageErrors(errorConfig)` mapper function to create computed properties from it.
+This can then directly imported and used in the `mapPageError` computed property:
+
+```javascript
+import errorConfiguration from './error.cfg.json';
+
+const { mapPageErrors } = Shopware.Component.getComponentHelper();
+
+Shopware.Component.register('sw-product-detail', {
+    computed: {
+        ...mapPageErrors(errorConfiguration),
+    }
+}
+```
+
+Wich then makes it possible to indicate if one or more errors exists, in another view or a tab:
+
+```html
+<sw-tabs
+    :hasError="swProductDetailBaseError">
+</sw-tabs>
+```

--- a/guides/plugins/plugins/administration/add-error-handling.md
+++ b/guides/plugins/plugins/administration/add-error-handling.md
@@ -1,4 +1,4 @@
-# API error handling in administration)
+# API error handling in administration
 ​
 ## Overview
 
@@ -28,17 +28,17 @@ Errors can be read from the store by calling the getter method `getApiErrorFromP
 function getApiErrorFromPath (state) => (entityName, id, path)
 ```
 ​
-Where path is an `array` representing the nested property names of your entity.
+In there, the parameter `path` is an `array` representing the nested property names of your entity.
 
-Also we provide a wrapper which can also handle nested fields in object notation, which is much easier to use for scalar fields:
+Also we provide a wrapper which can also handle nested fields in object notation, being much easier to use for scalar fields:
 ​
 ```javascript
 function getApiError(state) => (entity, field)
 ```
 ​
-For example an empty product name would result in an error with the path `product.name`, instead of having the array `['product', 'name']`.
+For example, an empty product name would result in an error with the path `product.name`, instead of having the array `['product', 'name']` present.
 
-In your Vue component, use computed properties to not flood your templates with store calls.
+In your Vue component, use computed properties to avoid flooding your templates with store calls.
 ​
 ```javascript
 computed: {
@@ -51,7 +51,7 @@ computed: {
 }
 ```
 
-Those computed properties can then be normally used in your templates:
+Those computed properties can then be used in your templates the familiar way:
 
 ```html
 <div>
@@ -64,23 +64,20 @@ Those computed properties can then be normally used in your templates:
 Like every Vuex mapping, fetching the errors from the store may be very repetitive and error-prone.
 Because of this we provide you an Vuex like mapper function:
 ​
-​
 ```javascript
 mapPropertyErrors(subject, properties)
 ```
 ​
-where subject is the entity name (not the entity itself) and properties is an array of properties you want to map.
+Here, the `subject` parameter is the entity name (not the entity itself) and `properties` is an array of the properties you want to map.
 You can spread its result to create computed properties in your component.
-The functions returned by the mapper are named like a camelCase representation of your input suffixed with `Error`.
+The functions returned by the mapper are named like a camelCase representation of your input, suffixed with `Error`.
 
 This is an example from the `sw-product-basic-form` component:
 ​
 ```javascript
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
     
-Component.register('sw-product-basic-form', {    
-    Component.register('sw-product-basic-form', {
-Component.register('sw-product-basic-form', {    
+Component.register('sw-product-basic-form', {
     computed: {
         ...mapPropertyErrors('product', [
             'name',
@@ -102,8 +99,8 @@ Which then are bound to the inputs like this:
 ​
 ### Error configuration for pages
 ​
-When working with nested views you need a way to tell the user that an error occurred on another view, e.g tab.
-For this you can write a config for your `sw-page` component which looks like: 
+When working with nested views, you need a way to tell the user that an error occurred on another view, e.g in another `tab`.
+For this you can write a config for your `sw-page` component which looks like seen below: 
 ​
 ```
 {
@@ -140,7 +137,7 @@ Shopware.Component.register('sw-product-detail', {
 }
 ```
 
-Wich then makes it possible to indicate if one or more errors exists, in another view or a tab:
+This makes it possible to indicate if one or more errors exists, in another view or a tab:
 
 ```html
 <sw-tabs

--- a/guides/plugins/plugins/administration/add-error-handling.md
+++ b/guides/plugins/plugins/administration/add-error-handling.md
@@ -2,7 +2,7 @@
 ​
 ## Overview
 
-The Shopware 6 Administration stores API errors in the [Vuex](https://vuex.vuejs.org/).
+The Shopware 6 Administration stores API errors in the [Vuex store](https://vuex.vuejs.org/).
 Where they are centrally accessible to your components, with a flat data structure wich looks like this:
 
 ```
@@ -19,6 +19,8 @@ Where they are centrally accessible to your components, with a flat data structu
  |- entityNameB
    ...         
 ```
+
+In this guide u will learn how to access this error store directly or via one of the provided helper functions.
 ​
 ## Read errors from the store
 ​
@@ -102,7 +104,7 @@ Which then are bound to the inputs like this:
 When working with nested views, you need a way to tell the user that an error occurred on another view, e.g in another `tab`.
 For this you can write a config for your `sw-page` component which looks like seen below: 
 ​
-```
+```json
 {
   "sw.product.detail.base": {
     "product": [


### PR DESCRIPTION
## What should be done?

Create a new article on our [GitBook instance|https://app.gitbook.com/@shopware/s/shopware/] which explains how to add proper error-handling in the administration.

This article should mention:
- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Administration

## Are there already guides in the previous documentation for this?
Unfortunately, No. But please have a look at our [example guide|https://app.gitbook.com/@shopware/s/shopware/guides/plugins/plugins/plugin-base-guide](e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the [Writing guidelines|https://app.gitbook.com/@shopware/s/shopware/resources/guidelines/documentation/writing].

For more information, ask me, [~p.stahl].