### PR TITLE
missing adjustment after swap of dev documentation

### DIFF
--- a/guides/plugins/plugins/framework/data-handling/add-custom-complex-data.md
+++ b/guides/plugins/plugins/framework/data-handling/add-custom-complex-data.md
@@ -282,7 +282,7 @@ This is how your collection class could then look like:
 ```php
 <?php declare(strict_types=1);
 
-namespace Swag\BasicExample\Core\Content\Bundle;
+namespace Swag\BasicExample\Core\Content\Example;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 


### PR DESCRIPTION
the former bundle tutorial is now displayed in a more generalized manner. at "ExampleCollection" the namespace still contained "Bundle" instead of "Example"