### PR TITLE
NEXT-17001 - Add more information about nested menu entries

### DIFF
--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -70,6 +70,8 @@ navigation: [{
 }]
 ```
 {% endcode %}
+    
+The parent can be on any level because the menu supports infinite depth nesting. For example, if `sw-manufacturer` were taken as the `parent`, the menu item would be present on the third level.
 
 {% hint style="info" %}
 If you're planning to publish your plugin to the Shopware Store keep in mind we're rejecting plugins which have created their own menu entry on the first level.

--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -73,6 +73,8 @@ navigation: [{
 
 You can find the parent id at the `index.js` file in each module folder. You can see the property `navigation` in the `Module.register` method. The id here can be used as the parent key.
     
+## Nesting menu entries
+    
 The parent can be on any level because the menu supports infinite depth nesting. For example, if `sw-manufacturer` were taken as the `parent`, the menu item would be present on the third level. So whats important here is that the configured parent defines where the menu entry will take place.
 
 {% hint style="info" %}

--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -70,8 +70,10 @@ navigation: [{
 }]
 ```
 {% endcode %}
+
+You can find the parent id at the `index.js` file in each module folder. You can see the property `navigation` in the `Module.register` method. The id here can be used as the parent key.
     
-The parent can be on any level because the menu supports infinite depth nesting. For example, if `sw-manufacturer` were taken as the `parent`, the menu item would be present on the third level.
+The parent can be on any level because the menu supports infinite depth nesting. For example, if `sw-manufacturer` were taken as the `parent`, the menu item would be present on the third level. So whats important here is that the configured parent defines where the menu entry will take place.
 
 {% hint style="info" %}
 If you're planning to publish your plugin to the Shopware Store keep in mind we're rejecting plugins which have created their own menu entry on the first level.


### PR DESCRIPTION
The documentation article about menu entries in the administration does not explain that it is also possible to use non-first entries as a parent. I added a block where I explain this behaviour.