### PR TITLE
RouteScope is gone :-)

### DIFF
--- a/guides/plugins/plugins/checkout/cart/add-cart-items.md
+++ b/guides/plugins/plugins/checkout/cart/add-cart-items.md
@@ -30,7 +30,6 @@ namespace Swag\BasicExample\Service;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItemFactoryRegistry;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Framework\Routing\StorefrontResponse;

--- a/guides/plugins/plugins/content/seo/add-custom-seo-url.md
+++ b/guides/plugins/plugins/content/seo/add-custom-seo-url.md
@@ -40,7 +40,6 @@ Let's now have a look at our example controller:
 
 namespace Swag\BasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Request;

--- a/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
@@ -38,7 +38,6 @@ use Shopware\Core\Framework\Adapter\Cache\CacheCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Routing\Annotation\Entity;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\HttpFoundation\Request;

--- a/guides/plugins/plugins/framework/store-api/add-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-store-api-route.md
@@ -58,7 +58,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Annotation\Entity;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -120,7 +119,7 @@ class ExampleRoute extends AbstractExampleRoute
 
 {% endcode %}
 
-As you can see, our class is annotated with `@RouteScope` and the defined scope `store-api`.
+As you can see, our class is annotated with `@Route` and the defined _routeScope `store-api`.
 
 In our class constructor we've injected our `swag_example.repository`. The method `getDecorated()` must throw a `DecorationPatternException` because it has no decoration yet and the method `load`, which fetches the data, returns a new `ExampleRouteResponse` with the respective repository search result as argument.
 

--- a/guides/plugins/plugins/framework/store-api/override-existing-route.md
+++ b/guides/plugins/plugins/framework/store-api/override-existing-route.md
@@ -25,7 +25,6 @@ use OpenApi\Annotations as OA;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Routing\Annotation\Entity;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
@@ -26,7 +26,6 @@ If the controller route is not to be cached for one or both of these states, the
 namespace Swag\BasicExample\Storefront\Controller;
 
 use Shopware\Storefront\Framework\Cache\Annotation\HttpCache;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Request;

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -19,7 +19,7 @@ Here's a video explaining the basics about storefront controllers from our free 
 
 ### Storefront Controller class example
 
-First of all we have to create a new controller which extends from the `StorefrontController` class. A controller is also just a service which can be registered via the service container. Furthermore, we have to define our `RouteScope` via annotation, it is used to define which domain a route is part of and **needs to be set for every route**. In our case the scope is `storefront`.
+First of all we have to create a new controller which extends from the `StorefrontController` class. A controller is also just a service which can be registered via the service container. Furthermore, we have to define our `Route` with `defaults` with `_routeScope` via annotation, it is used to define which domain a route is part of and **needs to be set for every route**. In our case the scope is `storefront`.
 
 Go ahead and create a new file `ExampleController.php` in the directory `<plugin root>/src/Storefront/Controller/`.
 
@@ -30,7 +30,6 @@ Go ahead and create a new file `ExampleController.php` in the directory `<plugin
 
 namespace Swag\BasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Storefront\Controller\StorefrontController;
 
 /**
@@ -54,7 +53,6 @@ Below you can find an example implementation of a controller method including a 
 
 namespace Swag\BasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Request;
@@ -82,7 +80,7 @@ class ExampleController extends StorefrontController
 
 The name of the method does not really matter, but it should somehow fit its purpose. More important is the `Route` annotation, that points to the route `/example`. Also note its name, which is also quite important. Make sure to use prefixes `frontend`, `api` or `store-api` here, depending on what your route does. Inside the method, we're using the method `renderStorefront` to render a twig template file in addition with the template variable `example`, which contains `Hello world`. This template variable will be usable in the rendered template file. The method `renderStorefront` then returns a `Response`, as every routed controller method has to.
 
-It is also possible to define the `RouteScope` per route.
+It is also possible to define the `_routeScope` per route.
 
 {% code title="<plugin root>/src/Storefront/Controller/ExampleController.php" %}
 
@@ -91,7 +89,6 @@ It is also possible to define the `RouteScope` per route.
 
 namespace Swag\BasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -102,8 +99,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ExampleController extends StorefrontController
 {
     /**
-    * @Route(defaults={"_routeScope"={"storefront"}})
-    * @Route("/example", name="frontend.example.example", methods={"GET"})
+    * @Route("/example", name="frontend.example.example", methods={"GET"}, defaults={"_routeScope"={"storefront"}})
     */
     public function showExample(): Response
     {
@@ -193,7 +189,6 @@ Here's an example:
 
 namespace Swag\BasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Request;

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -19,7 +19,7 @@ Here's a video explaining the basics about storefront controllers from our free 
 
 ### Storefront Controller class example
 
-First of all we have to create a new controller which extends from the `StorefrontController` class. A controller is also just a service which can be registered via the service container. Furthermore, we have to define our `Route` with `defaults` with `_routeScope` via annotation, it is used to define which domain a route is part of and **needs to be set for every route**. In our case the scope is `storefront`.
+First of all we have to create a new controller which extends from the `StorefrontController` class. A controller is also just a service which can be registered via the service container. Furthermore, we have to define our `Route` with `defaults` and `_routeScope` via annotation, it is used to define which domain a route is part of and **needs to be set for every route**. In our case the scope is `storefront`.
 
 Go ahead and create a new file `ExampleController.php` in the directory `<plugin root>/src/Storefront/Controller/`.
 

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -21,6 +21,10 @@ Here's a video explaining the basics about storefront controllers from our free 
 
 First of all we have to create a new controller which extends from the `StorefrontController` class. A controller is also just a service which can be registered via the service container. Furthermore, we have to define our `Route` with `defaults` and `_routeScope` via annotation, it is used to define which domain a route is part of and **needs to be set for every route**. In our case the scope is `storefront`.
 
+{% hint style="info" %}
+Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annotation: `@RouteScope`. This way of defining the route scope is deprecated for the 6.5 major version.
+{% endhint %}
+
 Go ahead and create a new file `ExampleController.php` in the directory `<plugin root>/src/Storefront/Controller/`.
 
 {% code title="<plugin root>/src/Storefront/Controller/ExampleController.php" %}

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -82,6 +82,10 @@ The name of the method does not really matter, but it should somehow fit its pur
 
 It is also possible to define the `_routeScope` per route.
 
+{% hint style="info" %}
+Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annotation: `@RouteScope`. This way of defining the route-scope is deprecated for the 6.5 major version.
+{% endhint %}
+
 {% code title="<plugin root>/src/Storefront/Controller/ExampleController.php" %}
 
 ```php

--- a/guides/plugins/plugins/storefront/add-custom-page.md
+++ b/guides/plugins/plugins/storefront/add-custom-page.md
@@ -23,7 +23,6 @@ Let's have a look at an example controller.
 
 namespace Swag\BasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -24,7 +24,6 @@ As mentioned before this guide builds up upon the [adding a custom controller](a
 
 namespace SwagBasicExample\Storefront\Controller;
 
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Storefront\Controller\StorefrontController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;

--- a/resources/guidelines/code/store-api.md
+++ b/resources/guidelines/code/store-api.md
@@ -3,7 +3,6 @@
 ## Routes
 
 * Stop implementing the Sales Channel API, it will be deprecated in the 6.4 major release. Define API Controllers \(Routes\) as services. Use named Routes internally.
-* RouteScope “store-api” has to be presented.
 * The class or each API method requires the annotation: `@Route(defaults={"_routeScope"={"store-api"}})`
 * OpenApi doc is required \(`@OA`\)
 * Decorator of response extends on `StoreApiResponse`


### PR DESCRIPTION
fix: remove superfluous uses of RouteScope, update
fix: remove wrong annotation of multiple @Route


Basically come into it because this coming from docs is really invalid:
```
* @Route(defaults={"_routeScope"={"storefront"}})
* @Route("/example", name="frontend.example.example", methods={"GET"})
```