### PR TITLE
Update manifest schema reference

### DIFF
--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -3,7 +3,7 @@
 {% code title="manifest.xml" %}
 ```markup
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/app-system/0.1.0/src/Core/Content/App/Manifest/Schema/manifest-1.0.xsd">
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/app-system/0.2.0/src/Core/Content/App/Manifest/Schema/manifest-1.0.xsd">
     <meta>
         <!-- This is the element for the technical name of your app and must equal the name of the folder your app is contained in -->
         <name>MyExampleApp</name>

--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -3,7 +3,7 @@
 {% code title="manifest.xml" %}
 ```markup
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/app-system/0.2.0/src/Core/Content/App/Manifest/Schema/manifest-1.0.xsd">
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Framework/App/Manifest/Schema/manifest-1.0.xsd">
     <meta>
         <!-- This is the element for the technical name of your app and must equal the name of the folder your app is contained in -->
         <name>MyExampleApp</name>
@@ -152,4 +152,3 @@
 </manifest>
 ```
 {% endcode %}
-


### PR DESCRIPTION
When you copy the reference you'll get lots of xsd related issues (depending on the IDE/editor). When we use the latest reference we are good to go, aren't we?