### PR TITLE
Expanded on adding a custom menu entry.

### DIFF
--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -56,11 +56,12 @@ Of course there's more to be configured here, but more's not necessary for this 
 
 ## Menu entry in category
 
-Due to UX reasons, we're not supporting plugin modules to add new menu entries on the first level of the main menu. Please use the "parent" property inside your navigation object to define the category where you want your menu entry will be appended to:
+Due to UX reasons, we're not supporting plugin modules to add new menu entries on the first level of the main menu. Please use the "parent" property inside your navigation object to define the category where you want your menu entry will be appended to. Your navigation entry will also have to have an id to show up in the rendered navigation:
 
 {% code title="<plugin root>/src/Resources/app/administration/src/module/swag-example/index.js" %}
 ```javascript
 navigation: [{
+    id: 'swag-custommodule-list'
     label: 'CustomModule',
     color: '#ff3d58',
     path: 'swag.custommodule.list',

--- a/guides/plugins/plugins/administration/add-menu-entry.md
+++ b/guides/plugins/plugins/administration/add-menu-entry.md
@@ -56,7 +56,7 @@ Of course there's more to be configured here, but more's not necessary for this 
 
 ## Menu entry in category
 
-Due to UX reasons, we're not supporting plugin modules to add new menu entries on the first level of the main menu. Please use the "parent" property inside your navigation object to define the category where you want your menu entry will be appended to. Your navigation entry will also have to have an id to show up in the rendered navigation:
+Due to UX reasons, we're not supporting plugin modules to add new menu entries on the first level of the main menu. Please use the "parent" property inside your navigation object to define the category where you want your menu entry will be appended to. Your navigation entry will also have to have an `id` to show up in the rendered navigation:
 
 {% code title="<plugin root>/src/Resources/app/administration/src/module/swag-example/index.js" %}
 ```javascript


### PR DESCRIPTION
Expanded the explanation on how to create a menu entry with the ID property of a navigation entry. The original documentation did not work for me, but reading the following link helped: https://forum.shopware.com/t/how-to-add-administration-navigation-entry-for-plugin-module-below-existing-settings-entry/67288