### PR TITLE
feat: Add app icon configuration to the manifest.xml

### DIFF
--- a/guides/plugins/apps/app-base-guide.md
+++ b/guides/plugins/apps/app-base-guide.md
@@ -39,6 +39,7 @@ The manifest file is the central point of your app. It defines the interface bet
         <author>Your Company Ltd.</author>
         <copyright>(c) by Your Company Ltd.</copyright>
         <version>1.0.0</version>
+        <icon>Resources/config/plugin.png</icon>
         <license>MIT</license>
     </meta>
 </manifest>


### PR DESCRIPTION
I needed to lookup the corresponding `.xsd` file in order to find the correct placement of the app icon.

This is just a proposed change, since it should be obvious that one can adjust this parameter. Not sure if there should be more text added.