### PR TITLE
fix: condition decorator file name

### DIFF
--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -102,7 +102,7 @@ $context->getRuleIds();
 
 Now we want to implement our new rule in the administration so that we can manage it. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/platform/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by decorating this service. The decoration of services in the administration will be covered in our [Adding services](../../administration/add-custom-service.md#Decorating%20a%20service) guide.
 
-Create a new directory called `<plugin root>/src/Resources/app/administration/src/decorator`. In this directory we create a new file called `rule-condition-service-decoration.js`.
+Create a new directory called `<plugin root>/src/Resources/app/administration/src/decorator`. In this directory we create a new file called `condition-type-data-provider.decorator.js`.
 
 {% code title="<plugin root>src/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.js" %}
 

--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -130,7 +130,7 @@ We also have to create a `main.js` file in our administration sources directory 
 {% code title="<plugin root>/src/Resources/app/administration/src/main.js" %}
 
 ```javascript
-import './decorator/rule-condition-service-decoration';
+import './decorator/condition-type-data-provider.decorator';
 ```
 
 {% endcode %}


### PR DESCRIPTION
The name of the JS file for adding the condition to administration seems to be `condition-type-data-provider.decorator.js` as written in the code example.

I'm new to Shopware development. My rule showed up in administration after I changed the file name.
Which does not really make sense as I believe this to be actually dependent on how the file is included in main.js.

However Shopify Core rules also name the file `condition-type-data-provider.decorator.js`, so I guess docs should be consistent here.