### PR TITLE
NEXT-12738 - Using the datepicker plugin

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -204,6 +204,7 @@
       * [Add custom sorting for product listing](guides/plugins/plugins/storefront/add-custom-sorting-product-listing.md)
       * [Add SCSS variables](guides/plugins/plugins/storefront/add-scss-variables.md)
       * [Using a modal window](guides/plugins/plugins/storefront/using-a-modal-window.md)
+      * [Using the datepicker plugin](guides/plugins/plugins/storefront/using-the-datepicker-plugin.md)
     * [Testing](guides/plugins/plugins/testing/README.md)
       * [End-to-end testing](guides/plugins/plugins/testing/end-to-end-testing.md)
       * [Jest unit tests in Shopware's administration](guides/plugins/plugins/testing/jest-admin.md)

--- a/guides/plugins/plugins/storefront/using-the-datepicker-plugin.md
+++ b/guides/plugins/plugins/storefront/using-the-datepicker-plugin.md
@@ -1,0 +1,190 @@
+# Using the datepicker plugin
+
+## Overview
+
+To provide an input field for date and time values, you can use the datepicker plugin. This guide shows you how to use it.
+
+The datepicker plugin uses the `flatpickr` implementation under the hood. So, check out the `flatpickr` documentation,
+if you need more information about the date picker configuration itself.
+
+<!-- markdown-link-check-disable-next-line -->
+{% embed url="https://flatpickr.js.org" caption="" %}
+
+## Prerequisites
+
+You won't learn how to create a plugin in this guide, head over to our Plugin base guide to create
+your first plugin:
+
+{% page-ref page="../plugin-base-guide.md" %}
+
+You should also know how to customize templates:
+
+{% page-ref page="./customize-templates.md" %}
+
+## Setup a datepicker input field
+
+To apply the datepicker functionality we have to add a DOM element in a template, e.g. an input field.
+To keep this example simple for now we just override the `base_main_inner` block of the `storefront/page/content/index.html.twig` template.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```html
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+    <label>
+        <input type="text"
+               name="customDate"
+               class="customDate"
+        />
+    </label>
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+Now you should see an empty input field if you open the storefront in your browser.
+We need to add the data-attribute `data-date-picker` to activate the datepicker plugin on our input field.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```html
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+    <label>
+        <input type="text"
+               name="customDate"
+               class="customDate"
+               data-date-picker
+        />
+    </label>
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+If we check the change in the browser again, thus after reloading the page, we can see that the datepicker plugin is now active on this element.
+
+## Configure the datepicker
+
+If you select a date with the datepicker from the example above, you will see that a time is always selected and displayed in the input field. By default, the time selection is activated.
+
+We can change this behaviour by passing more options to the datepicker plugin.
+
+Here you can see how this is done by setting up a local Twig variable `pickerOptions`. We can assign a JSON formatted object to the variable and pass the value to the datepicker plugin through the `data-date-picker-options` attribute.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```html
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+
+    {% set pickerOptions = '{
+        "locale": "' ~ app.request.locale ~ '",
+        "enableTime": true
+    }' %}
+    
+    <label>
+        <input type="text"
+               name="customDate"
+               class="customDate"
+               data-date-picker
+               data-date-picker-options="{{ pickerOptions }}"
+        />
+    </label>
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+As you can see, we also pass in the `locale` option which gets its value from `app.request.locale`. As a result,
+the datepicker plugin now uses the same locale as the current storefront and the date formatting matches active
+languages accordingly.
+
+## Preselect a date
+
+To preselect the value of the datepicker we can simply set its value in the input field which gets picked up by the datepicker plugin.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```html
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+
+    {% set pickerOptions = '{
+        "locale": "' ~ app.request.locale ~ '",
+        "enableTime": true
+    }' %}
+    
+    <label>
+        <input type="text"
+               name="customDate"
+               class="customDate"
+               value="2021-01-01T00:00:00+00:00"
+               data-date-picker
+               data-date-picker-options="{{ pickerOptions }}"
+        />
+    </label>
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+## Controlling the datepicker via buttons
+
+To open or close the datepicker by trigger buttons you can pass in DOM selectors. You can also setup a selector to reset the currently selected value.
+Here is an example which shows all three selectors in action.
+
+{% code title="<plugin root>/src/Resources/views/storefront/page/content/index.html.twig" %}
+```html
+{% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
+
+{% block base_main_inner %}
+
+    {% set pickerProperties = '{
+        "locale": "' ~ app.request.locale ~ '",
+        "enableTime": true,
+        "selectors": {
+            "openButton" : ".openDatePicker",
+            "closeButton": ".closeDatePicker",
+            "clearButton": ".resetDatePicker"
+        }
+    }' %}
+
+    <label>
+        <input type="text"
+               name="foo"
+               class="customDate"
+               value="2021-04-13T00:00:00+00:00"
+               data-date-picker
+               data-date-picker-options="{{ pickerProperties }}"
+        />
+
+        <button class="openDatePicker">Open</button>
+        <button class="closeDatePicker">Close</button>
+        <button class="resetDatePicker">Reset</button>
+    </label>
+
+    {{ parent() }}
+{% endblock %}
+```
+{% endcode %}
+
+## More options
+
+| Option | Default | Description |
+| :--- | :--- | :--- |
+| `dateFormat` | 'Y-m-dTH:i:S+00:00' | Pattern for the date string representation
+| `altInput` | true | Hides your original input and creates a new one.
+| `altFormat` | 'j. FY, H:i' | Alternative pattern for the date string representation if `altInput` is enabled. The value of the input field gets still formatted by `dateFormat`
+| `time_24hr` | true | 
+| `enableTime` | true |
+| `noCalendar` |false |
+| `weekNumbers` | true |
+| `allowInput` | true |
+| `minDate` | null | Specifies the minimum/earliest date (inclusively) allowed for selection
+| `maxDate` | null | Specifies the maximum/latest date (inclusively) allowed for selection.
+


### PR DESCRIPTION
### What should be done?
Create a new article on our GitBook instance which explains how to use the storefront javascript "datepicker" plugin.
This article should mention:
The prerequisite, a working plugin (Refer to the plugin base guide)
Every other prerequisite you figure out during writing the guide (e.g. a subscriber, knowing how to create a service, a controller, etc.)
A short code example, including an explanation, on how to do it

Category: Extensions > Plugins > Storefront