### PR TITLE
Typo add-translations.md

### DIFF
--- a/guides/plugins/plugins/storefront/add-translations.md
+++ b/guides/plugins/plugins/storefront/add-translations.md
@@ -60,7 +60,7 @@ Translation with placeholders:
 
 ```text
 <div class="product-detail-headline">
-    {{ 'soldProducts' | trans({'%count%': 3, '%country%': 'Germany') }}
+    {{ 'soldProducts' | trans({'%count%': 3, '%country%': 'Germany'}) }}
 </div>
 ```
 


### PR DESCRIPTION
There is a unclosed translation object in the example code of **Translation with placeholders**