### PR TITLE
Fix App Icon path

### DIFF
--- a/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md
+++ b/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md
@@ -62,7 +62,7 @@ The manifest file is the central point of your app. It defines the interface bet
         <author>shopware AG</author>
         <copyright>(c) shopware AG</copyright>
         <version>4.14.0</version>
-        <icon>Resources/app.png</icon>
+        <icon>Resources/app-icon.png</icon>
         <license>MIT</license>
     </meta>
 </manifest>


### PR DESCRIPTION
The Folder structure right above the manifest.xml shows, that the icon is actually called app-icon.png and not app.png. This might be confusing.
![image](https://user-images.githubusercontent.com/88590092/184134289-98782af2-962e-4826-bc60-c2a05d38ed3a.png)
