### PR TITLE
500-ignore-symfony-deprecations-in-recommended-phpunit-config

### DIFF
--- a/guides/plugins/plugins/testing/php-unit.md
+++ b/guides/plugins/plugins/testing/php-unit.md
@@ -27,7 +27,7 @@ Here's an example configuration for the development template:
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          bootstrap="../../../vendor/shopware/platform/src/Core/TestBootstrap.php"
          cacheResult="false">
 
@@ -38,6 +38,7 @@ Here's an example configuration for the development template:
         <env name="APP_DEBUG" value="1"/>
         <env name="APP_SECRET" value="s$cretf0rt3st"/>
         <env name="SHELL_VERBOSITY" value="-1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
[The core phpunit.xml.dist](https://github.com/shopware/platform/blob/891e14d48ac916c649a1bb29ac87d75ef0feca61/phpunit.xml.dist#L75) ignores Symfony deprecations.

This PR includes the directive for doing the same to the recommended `phpunit.xml.dist` on [the doc page on unit testing plugins](https://developer.shopware.com/docs/guides/plugins/plugins/testing/php-unit#phpunit-configuration).

Not doing this creates confusing deprecation warnings on running plugin tests (confusing because the warnings have nothing to do with the tests defined by the plugin), see [this issue](https://github.com/shopware/docs/issues/500).

While I was at it, I took the liberty to bump the schema version used by the recommended `phpunit.xml.dist` - since shopware requires phpunit 9.5, using the more current schema seems appropriate (and [this is also what core does](https://github.com/shopware/platform/blob/891e14d48ac916c649a1bb29ac87d75ef0feca61/phpunit.xml.dist#L4)).