### PR TITLE
Fix input field in tutorial

### DIFF
--- a/guides/plugins/plugins/content/cms/add-cms-element.md
+++ b/guides/plugins/plugins/content/cms/add-cms-element.md
@@ -311,7 +311,7 @@ Shopware.Component.register('sw-cms-el-config-dailymotion', {
 
     computed: {
         dailyUrl() {
-            return this.element.config.dailyUrl;
+            return this.element.config.dailyUrl.value;
         }
     },
 


### PR DESCRIPTION
Following the tutorial, the sw-text-field will show [Object object] instead of the value of the config field. Added the missing property here.