### PR TITLE
fix db table name in scheduled task docs

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
@@ -121,7 +121,7 @@ Usually scheduled tasks are registered when installing or updating your plugin. 
 
 In order to properly test your scheduled task, you first have to run the command `bin/console scheduled-task:run`. This will start the `ScheduledTaskRunner`, which takes care of your scheduled tasks and their respective timings. It will dispatch a message to the message bus once your scheduled task's interval is due.
 
-Now you still need to run the command `bin/console messenger:consume` to actually execute the dispatched messages. Make sure, that the `status` of your scheduled task is set to `scheduled` in the `scheduled_tasks` table, otherwise it won't be executed. This is not necessary, when you're using the admin worker.
+Now you still need to run the command `bin/console messenger:consume` to actually execute the dispatched messages. Make sure, that the `status` of your scheduled task is set to `scheduled` in the `scheduled_task` table, otherwise it won't be executed. This is not necessary, when you're using the admin worker.
 
 ## More interesting topics
 


### PR DESCRIPTION
The table is called `scheduled_task` at least in my installation, so I'd assume that this is a typo 😊