### PR TITLE
Fix Add cms block Storefront representation guide

### DIFF
--- a/guides/plugins/plugins/content/cms/add-cms-block.md
+++ b/guides/plugins/plugins/content/cms/add-cms-block.md
@@ -275,9 +275,9 @@ So go ahead and re-create that structure in your plugin: `<plugin root>/src/Reso
 
 In there create a new twig template named after your block, so `cms-block-image-text-reversed.html.twig` that is.
 
-Since the [original 'image\_text' file](https://github.com/shopware/platform/blob/v6.3.4.1/src/Storefront/Resources/views/storefront/block/cms-block-image-text.html.twig) is already perfectly fine, you can go ahead and extend from it in your storefront template.
+Since the [original 'image\_text' file](https://github.com/shopware/platform/blob/v6.3.4.1/src/Storefront/Resources/views/storefront/block/cms-block-my-image-text.html.twig) is already perfectly fine, you can go ahead and extend from it in your storefront template.
 
-{% code title="<plugin root>/src/Resources/views/storefront/block/cms-block-image-text-reversed.html.twig" %}
+{% code title="<plugin root>/src/Resources/views/storefront/block/cms-block-my-image-text-reversed.html.twig" %}
 {% raw %}
 ```text
 {% sw_extends '@Storefront/storefront/block/cms-block-image-text.html.twig' %}

--- a/guides/plugins/plugins/content/cms/add-cms-block.md
+++ b/guides/plugins/plugins/content/cms/add-cms-block.md
@@ -273,9 +273,9 @@ A block's storefront representation is always expected in the directory [platfor
 
 So go ahead and re-create that structure in your plugin: `<plugin root>/src/Resources/views/storefront/block/`
 
-In there create a new twig template named after your block, so `cms-block-image-text-reversed.html.twig` that is.
+In there create a new twig template named after your block, so `cms-block-my-image-text-reversed.html.twig` that is.
 
-Since the [original 'image\_text' file](https://github.com/shopware/platform/blob/v6.3.4.1/src/Storefront/Resources/views/storefront/block/cms-block-my-image-text.html.twig) is already perfectly fine, you can go ahead and extend from it in your storefront template.
+Since the [original 'image\_text' file](https://github.com/shopware/platform/blob/v6.3.4.1/src/Storefront/Resources/views/storefront/block/cms-block-image-text.html.twig) is already perfectly fine, you can go ahead and extend from it in your storefront template.
 
 {% code title="<plugin root>/src/Resources/views/storefront/block/cms-block-my-image-text-reversed.html.twig" %}
 {% raw %}


### PR DESCRIPTION
The guide contains a wrong filename that does not match the previous steps. This changes fix it.