### PR TITLE
move main.js entry to the right place

### DIFF
--- a/guides/plugins/themes/add-css-js-to-theme.md
+++ b/guides/plugins/themes/add-css-js-to-theme.md
@@ -65,8 +65,7 @@ Since Shopware knows where your style files are located, they are automatically 
     │   ├── app
     │   │   └── storefront
     │   │       └── src
-    │   │           └── js
-    │   │               └── main.js <-- JS entry
+    │   │           └── main.js <-- JS entry
     └── SwagBasicExampleTheme.php
 ```
 


### PR DESCRIPTION
Changed the tree for main.js to the one as described in the text before "In the case of JavaScript, you have your `main.js` as entry point which has to be located the `src/Resources/app/storefront/src/` directory:
"