### PR TITLE
Translations: Added a section on general use in PHP

### DIFF
--- a/guides/plugins/plugins/storefront/add-translations.md
+++ b/guides/plugins/plugins/storefront/add-translations.md
@@ -82,11 +82,11 @@ $this->trans('soldProducts', ['%count%' => 3, '%country%' => 'Germany']);
 
 ## Using translation generally in PHP
 
-If we need to use a snippet elsewhere in PHP, we can use Dependency Injection to inject `Shopware\Core\Framework\Adapter\Translation\Translator` which implements Symfony's `Symfony\Contracts\Translation\TranslatorInterface`:
+If we need to use a snippet elsewhere in PHP, we can use Dependency Injection to inject `translator` which implements Symfony's `Symfony\Contracts\Translation\TranslatorInterface`:
 
 ```xml
 <service id="Swag\Example\Service\SwagService" public="true" >
-    <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator" />
+    <argument type="service" id="translator" />
 </service>
 ```
 

--- a/guides/plugins/plugins/storefront/add-translations.md
+++ b/guides/plugins/plugins/storefront/add-translations.md
@@ -82,7 +82,7 @@ $this->trans('soldProducts', ['%count%' => 3, '%country%' => 'Germany']);
 
 ## Using translation generally in PHP
 
-If we need to use a snippet elsewhere in PHP, we can use Dependency Injection to inject `translator` which implements Symfony's `Symfony\Contracts\Translation\TranslatorInterface`:
+If we need to use a snippet elsewhere in PHP, we can use [Dependency Injection](../plugin-fundamentals/dependency-injection.md) to inject the `translator`, which implements Symfony's `Symfony\Contracts\Translation\TranslatorInterface`:
 
 ```xml
 <service id="Swag\Example\Service\SwagService" public="true" >
@@ -103,4 +103,3 @@ Your class can then use translation similarly to controllers:
 ```php
 $this->translator->trans('soldProducts', ['%count%' => 3, '%country%' => 'Germany']);
 ```
-

--- a/guides/plugins/plugins/storefront/add-translations.md
+++ b/guides/plugins/plugins/storefront/add-translations.md
@@ -80,3 +80,27 @@ Translation with placeholders:
 $this->trans('soldProducts', ['%count%' => 3, '%country%' => 'Germany']);
 ```
 
+## Using translation generally in PHP
+
+If we need to use a snippet elsewhere in PHP, we can use Dependency Injection to inject `Shopware\Core\Framework\Adapter\Translation\Translator` which implements Symfony's `Symfony\Contracts\Translation\TranslatorInterface`:
+
+```xml
+<service id="Swag\Example\Service\SwagService" public="true" >
+    <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator" />
+</service>
+```
+
+```php
+private $translator;
+public function __construct(TranslatorInterface $translator)
+{
+    $this->translator = $translator;
+}
+```
+
+Your class can then use translation similarly to controllers:
+
+```php
+$this->translator->trans('soldProducts', ['%count%' => 3, '%country%' => 'Germany']);
+```
+


### PR DESCRIPTION
I noticed there was a section on using translation inside PHP controllers, but nothing noted about general use, so I figured I'd add it, so it's more straight forward if your use-case isn't translating directly in a controller. I spent a bit of time looking for how to do this the first time I needed to do translations in PHP, so I hope this can help new developers @ WEXO and elsewhere save some time getting up to speed on translation usage.

If you think it needs changes, feel free to let me know.