### PR TITLE
Escape JSON to ensure correct HTML parsing

### DIFF
--- a/guides/plugins/plugins/storefront/add-custom-javascript.md
+++ b/guides/plugins/plugins/storefront/add-custom-javascript.md
@@ -197,7 +197,7 @@ Imagine the following example can be found in the core:
 {% block element_product_slider_slider %}
     <div class="base-slider"
          data-product-slider="true"
-         data-product-slider-options="{{ productSliderOptions|json_encode }}">
+         data-product-slider-options="{{ productSliderOptions|default({})|json_encode|escape('html_attr') }}">
     </div>
 {% endblock %}
 ```


### PR DESCRIPTION
When you use the code you will eventually end up with wrong HTML :( When you pass in null it will also end up bad in the option merging later on. Why shall it be null? It can be because you propagate to allow others to change that value. Makes the code a bit more bullet proof