### PR TITLE
NEXT-16118 - Feature will be available starting with 6.4.3.0

### DIFF
--- a/guides/plugins/apps/content/cms/add-custom-cms-blocks.md
+++ b/guides/plugins/apps/content/cms/add-custom-cms-blocks.md
@@ -1,7 +1,7 @@
 # Add custom CMS blocks
 
 {% hint style="info" %}
-This functionality is available starting with Shopware 6.4.2.0.
+This functionality is available starting with Shopware 6.4.3.0.
 {% endhint %}
 
 Didn't get in touch with Shopware's Shopping Experiences \(CMS\) yet? Check out the concept behind it first:


### PR DESCRIPTION
Adding custom CMS blocks via the App system will be available starting with `6.4.3.0` instead of `6.4.2.0`.