### PR TITLE
Remove markdown link check for external adminer link

### DIFF
--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -103,6 +103,7 @@ Various
 * Webserver with HTTP2 support
 
 {% hint style="info" %}
+<!-- markdown-link-check-disable-next-line -->
 Adminer \([https://www.adminer.org/](https://www.adminer.org/)\) is our recommended database administration tool since it has better support for binary data types.
 {% endhint %}
 


### PR DESCRIPTION
The link to the adminer homepage is marked as a dead link sometimes. When this happens on the merge commit the docs won't be published with a new version.

See failing github actions:

* https://github.com/shopware/docs/actions/runs/1470520702
* https://github.com/shopware/docs/actions/runs/1467673872