### PR TITLE
Update dependency-injection.md

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/dependency-injection.md
+++ b/guides/plugins/plugins/plugin-fundamentals/dependency-injection.md
@@ -60,7 +60,7 @@ class ExampleService
     */
     private $systemConfigService;
 
-    public function __construct(SystemConfigService $systemConfigService): void
+    public function __construct(SystemConfigService $systemConfigService)
     {
         $this->systemConfigService = $systemConfigService;
     }

--- a/guides/plugins/plugins/plugin-fundamentals/dependency-injection.md
+++ b/guides/plugins/plugins/plugin-fundamentals/dependency-injection.md
@@ -60,7 +60,7 @@ class ExampleService
     */
     private $systemConfigService;
 
-    public function __construct(SystemConfigService $systemConfigService)
+    public function __construct(SystemConfigService $systemConfigService):void
     {
         $this->systemConfigService = $systemConfigService;
     }

--- a/guides/plugins/plugins/plugin-fundamentals/dependency-injection.md
+++ b/guides/plugins/plugins/plugin-fundamentals/dependency-injection.md
@@ -60,7 +60,7 @@ class ExampleService
     */
     private $systemConfigService;
 
-    public function __construct(SystemConfigService $systemConfigService):void
+    public function __construct(SystemConfigService $systemConfigService)
     {
         $this->systemConfigService = $systemConfigService;
     }

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -68,7 +68,7 @@ class ExampleController extends StorefrontController
     */
     public function showExample(): Response
     {
-        return $this->renderStorefront('@SwagBasicExample/storefront/page/example/index.html.twig', [
+        return $this->renderStorefront('@SwagBasicExample/storefront/page/example.html.twig', [
             'example' => 'Hello world'
         ]);
     }


### PR DESCRIPTION
Constructors in object-oriented languages do not have return types.
https://bugs.php.net/bug.php?id=75263

And there is a wrong path specified in "guides/plugins/plugins/storefront/add-custom-controller.md"