### PR TITLE
Add a missing link for the create migration command to the migrations…

### DIFF
--- a/concepts/framework/migrations.md
+++ b/concepts/framework/migrations.md
@@ -8,6 +8,8 @@ For Shopware to recognise additional plugin migrations, they need to be placed i
 
 Each migration filename follows a specific pattern. To ease plugin development, Shopware provides a console command which can be used to generate a correctly named migration file with the default methods needed.
 
+{% page-ref page="guides/plugins/plugins/plugin-fundamentals/database-migrations#create-migration" %}
+
 ## Modifying the database
 
 Each migration can have two methods. The `update` and `updateDestructive`. The `update` method must contain only non-destructive changes which can be rolled back at any time. The `updateDestructive` method can contain destructive changes, which cannot be reversed, like dropping columns or tables. For examples of database migrations please refer to the guide on how to use database migrations:


### PR DESCRIPTION
The Page only says that there is an command for creating an migration, but does not mention which one.
This PR adds an link to the database-migrations guide.