### PR TITLE
Add note about plugin styles import for StorefrontBootstrap

### DIFF
--- a/guides/plugins/themes/add-theme-inheritance-without-resources.md
+++ b/guides/plugins/themes/add-theme-inheritance-without-resources.md
@@ -14,6 +14,7 @@ If you want to build your theme only upon the Bootstrap SCSS you can use the `@S
   ...
   "style": [
     "@StorefrontBootstrap",
+    "@Plugins",
     "app/storefront/src/scss/base.scss"
   ]
 }
@@ -24,6 +25,7 @@ If you want to build your theme only upon the Bootstrap SCSS you can use the `@S
 * This option can only be used in the `style` section of the `theme.json`. You must not use it in `views` or `script`.
 * All theme variables like `$sw-color-brand-primary` are also available when using the Bootstrap option.
 * You can only use either `@StorefrontBootstrap` or `@Storefront`. They should not be used at the same time. The `@Storefront` bundle **includes** the Bootstrap SCSS already.
+* `@StorefrontBootstrap` does not include `@Plugins`, you have to add it yourself.
 {% endhint %}
 
 ## Next steps


### PR DESCRIPTION
`@StorefrontBootstrap` does not include `@Plugins` in contrast to `@Storefront`. Added it into example and added a note.