### PR TITLE
Update add-custom-flow-actions-from-app-system.md

### DIFF
--- a/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md
+++ b/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md
@@ -98,7 +98,7 @@ A single flow action would look like this:
 ```xml
 <flow-action>
     <meta>
-        <name>slack_message</name>
+        <name>slackmessage</name>
         <label>Send slack message</label>
         <label lang="de-DE">Slack-Nachricht senden</label>
         <badge>Slack</badge>


### PR DESCRIPTION
Docs contain wrong examples. 

The Custom Flow loader will fail silently and nothing will be displayed.

Installation via CLI will show this error.

The value 'slack_message' is not accepted by the pattern '[a-z][a-z.]*[a-z]'. (in /app/ - line 4, column 0)