### PR TITLE
Update using-a-modal-window.md

### DIFF
--- a/guides/plugins/plugins/storefront/using-a-modal-window.md
+++ b/guides/plugins/plugins/storefront/using-a-modal-window.md
@@ -361,9 +361,9 @@ export default class ExamplePlugin extends Plugin {
         this.modal = new PseudoModalUtil(
             content,
             useBackrop,
-            'custom-js-pseudo-modal-template',
-            'custom-js-pseudo-modal-template-content-element',
-            'custom-js-pseudo-modal-template-title-element'
+            '.custom-js-pseudo-modal-template',
+            '.custom-js-pseudo-modal-template-content-element',
+            '.custom-js-pseudo-modal-template-title-element'
         );
 
         // open the modal window and make it visible


### PR DESCRIPTION
Won't work without the dot. 

Inside PseudoModalUtil this is done like this. 
        templateSelector = `.${PSEUDO_MODAL_TEMPLATE_CLASS}`,
        templateContentSelector = `.${PSEUDO_MODAL_TEMPLATE_CONTENT_CLASS}`,
        templateTitleSelector = `.${PSEUDO_MODAL_TEMPLATE_TITLE_CLASS}`,