### PR TITLE
NEXT-15014 - Allow using Route defaults for some annotation replacement

### DIFF
--- a/guides/plugins/plugins/checkout/cart/add-cart-items.md
+++ b/guides/plugins/plugins/checkout/cart/add-cart-items.md
@@ -37,7 +37,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Shopware\Core\Checkout\Cart\Cart;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/checkout/cart/add-cart-items.md
+++ b/guides/plugins/plugins/checkout/cart/add-cart-items.md
@@ -37,7 +37,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Shopware\Core\Checkout\Cart\Cart;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/content/seo/add-custom-seo-url.md
+++ b/guides/plugins/plugins/content/seo/add-custom-seo-url.md
@@ -47,7 +47,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/content/seo/add-custom-seo-url.md
+++ b/guides/plugins/plugins/content/seo/add-custom-seo-url.md
@@ -47,7 +47,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/framework/rate-limiter/add-rate-limiter-to-api-route.md
+++ b/guides/plugins/plugins/framework/rate-limiter/add-rate-limiter-to-api-route.md
@@ -117,7 +117,7 @@ use Shopware\Core\Framework\RateLimiter\RateLimiter;
 ...
 
 /**
- * @RouteScope(scopes={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"})
  */
 class ExampleRoute extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/rate-limiter/add-rate-limiter-to-api-route.md
+++ b/guides/plugins/plugins/framework/rate-limiter/add-rate-limiter-to-api-route.md
@@ -117,7 +117,7 @@ use Shopware\Core\Framework\RateLimiter\RateLimiter;
 ...
 
 /**
- * @Route(defaults={"_routeScope"={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"}})
  */
 class ExampleRoute extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
@@ -44,7 +44,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @RouteScope(scopes={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"})
  */
 class CachedExampleRoute extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
@@ -44,7 +44,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @Route(defaults={"_routeScope"={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"}})
  */
 class CachedExampleRoute extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/store-api/add-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-store-api-route.md
@@ -60,7 +60,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"}})
  */
 class ExampleRoute extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/store-api/add-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-store-api-route.md
@@ -60,7 +60,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"})
  */
 class ExampleRoute extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/store-api/override-existing-route.md
+++ b/guides/plugins/plugins/framework/store-api/override-existing-route.md
@@ -29,7 +29,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"}})
  */
 class ExampleRouteDecorator extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/framework/store-api/override-existing-route.md
+++ b/guides/plugins/plugins/framework/store-api/override-existing-route.md
@@ -29,7 +29,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"store-api"})
+ * @Route(defaults={"_routeScope"={"store-api"})
  */
 class ExampleRouteDecorator extends AbstractExampleRoute
 {

--- a/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -33,7 +33,7 @@ use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Storefront\Controller\StorefrontController;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {
@@ -59,7 +59,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {
@@ -92,12 +92,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {
     /**
-    * @Route(defaults={"_routeScope"={"storefront"})
+    * @Route(defaults={"_routeScope"={"storefront"}})
     * @Route("/example", name="frontend.example.example", methods={"GET"})
     */
     public function showExample(): Response
@@ -188,7 +188,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -33,7 +33,7 @@ use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Storefront\Controller\StorefrontController;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {
@@ -59,7 +59,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {
@@ -92,12 +92,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {
     /**
-    * @RouteScope(scopes={"storefront"})
+    * @Route(defaults={"_routeScope"={"storefront"})
     * @Route("/example", name="frontend.example.example", methods={"GET"})
     */
     public function showExample(): Response
@@ -188,7 +188,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-custom-page.md
+++ b/guides/plugins/plugins/storefront/add-custom-page.md
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-custom-page.md
+++ b/guides/plugins/plugins/storefront/add-custom-page.md
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @RouteScope(scopes={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"})
  */
 class ExampleController extends StorefrontController
 {

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route(defaults={"_routeScope"={"storefront"})
+ * @Route(defaults={"_routeScope"={"storefront"}})
  */
 class ExampleController extends StorefrontController
 {

--- a/resources/guidelines/code/store-api.md
+++ b/resources/guidelines/code/store-api.md
@@ -4,7 +4,7 @@
 
 * Stop implementing the Sales Channel API, it will be deprecated in the 6.4 major release. Define API Controllers \(Routes\) as services. Use named Routes internally.
 * RouteScope “store-api” has to be presented.
-* The class or each API method requires the annotation: `@Route(defaults={"_routeScope"={"store-api"})`
+* The class or each API method requires the annotation: `@Route(defaults={"_routeScope"={"store-api"}})`
 * OpenApi doc is required \(`@OA`\)
 * Decorator of response extends on `StoreApiResponse`
 

--- a/resources/guidelines/code/store-api.md
+++ b/resources/guidelines/code/store-api.md
@@ -4,7 +4,7 @@
 
 * Stop implementing the Sales Channel API, it will be deprecated in the 6.4 major release. Define API Controllers \(Routes\) as services. Use named Routes internally.
 * RouteScope “store-api” has to be presented.
-* The class or each API method requires the annotation: `@RouteScope(scopes={"store-api"})`
+* The class or each API method requires the annotation: `@Route(defaults={"_routeScope"={"store-api"})`
 * OpenApi doc is required \(`@OA`\)
 * Decorator of response extends on `StoreApiResponse`
 

--- a/resources/guidelines/code/storefront-controller.md
+++ b/resources/guidelines/code/storefront-controller.md
@@ -12,7 +12,7 @@
 * Use Symfony flash bags for error reporting
 * Each storefront functionality has to be available inside the store-api too
 * A storefront controller should never contain business logic
-* The class requires the annotation: `@Route(defaults={"_routeScope"={"storefront"})`
+* The class requires the annotation: `@Route(defaults={"_routeScope"={"storefront"}})`
 * Depending services has to be injected over the class constructor
 * Depending services has to be defined in the DI-Container service definition
 * Depending services has to be assigned to a private class property

--- a/resources/guidelines/code/storefront-controller.md
+++ b/resources/guidelines/code/storefront-controller.md
@@ -12,7 +12,7 @@
 * Use Symfony flash bags for error reporting
 * Each storefront functionality has to be available inside the store-api too
 * A storefront controller should never contain business logic
-* The class requires the annotation: `@RouteScope(scopes={"storefront"})`
+* The class requires the annotation: `@Route(defaults={"_routeScope"={"storefront"})`
 * Depending services has to be injected over the class constructor
 * Depending services has to be defined in the DI-Container service definition
 * Depending services has to be assigned to a private class property


### PR DESCRIPTION
change the examples for the Route annotation from `RouteScope` that is `deprecated`

Check commit: https://github.com/shopware/platform/commit/fb623aa035897a471ef856682a5c484846de59a0