### PR TITLE
How to rebuild administration in add-new-tab.md

### DIFF
--- a/guides/plugins/plugins/administration/add-new-tab.md
+++ b/guides/plugins/plugins/administration/add-new-tab.md
@@ -132,6 +132,22 @@ This is an example of what your `main.js` should look like in order to load your
 ```javascript
 import './page/sw-product-detail';
 ```
+{% hint style="info" %}
+Don't forget to rebuild the administration after making changes to your `main.js`.
+{% tabs %}
+{% tab title="Development template" %}
+```bash
+./psh.phar administration:build
+```
+{% endtab %}
+
+{% tab title="Production template" %}
+```bash
+./bin/build-administration.sh
+```
+{% endtab %}
+{% endtabs %}
+{% endhint %}
 
 ## Registering the tab's new route
 

--- a/guides/plugins/plugins/administration/add-new-tab.md
+++ b/guides/plugins/plugins/administration/add-new-tab.md
@@ -133,7 +133,7 @@ This is an example of what your `main.js` should look like in order to load your
 import './page/sw-product-detail';
 ```
 {% hint style="info" %}
-Don't forget to rebuild the administration after making changes to your `main.js`.
+Don't forget to rebuild the administration after applying changes to your `main.js`.
 {% tabs %}
 {% tab title="Development template" %}
 ```bash
@@ -238,4 +238,3 @@ Here's what this new template could look like:
 {% endcode %}
 
 It simply creates a new card with a title, which only contains a 'Hello world!' string. And that's it - your tab should now be fully functional.
-


### PR DESCRIPTION
I noticed that the only page in the docs that ever mentions that you need to rebuild administration after you change your main.js is add-custom-field.md. This was very confusing to me and I think it should be added to pretty much every page in the docs that makes changes to main.js.