### PR TITLE
allow clientsite caching of static assets

### DIFF
--- a/guides/hosting/infrastructure/reverse-http-cache.md
+++ b/guides/hosting/infrastructure/reverse-http-cache.md
@@ -426,6 +426,11 @@ sub vcl_backend_response {
 sub vcl_deliver {
     ## we don't want the client to cache
     set resp.http.Cache-Control = "max-age=0, private";
+    
+    #caching static assets is fine through
+    if (req.url ~ "\.(jpg|jpeg|png|gif|css|js|woff|woff2|svg|eot|webp)$") {
+        set resp.http.Cache-Control = "max-age=2592000, public";
+    }
 
     # remove link header, if session is already started to save client resources
     if (req.http.cookie ~ "session-") {


### PR DESCRIPTION
I don't see any reason why clients (and proxies) should now be allowed to cache static assets