### PR TITLE
GTS-325 - Tell developers that apps are available since 6.4.0.0

### DIFF
--- a/concepts/api/store-api.md
+++ b/concepts/api/store-api.md
@@ -1,6 +1,6 @@
 # Store API
 
-Every interaction between the store and a customer can be modeled using the Store API. It serves as a normalised layer or interface to communicate between customer-facing applications and the Shopware Core. It can be used to build custom frontends like singe page applications, native apps or simple catalog apps. It really doesn't matter, what you want to build, as long as you're able to consume a JSON API via HTTP.
+Every interaction between the store and a customer can be modeled using the Store API. It serves as a normalised layer or interface to communicate between customer-facing applications and the Shopware Core. It can be used to build custom frontends like single page applications, native apps or simple catalog apps. It really doesn't matter, what you want to build, as long as you're able to consume a JSON API via HTTP.
 
 ![Data and logic flow in Shopware 6 \(top to bottom and vice versa\)](../../.gitbook/assets/image%20%283%29.png)
 

--- a/concepts/extensions/README.md
+++ b/concepts/extensions/README.md
@@ -6,7 +6,7 @@ In order to provide users \(i.e. developers\) with a clear abstraction, Shopware
 
 ![](../../.gitbook/assets/app-extension-model.png)
 
-Apps are not executed within the process of the Shopware core, but are notified about events via Webhooks which they can register. They can modify and interact with Shopware resources through the [Admin REST API](https://shopware.stoplight.io/docs/admin-api).
+Starting with Shopware 6.4.0.0, we introduced a new way to extend Shopware using the newly created app system. Apps are not executed within the process of the Shopware core, but are notified about events via Webhooks which they can register. They can modify and interact with Shopware resources through the [Admin REST API](https://shopware.stoplight.io/docs/admin-api).
 
 [Learn more about apps](apps-concept.md)
 

--- a/guides/plugins/overview.md
+++ b/guides/plugins/overview.md
@@ -9,10 +9,9 @@ The variety of Shopware's extension interfaces can be overwhelming, so let's sta
 | Execute Webhooks | ✅ | ❌ | ✅ | Apps main functionality is to call Webhooks, but Plugins can be implemented to do that as well. |
 | Modify database structure, add custom entities | ✅ | ❌ | ❌ |  |
 | Integrate payment providers | ✅ | ❌ | ✅ |  |
-| Publish in App Store | ❌ | ❌ | ✅ |  |
-| Publish in Plugin Store | ✅ | ✅ | ❌ |  |
+| Publish in the Shopware Store | ✅ | ✅ | ✅ |  |
 | Install in Shopware 6 Cloud Shops | ❌ | ❌ | ✅ |  |
-| Install in Shopware 6 on-Premise Shops | ✅ | ✅ | ✅ |  |
+| Install in Shopware 6 on-Premise Shops | ✅ | ✅ | ✅ | Apps can be installed and used since Shopware 6.4.0.0 |
 | Add custom logic/routes/commands | ✅ | ❌ | ✅ | Apps extract functionalities/logic into separate services, so technically they can add custom logic |
 | Control order of style/template inheritance | ❌ | ✅ | ✅ |  |
 


### PR DESCRIPTION
Even if the app documentation is not availabe in the 6.3.x version of our documentation, developers think apps can be used in every shopware version.

I added some hints in the documentation, telling the developers that apps can be used since 6.4.