### PR TITLE
Clear up snippet folder for those extending existing modules

### DIFF
--- a/guides/plugins/plugins/administration/adding-snippets.md
+++ b/guides/plugins/plugins/administration/adding-snippets.md
@@ -25,6 +25,10 @@ In this example you would have access the two translations by the following path
 
 By default, Shopware 6 will collect those files automatically when your plugin is activated.
 
+{% hint style="info" %}
+When you do not build a module and therefore do not fit into the suggested directory structure, you can still place the translation files anywhere in `<plugin root>/src/Resources/app/administration/`.
+{% endhint %}
+
 ## Using the snippets in JavaScript
 
 Since snippets are automatically registered in the scope of your module, you can use them directly:


### PR DESCRIPTION
I often get the question why snippets are not loaded and if it is important where they are placed although you don't have a module. Although the hint to have a structure is good, not everyone has this structure. Just mention a fact.