### PR TITLE
Add documentation for afterOrderEnabled property

### DIFF
--- a/guides/plugins/plugins/checkout/payment/add-payment-plugin.md
+++ b/guides/plugins/plugins/checkout/payment/add-payment-plugin.md
@@ -443,6 +443,9 @@ class SwagBasicExample extends Plugin
             'name' => 'Example payment',
             'description' => 'Example payment description',
             'pluginId' => $pluginId,
+            // if true, payment method will also be available after the order 
+            // is created, e.g. if payment fails and the user wants to try again
+            'afterOrderEnabled' => true,
         ];
 
         /** @var EntityRepositoryInterface $paymentRepository */


### PR DESCRIPTION
It took me a couple of hours to figure out why custom payment methods disappeared when retrying payments. I don't know if this is the best place to document it, but I couldn't find it anywhere else and since this is the guide most people will use when creating payment methods I think it should be included.