### PR TITLE
Add argument to DOM binding

### DIFF
--- a/guides/plugins/plugins/storefront/add-custom-javascript.md
+++ b/guides/plugins/plugins/storefront/add-custom-javascript.md
@@ -112,7 +112,7 @@ A lot of text, here is the respective example:
 {% block base_main_inner %}
     {{ parent() }}
 
-    <template data-example-plugin></template>
+    <template data-example-plugin="true"></template>
 {% endblock %}
 ```
 {% endcode %}


### PR DESCRIPTION
I figured out that DOM binding only works if  `data-example-plugin` has a value like `true` (so not `false` or `undefined`).