### PR TITLE
Update systemd service template

### DIFF
--- a/guides/hosting/infrastructure/message-queue.md
+++ b/guides/hosting/infrastructure/message-queue.md
@@ -70,8 +70,8 @@ PartOf=shopware_consumer.target
 Type=simple
 User=www-data # Change this to webservers user name
 Restart=always
-RestartSec=always
 # Change the path to your shop path
+WorkingDirectory=/var/www/html
 ExecStart=php /var/www/html/bin/console messenger:consume --time-limit=60 --memory-limit=512M
 
 [Install]


### PR DESCRIPTION
A missing `WorkingDirectory` led to errors with the export:  
`The stream or file "//var/log/app.log" could not be opened in append mode: failed to open stream: Permission denied`  
Reason for this is probably path traversing issues when running directly from `/var/www/html/bin` or missing `.env` variables.  
`RestartSec=always` is just plain wrong here - should be a numerical or omitted completely.