### PR TITLE
Update overview.md to use `trunk` as default branch

### DIFF
--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -159,7 +159,7 @@ You now have the application template for Shopware 6 in the directory `developme
 cd development
 ```
 
-Per default the development template has `shopware/platform` in the version `dev-master` as requirement in its `composer.json` file. This always corresponds to the latest commit on the master branch on GitHub. If you want to use a specific version change `dev-master` to `6.1` for example. Now Shopware 6.1 will be installed instead of the latest master state.
+Per default the development template has `shopware/platform` in the version `dev-trunk` as requirement in its `composer.json` file. This always corresponds to the latest commit on the master branch on GitHub. If you want to use a specific version change `dev-trunk` to `6.1` for example. Now Shopware 6.1 will be installed instead of the latest master state.
 
 Only if you want to work with the Shopware platform code itself, e.g. in order to create a pull request for it, you should clone the `platform` code manually. Before doing so, remove the existing platform directory.
 

--- a/guides/installation/overview.md
+++ b/guides/installation/overview.md
@@ -159,7 +159,7 @@ You now have the application template for Shopware 6 in the directory `developme
 cd development
 ```
 
-Per default the development template has `shopware/platform` in the version `dev-trunk` as requirement in its `composer.json` file. This always corresponds to the latest commit on the master branch on GitHub. If you want to use a specific version change `dev-trunk` to `6.1` for example. Now Shopware 6.1 will be installed instead of the latest master state.
+By default, the development template has `shopware/platform` in the version `dev-trunk` as a requirement in its `composer.json` file. This always corresponds to the latest commit on the master branch of GitHub. You can also change to a specific version — for example, `dev-trunk` to `6.1`. Now Shopware 6.1 will be installed instead of the latest master state.
 
 Only if you want to work with the Shopware platform code itself, e.g. in order to create a pull request for it, you should clone the `platform` code manually. Before doing so, remove the existing platform directory.
 


### PR DESCRIPTION
The docs should reflect the use of the `trunk` branch instead of `master`.