### PR TITLE
Varnish config: Administration not compatible

### DIFF
--- a/guides/hosting/infrastructure/reverse-http-cache.md
+++ b/guides/hosting/infrastructure/reverse-http-cache.md
@@ -113,6 +113,7 @@ sub vcl_recv {
         req.method != "POST" &&
         req.method != "TRACE" &&
         req.method != "OPTIONS" &&
+        req.method != "PATCH" &&
         req.method != "DELETE") {
         /* Non-RFC2616 or CONNECT which is weird. */
         return (pipe);


### PR DESCRIPTION
The sample Varnish config doesn't handle PATCH requests which causes issues when the administration passes requests through Varnish.

This PR adds this.