### PR TITLE
Fix wrong filename

### DIFF
--- a/guides/plugins/plugins/content/cms/add-cms-block.md
+++ b/guides/plugins/plugins/content/cms/add-cms-block.md
@@ -269,7 +269,7 @@ A block's storefront representation is always expected in the directory [platfor
 
 So go ahead and re-create that structure in your plugin: `<plugin root>/src/Resources/views/storefront/block/`
 
-In there create a new twig template named after your block, so `cms-block-image-text-reversed.html.twig` that is.
+In there create a new twig template named after your block, so `cms-block-my-image-text-reversed.html.twig` that is.
 
 Since the [original 'image\_text' file](https://github.com/shopware/platform/blob/v6.3.4.1/src/Storefront/Resources/views/storefront/block/cms-block-image-text.html.twig) is already perfectly fine, you can go ahead and extend from it in your storefront template.
 


### PR DESCRIPTION
We registered the cms-block with:
name: 'my-image-text-reversed'.

Accordingly, the block must be named 'cms-block-my-image-text-reversed.html.twig' instead of 'cms-block-image-text-reversed.html.twig'.
Otherwise the Block won't get rendered.