### PR TITLE
Use "tested on" instead of min requirements

### DIFF
--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -54,7 +54,7 @@ Although Shopware 6 supports most UNIX like environments, we recommend using **U
 
 PHP
 
-* tested on 7.4.3, 8.0 and 8.1
+* Tested on 7.4.3, 8.0 and 8.1
 * `memory_limit` 512M minimum
 * `max_execution_time` 30 seconds minimum
 * Extensions:

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -54,7 +54,7 @@ Although Shopware 6 supports most UNIX like environments, we recommend using **U
 
 PHP
 
-* 7.4.3 or higher
+* tested on 7.4.3, 8.0 and 8.1
 * `memory_limit` 512M minimum
 * `max_execution_time` 30 seconds minimum
 * Extensions:
@@ -81,9 +81,9 @@ PHP
 
 SQL
 
-* MySQL 5.7.21 or higher
+* tested on MySQL 5.7.21, and 8.0
   * Only MySQL 8.0.20 in specific is not compatible
-* MariaDB 10.3.22 or higher
+* tested on MariaDB 10.3.22, 10.4 and 10.5
   * MariaDB 10.3.29, 10.4.19, 10.5.10 are not compatible at the moment
 
 JavaScript
@@ -94,8 +94,11 @@ JavaScript
 Various
 
 * Apache 2.4 or higher with mod-rewrite enabled
+* tested on elasticsearch 7.8.0
 * Bash
 * Git
+
+Please note: we always want to support latest versions. If you find an issue with a newer version, please let us know about it in our [issue tracker](https://issues.shopware.com)
 
 ### Recommendations
 

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -81,9 +81,9 @@ PHP
 
 SQL
 
-* tested on MySQL 5.7.21, and 8.0
+* Tested on MySQL 5.7.21, and 8.0
   * Only MySQL 8.0.20 in specific is not compatible
-* tested on MariaDB 10.3.22, 10.4 and 10.5
+* Tested on MariaDB 10.3.22, 10.4 and 10.5
   * MariaDB 10.3.29, 10.4.19, 10.5.10 are not compatible at the moment
 
 JavaScript
@@ -94,7 +94,7 @@ JavaScript
 Various
 
 * Apache 2.4 or higher with mod-rewrite enabled
-* tested on elasticsearch 7.8.0
+* Tested on elasticsearch 7.8.0
 * Bash
 * Git
 


### PR DESCRIPTION
Presently, we only show min system requirements in our Documentation. Also in installation steps (when server is already running and configured), only minimum server requirements are checked.

Compatibilities with new PHP versions can only be found in change log when digging for it which is not very beginner friendly. To resolve that, the idea is to show versions that are tested in our CI. Additionally, we propose to report issues with newer versions in our issue tracker.