### PR TITLE
Change CLI command for message consume

### DIFF
--- a/guides/hosting/infrastructure/message-queue.md
+++ b/guides/hosting/infrastructure/message-queue.md
@@ -17,19 +17,19 @@ The recommended method for consuming messages is using the cli worker.
 You can configure the command just to run a certain amount of time or to stop if it exceeds a certain memory limit like: 
 
 ```bash
-bin/console messenger:consume-messages default --memory-limit=128M
+bin/console messenger:consume default --memory-limit=128M
 ```
 
 For more information about the command and its configuration use the -h option: 
 
 ```bash
-bin/console messenger:consume-messages -h
+bin/console messenger:consume -h
 ```
 
 You should use the limit option to periodically restart the worker processes, because of the memory leak issues of long-running php processes. To automatically start the processes again after they stopped because of exceeding the given limits you can use something like [upstart](http://upstart.ubuntu.com/getting-started.html) or [supervisor](http://supervisord.org/running.html). Alternatively you can configure a cron job that runs the command again shortly after the time limit exceeds.
 
 ```bash
-bin/console messenger:consume-messages default --time-limit=60
+bin/console messenger:consume default --time-limit=60
 ```
 
 


### PR DESCRIPTION
Deprecated command bin/console messenger:consume-messages replaced with regular command bin/console messenger:consume