### PR TITLE
NEXT-12739 - Add dynamic content via AJAX calls

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -180,6 +180,7 @@
     * [Storefront](guides/plugins/plugins/storefront/README.md)
       * [Customize templates](guides/plugins/plugins/storefront/customize-templates.md)
       * [Add custom controller](guides/plugins/plugins/storefront/add-custom-controller.md)
+      * [Add dynamic content via AJAX calls](./guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md)
       * [Add custom Javascript](guides/plugins/plugins/storefront/add-custom-javascript.md)
       * [Override existing Javascript](guides/plugins/plugins/storefront/override-existing-javascript.md)
       * [Add custom assets](guides/plugins/plugins/storefront/add-custom-assets.md)

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -1,5 +1,7 @@
 # Add dynamic content via ajax calls
 
+## Overview
+
 This guide will show you how to add dynamic content to your storefront.
 It combines and builds upon the the guides about [adding custom Javascript](./add-custom-javascript.md) and [adding a custom controller](./add-custom-controller.md), so you should probably read them first.
 
@@ -10,6 +12,7 @@ For this guide we will use a very simple controller that returns a timestamp wra
 As mentioned before this guide builds up upon the [adding a custom controller](./add-custom-controller.md) guide.
 This means that this article will only cover the differences between returning a template and a `JSON` response and making it accessible to `XmlHttpRequests`.
 
+{% code title="<plugin base>/Storefront/Controller/ExampleController.php" %}
 ```php
 <?php declare(strict_types=1);
 
@@ -34,12 +37,13 @@ class ExampleController extends StorefrontController
     }
 }
 ```
+{% endcode %}
 
-As you might have seen this controller isn't too different from the controller used in the before mentioned article.
+As you might have seen this controller isn't too different from the controller used in the article mentioned before.
 The route annotation has an added `defaults={"XmlHttpRequest"=true}` to allow XmlHttpRequest and it returns a `JsonResponse` instead of a normal `Response`.
 Using a `JsonResponse` instead of a normal `Response` causes the data structures passed to it to be automatically turned into a `JSON` string.
 
-The following `services.xml` and `routes.xml` are identical to before mentioned article, but here they are for reference anyways:
+The following `services.xml` and `routes.xml` are identical as in the before mentioned article, but here they are for reference anyways:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -71,15 +75,14 @@ The following `services.xml` and `routes.xml` are identical to before mentioned 
 
 ## Preparing the Plugin
 
-Now we have to add a `plugin` to display the timestamp we get from our controller.
+Now we have to add a `Storefront Javascript plugin` to display the timestamp we get from our controller.
 
 Again this builds upon the [adding custom Javascript](./add-custom-javascript.md),
-so if you don't already now what storefront `plugins` are go ahead and read that.
+so if you don't already know what storefront `plugins` are, go ahead and read that.
 
 ```javascript
 import HttpClient from 'src/service/http-client.service';
 import Plugin from 'src/plugin-system/plugin.class';
-
 
 export default class AjaxPlugin extends Plugin {
     init() {
@@ -100,7 +103,7 @@ export default class AjaxPlugin extends Plugin {
     }
 
     _fetch() {
-        // make the  network request and call the `_setContent` function as a callback
+        // make the network request and call the `_setContent` function as a callback
         this._client.get('/example', this._setContent.bind(this), 'application/json', true)
     }
 
@@ -111,11 +114,9 @@ export default class AjaxPlugin extends Plugin {
 }
 ```
 
-
-
 ## Adding the Template
 
-The only thing that is now left to do is to provide an template for the storefront plugin to hook into:
+The only thing that is now left, is to provide a template for the storefront plugin to hook into:
 
 ```twig
 {% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
@@ -134,5 +135,5 @@ The only thing that is now left to do is to provide an template for the storefro
 
 ## Next steps
 
-The controller we used in this example isn't awfully useful, but this pattern of providing and using data is generally the same.
+The controller we used in this example doesn't do a lot of things, but this pattern of providing and using data is generally the same in all controllers of this kind.
 Even is you use it to fetch data form the database and in that case you probably want to learn more about the DAL [here](../../../../concepts/framework/data-abstraction-layer.md).

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -33,7 +33,7 @@ class ExampleController extends StorefrontController
     */
     public function showExample(): JsonResponse
     {
-        return new JsonResponse(['timestamp' => \date(\DateTimeInterface::W3C)]);
+        return new JsonResponse(['timestamp' => (new \DateTime())->format(\DateTimeInterface::W3C)]);
     }
 }
 ```
@@ -81,8 +81,8 @@ The following `services.xml` and `routes.xml` are identical as in the before men
 
 Now we have to add a `Storefront Javascript plugin` to display the timestamp we get from our controller.
 
-Again this builds upon the [adding custom Javascript](./add-custom-javascript.md),
-so if you don't already know what storefront `plugins` are, go ahead and read that.
+Again this is built upon the [adding custom Javascript](./add-custom-javascript.md) article,
+so if you don't already know what storefront `plugins` are, hold on and read it first.
 
 {% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
 ```javascript

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -45,6 +45,7 @@ Using a `JsonResponse` instead of a normal `Response` causes the data structures
 
 The following `services.xml` and `routes.xml` are identical as in the before mentioned article, but here they are for reference anyways:
 
+{% code title="<plugin root>/src/Resources/config/services.xml" %}
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <routes xmlns="http://symfony.com/schema/routing"
@@ -55,7 +56,9 @@ The following `services.xml` and `routes.xml` are identical as in the before men
     <import resource="../../Storefront/Controller/**/*Controller.php" type="annotation" />
 </routes>
 ```
+{% endcode %}
 
+{% code title="<plugin root>/src/Resources/config/routes.xml" %}
 ```xml
 <?xml version="1.0" ?>
 
@@ -72,6 +75,7 @@ The following `services.xml` and `routes.xml` are identical as in the before men
     </services>
 </container>
 ```
+{% endcode %}
 
 ## Preparing the Plugin
 
@@ -80,6 +84,7 @@ Now we have to add a `Storefront Javascript plugin` to display the timestamp we 
 Again this builds upon the [adding custom Javascript](./add-custom-javascript.md),
 so if you don't already know what storefront `plugins` are, go ahead and read that.
 
+{% code title="<plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js" %}
 ```javascript
 import HttpClient from 'src/service/http-client.service';
 import Plugin from 'src/plugin-system/plugin.class';
@@ -113,11 +118,13 @@ export default class AjaxPlugin extends Plugin {
     }
 }
 ```
+{% endcode %}
 
 ## Adding the Template
 
 The only thing that is now left, is to provide a template for the storefront plugin to hook into:
 
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
 ```twig
 {% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
 
@@ -132,8 +139,9 @@ The only thing that is now left, is to provide a template for the storefront plu
 	</div>
 {% endblock %}
 ```
+{% endcode %}
 
 ## Next steps
 
-The controller we used in this example doesn't do a lot of things, but this pattern of providing and using data is generally the same in all controllers of this kind.
-Even is you use it to fetch data form the database and in that case you probably want to learn more about the DAL [here](../../../../concepts/framework/data-abstraction-layer.md).
+The controller we used in this example doesn't do a lot, but this pattern of providing and using data is generally the same.
+Even if you use it to fetch data form the database, but in that case you probably want to learn more about the DAL [here](../../../../concepts/framework/data-abstraction-layer.md).

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -33,7 +33,7 @@ class ExampleController extends StorefrontController
     */
     public function showExample(): JsonResponse
     {
-        return new JsonResponse(['timestamp' => gmdate("Y-m-d\TH:i:s\Z")]);
+        return new JsonResponse(['timestamp' => \date(\DateTimeInterface::W3C)]);
     }
 }
 ```

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -1,0 +1,138 @@
+# Add dynamic content via ajax calls
+
+This guide will show you how to add dynamic content to your storefront.
+It combines and builds upon the the guides about [adding custom Javascript](./add-custom-javascript.md) and [adding a custom controller](./add-custom-controller.md), so you should probably read them first.
+
+## Setting up the Controller
+
+For this guide we will use a very simple controller that returns a timestamp wrapped in the JSON format.
+
+As mentioned before this guide builds up upon the [adding a custom controller](./add-custom-controller.md) guide.
+This means that this article will only cover the differences between returning a template and a `JSON` response and making it accessible to `XmlHttpRequests`.
+
+```php
+<?php declare(strict_types=1);
+
+namespace SwagBasicExample\Storefront\Controller;
+
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
+use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @RouteScope(scopes={"storefront"})
+ */
+class ExampleController extends StorefrontController
+{
+   /**
+    * @Route("/example", name="frontend.example.example", defaults={"XmlHttpRequest"=true}, methods={"GET"})
+    */
+    public function showExample(): JsonResponse
+    {
+        return new JsonResponse(['timestamp' => gmdate("Y-m-d\TH:i:s\Z")]);
+    }
+}
+```
+
+As you might have seen this controller isn't too different from the controller used in the before mentioned article.
+The route annotation has an added `defaults={"XmlHttpRequest"=true}` to allow XmlHttpRequest and it returns a `JsonResponse` instead of a normal `Response`.
+Using a `JsonResponse` instead of a normal `Response` causes the data structures passed to it to be automatically turned into a `JSON` string.
+
+The following `services.xml` and `routes.xml` are identical to before mentioned article, but here they are for reference anyways:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="../../Storefront/Controller/**/*Controller.php" type="annotation" />
+</routes>
+```
+
+```xml
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="SwagBasicExample\Storefront\Controller\ExampleController" public="true">
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+    </services>
+</container>
+```
+
+## Preparing the Plugin
+
+Now we have to add a `plugin` to display the timestamp we get from our controller.
+
+Again this builds upon the [adding custom Javascript](./add-custom-javascript.md),
+so if you don't already now what storefront `plugins` are go ahead and read that.
+
+```javascript
+import HttpClient from 'src/service/http-client.service';
+import Plugin from 'src/plugin-system/plugin.class';
+
+
+export default class AjaxPlugin extends Plugin {
+    init() {
+        // initalize the HttpClient
+        this._client = new HttpClient();
+
+        // get refernces to the dom elements
+        this.button = this.el.children['ajax-button'];
+        this.textdiv = this.el.children['ajax-display'];
+
+        // register the events
+        this._registerEvents();
+    }
+
+    _registerEvents() {
+        // fetch the timestamp, when the button is clicked
+        this.button.onclick = this._fetch.bind(this);
+    }
+
+    _fetch() {
+        // make the  network request and call the `_setContent` function as a callback
+        this._client.get('/example', this._setContent.bind(this), 'application/json', true)
+    }
+
+    _setContent(data) {
+        // parse the response and set the `textdiv.innerHTML` to the timestamp
+        this.textdiv.innerHTML = JSON.parse(data).timestamp;
+    }
+}
+```
+
+
+
+## Adding the Template
+
+The only thing that is now left to do is to provide an template for the storefront plugin to hook into:
+
+```twig
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block cms_content %}
+	<div>
+		<h1>Swag AJAX Example</h1>
+
+		<div data-ajax-helper>
+			<div id="ajax-display"></div>
+			<button id="ajax-button">Button</button>
+		</div>
+	</div>
+{% endblock %}
+```
+
+## Next steps
+
+The controller we used in this example isn't awfully useful, but this pattern of providing and using data is generally the same.
+Even is you use it to fetch data form the database and in that case you probably want to learn more about the DAL [here](../../../../concepts/framework/data-abstraction-layer.md).


### PR DESCRIPTION
What should be done?

Create a new article on our GitBook instance which explains how to add dynamic templates by using AJAX calls.

This article should mention:

- The prerequisite, a working plugin (Refer to the plugin base guide)
- Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
- A short code example, including an explanation, on how to do it
- Basically: "How to setup a controller, get the content via AJAX and render it to the template."
- HTTP Cache compatible!

Talk to Soner Sayakci or Oliver Skroblin about this if unclear

Category: Extensions > Plugins > Storefront
Are there already guides in the previous documentation for this?

Unfortunately, No. But please have a look at our example guide(e.g. note the PLACEHOLDERs for cross-references, that do not exist yet) and the Writing guidelines.

For more information, ask me, Patrick Stahl.