### PR TITLE
Remove unneeded warning for extending webpack configurations

### DIFF
--- a/guides/plugins/plugins/administration/extending-webpack.md
+++ b/guides/plugins/plugins/administration/extending-webpack.md
@@ -25,8 +25,3 @@ module.exports = () => {
 {% endcode %}
 
 This way, the configuration is automatically loaded and then merged with the Shopware provided webpack configuration, including all other plugin webpack configurations. Merging is done with the [webpackMerge](https://github.com/survivejs/webpack-merge) library.
-
-{% hint style="danger" %}
-This merging makes it technically possible to override the Shopware provided configuration, but you shouldn't change the default configurations so that the builded core code will differ from the original builded code without your configuration, because this could break the administration, your plugin or other third-party plugins.
-{% endhint %}
-


### PR DESCRIPTION
Shopware Admin now uses the multi-compiler mode. Therefore it is not possible anymore to break the core.