### PR TITLE
Add hint to add EntityCustomFieldsTrait

### DIFF
--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -21,16 +21,50 @@ Also, adding translatable custom fields is covered here in short as well, for wh
 
 This short section will cover how to add a custom field support for your custom entity. As previously mentioned, the example from our [Add custom complex data](../data-handling/add-custom-complex-data.md) guide is used and extended here.
 
-In order to support custom fields with your custom entity, there are two steps necessary:
+In order to support custom fields with your custom entity, there are three steps necessary:
 
+* Add `EntityCustomFieldsTrait` trait to your `Entity`
 * Add a `CustomFields` field to your `EntityDefinition`
 * Add a column `custom_fields` to your entities' database table via migration
 
 Also, you may want to add translatable custom fields, which is also covered in very short here.
 
+### Add custom field to entity
+
+{% hint style="info" %}
+  Available starting with Shopware 6.4.1.0.
+{% endhint %}
+
+Let's assume you already got a working and running entity definition.
+If you want to support custom fields with your custom entity,
+you may add the `EntityCustomFieldsTrait` to your entity class, so the methods
+`getCustomFields()` and `setCustomFields()` can be used.
+
+{% code title="<plugin root>/src/Core/Content/Example/ExampleEntity.php" %}
+
+```php
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+
+[...]
+class ExampleEntity extends Entity
+{
+    use EntityIdTrait;
+    use EntityCustomFieldsTrait;
+
+    [...]
+
+}
+```
+
+{% endcode %}
+
 ### Add custom field to entity definition
 
-Let's assume you already got a working and running entity definition. If you want to support custom fields with your custom entity, you have to add the Data Abstraction Layer \(DAL\) field `CustomFields` to it.
+Now follows the important parts. For this to work at all, you have to add the
+Data Abstraction Layer \(DAL\) field `CustomFields` to your entity definition.
 
 {% code title="<plugin root>/src/Core/Content/Example/ExampleDefinition.php" %}
 

--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -35,10 +35,7 @@ Also, you may want to add translatable custom fields, which is also covered in v
   Available starting with Shopware 6.4.1.0.
 {% endhint %}
 
-Let's assume you already got a working and running entity definition.
-If you want to support custom fields with your custom entity,
-you may add the `EntityCustomFieldsTrait` to your entity class, so the methods
-`getCustomFields()` and `setCustomFields()` can be used.
+Let's assume you already got a working and running entity definition. If you want to support custom fields with your custom entity, you may add the `EntityCustomFieldsTrait` to your entity class, so the methods `getCustomFields()` and `setCustomFields()` can be used.
 
 {% code title="<plugin root>/src/Core/Content/Example/ExampleEntity.php" %}
 

--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -63,8 +63,7 @@ class ExampleEntity extends Entity
 
 ### Add custom field to entity definition
 
-Now follows the important parts. For this to work at all, you have to add the
-Data Abstraction Layer \(DAL\) field `CustomFields` to your entity definition.
+Now follows the important part. For this to work, you have to add the Data Abstraction Layer \(DAL\) field `CustomFields` to your entity definition.
 
 {% code title="<plugin root>/src/Core/Content/Example/ExampleDefinition.php" %}
 

--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -21,11 +21,11 @@ Also, adding translatable custom fields is covered here in short as well, for wh
 
 This short section will cover how to add a custom field support for your custom entity. As previously mentioned, the example from our [Add custom complex data](../data-handling/add-custom-complex-data.md) guide is used and extended here.
 
-In order to support custom fields with your custom entity, there are three steps necessary:
+In order to support custom fields with your custom entity, there are three necessary steps :
 
-* Add `EntityCustomFieldsTrait` trait to your `Entity`
-* Add a `CustomFields` field to your `EntityDefinition`
-* Add a column `custom_fields` to your entities' database table via migration
+* Add `EntityCustomFieldsTrait` trait to your `Entity`.
+* Add a `CustomFields` field to your `EntityDefinition`.
+* Add a column `custom_fields` to your entities' database table via migration.
 
 Also, you may want to add translatable custom fields, which is also covered in very short here.
 


### PR DESCRIPTION
I recently wanted to use custom fields on a custom entity, but was confused.

Everything uses the methods `getCustomFields()` and `setCustomFields()`, but those weren't present on my entity. I double-checked the docs, but everything seemed ok.

So I looked at the core code and noticed this trait. Hope this addition helps some person in the future.