### PR TITLE
fixed typo in first line of the administration - add menu entry guide

### DIFF
--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-When it comes to the module configuration, the menu entry is one of the mos important things to set up. It serves to open your module.
+When it comes to the module configuration, the menu entry is one of the most important things to set up. It serves to open your module.
 
 ## Prerequisites
 


### PR DESCRIPTION
Found a little typo in the docs. Here's the fix.