### PR TITLE
NEXT-25714 - New DocumentRenderer documentation

### DIFF
--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -336,7 +336,7 @@ Here's what the function does:
 * If an error occurs, the exception is caught and the error message is added to the `RendererResult` object as an error.
 * `The RendererResult` object is returned.
 
-In this example we're rendering a specific template, which we will have a short look at in the next section.
+In this example, we are rendering a specific template, which we will have a look at in the next section.
 
 ### Adding a document type template
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -321,9 +321,9 @@ The `supports` method just returns the string "example", which is the technical 
 
 Now let's have a look at the `render` method. This function contains three parameters:
 
-* $operations: An array of `DocumentGenerateOperation` objects.
-* $context: A Context object.
-* $rendererConfig: A `DocumentRendererConfig` object, so we can add additional configuration later.
+* `$operations`: An array of `DocumentGenerateOperation` objects.
+* `$context`: A Context object.
+* `$rendererConfig`: A `DocumentRendererConfig` object, so we can add additional configuration later.
 
 The function returns a `RendererResult` object.
 Here's what the function does:

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -358,7 +358,7 @@ This could be it already. The [base.html.twig](https://github.com/shopware/platf
 
 ## Adding a number range
 
-You're almost done here. You've got a new document type in the database, a renderer for your new document type, and it even uses a custom template. However, you also need to add a new number range for your documents, otherwise a new number for your documents wouldn't be generated.
+You are almost done here. You have a new document type in the database, a renderer for your new document type, and it even uses a custom template. However, you also need to add a new number range for your documents; otherwise, a new number wouldn't be generated for your documents.
 
 Adding a new number range is also done by using a [plugin database migration](../../plugin-fundamentals/database-migrations.md).
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -8,7 +8,7 @@ Using the Shopware Administration, you can easily create new documents. This gui
 
 This guide is built upon the [plugin base guide](../../plugin-base-guide.md), but of course you can use those examples with any other plugin.
 
-Furthermore, adding a custom document type via your plugin is done by using [plugin database migrations](../../plugin-fundamentals/database-migrations.md). Since this isn't explained in this guide, you'll have to know and understand the plugin database migrations first.
+Furthermore, adding a custom document type via your plugin is done by using [plugin database migrations](../../plugin-fundamentals/database-migrations.md). Since this isn't explained in this guide, you will have to know and understand the plugin database migrations first.
 
 ## Adding a custom document type, and its own base configuration to the database
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -333,7 +333,7 @@ Here's what the function does:
 * A search is performed on the order repository to find all orders by `$ids`.
 * For each order found, the function attempts to generate a document.
 * If successful, a new `RenderedDocument` object is created. This object is then added to the `RendererResult` object as a success.
-* If an error occurs, an exception is caught, error message are added to the `RendererResult` object as an error.
+* If an error occurs, the exception is caught and the error message is added to the `RendererResult` object as an error.
 * `The RendererResult` object is returned.
 
 In this example we're rendering a specific template, which we will have a short look at in the next section.

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -503,7 +503,7 @@ As already said, we're first creating the entries in the tables `number_range`, 
 
 Afterwards we import the translations for the `number_range_translation` and the `number_range_type_translation` tables by using the `ImportTranslationsTrait` once again.
 
-And that's it now! You've just created:
+And that's it now. You Have just created:
 
 * A custom document type, including translations
 * A custom document renderer

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -315,7 +315,7 @@ class ExampleDocumentRenderer extends AbstractDocumentRenderer
 
 {% endcode %}
 
-First we're injecting the `rootDir` of the Shopware installation into our renderer, since we'll need that for rendering our template, and the `DocumentTemplateRenderer`, which will do the template rendering. We also inject `orderRepository` to get all order entity by list of order's id, `documentConfigLoader` to load the document configuration and `numberRangeValueGenerator` to get the document number
+First, we are injecting the `rootDir` of the Shopware installation into our renderer since we will need that for rendering our template, and the `DocumentTemplateRenderer`, which will do the template rendering. We also inject `orderRepository` to get all order entities by list of order's id, `documentConfigLoader` to load the document configuration and `numberRangeValueGenerator` to get the document number
 
 The `supports` method just returns the string "example", which is the technical name of our new document type.
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -138,7 +138,7 @@ class Migration1616677952AddDocumentType extends MigrationStep
 
 {% endcode %}
 
-So first we're creating the new document type with the `technical_name` "example". Make sure to save the ID here, since you're going to need it for the following translations.
+So first, we are creating the new document type with the `technical_name` as "example". Make sure to save the ID here since you are going to need it for the following translations:
 
 Afterwards we're inserting the translations, one for German, one for English. For this we're using the `Shopware\Core\Migration\Traits\ImportTranslationsTrait`, which adds the helper method `importTranslation`. There you have to supply the translation table and an instance of `Shopware\Core\Migration\Traits\Translations`. The latter accepts two constructor parameters:
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -328,7 +328,7 @@ Now let's have a look at the `render` method. This function contains three param
 The function returns a `RendererResult` object.
 Here's what the function does:
 
-* It creates an array `$ids` which is populated with the `orderId` of each `DocumentGenerateOperation` object in $operations.
+* It creates an array of `$ids`, which is populated with the `orderId` of each `DocumentGenerateOperation` object in $operations.
 * If `$ids` is empty, the function returns an empty `RendererResult` object.
 * A search is performed on the order repository to find all orders by `$ids`.
 * For each order found, the function attempts to generate a document.

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -153,7 +153,7 @@ After installing your plugin, your new document type should be available in the 
 
 ## Adding a renderer
 
-The renderer for a document type is responsible for actually rendering the respective document, including a template. That's why we'll have to create a custom renderer for the new type as well, we'll call it `ExampleDocumentRenderer`.
+The renderer for a document type is responsible for rendering the respective document, including a template. That is why we will have to create a custom renderer for the new type as well, lets call it `ExampleDocumentRenderer`.
 
 We'll place it in the same directory as all other default document renderers: `<plugin root>/src/Core/Checkout/Document/Renderer`
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -147,7 +147,7 @@ Afterwards we're inserting the translations, one for German, one for English. Fo
 
   It will then take care of properly inserting those translations.
 
-And the last, We're creating the new document base configuration for the new document type to store some default configuration for out new document type.
+And the last, We are creating the new document base configuration for the new document type to store some default configurations for our new document type.
 
 After installing your plugin, your new document type should be available in the Administration. However, it wouldn't work yet, since every document type has to come with a respective `AbstractDocumentRenderer`. This is covered in the next section.
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -155,7 +155,7 @@ After installing your plugin, your new document type should be available in the 
 
 The renderer for a document type is responsible for rendering the respective document, including a template. That is why we will have to create a custom renderer for the new type as well, lets call it `ExampleDocumentRenderer`.
 
-We'll place it in the same directory as all other default document renderers: `<plugin root>/src/Core/Checkout/Document/Renderer`
+We will place it in the same directory as all other default document renderers: `<plugin root>/src/Core/Checkout/Document/Renderer`
 
 Your custom document renderer has to implement the `Shopware\Core\Checkout\Document\Renderer\AbstractDocumentRenderer`, which forces you to implement three methods:
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -8,9 +8,9 @@ Using the Shopware Administration, you can easily create new documents. This gui
 
 This guide is built upon the [plugin base guide](../../plugin-base-guide.md), but of course you can use those examples with any other plugin.
 
-Furthermore adding a custom document type via your plugin is done by using [plugin database migrations](../../plugin-fundamentals/database-migrations.md). Since this isn't explained in this guide, you'll have to know and understand the plugin database migrations first.
+Furthermore, adding a custom document type via your plugin is done by using [plugin database migrations](../../plugin-fundamentals/database-migrations.md). Since this isn't explained in this guide, you'll have to know and understand the plugin database migrations first.
 
-## Adding a custom document type to the database
+## Adding a custom document type, and its own base configuration to the database
 
 Let's start with adding your custom document type to the database, so it's actually available for new document configurations. This is done by adding a plugin database migration. To be precise, we need to add an entry to the database table `document_type` table and an entry for each supported language to the `document_type_translation` table.
 
@@ -33,7 +33,9 @@ use Shopware\Core\Migration\Traits\Translations;
 class Migration1616677952AddDocumentType extends MigrationStep
 {
     use ImportTranslationsTrait;
-
+    
+    final public const TYPE = 'example';
+    
     public function getCreationTimestamp(): int
     {
         return 1616677952;
@@ -45,11 +47,12 @@ class Migration1616677952AddDocumentType extends MigrationStep
 
         $connection->insert('document_type', [
             'id' => $documentTypeId,
-            'technical_name' => 'example',
+            'technical_name' => self::TYPE,
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)
         ]);
 
         $this->addTranslations($connection, $documentTypeId);
+        $this->addDocumentBaseConfig($connection, $documentTypeId);
     }
 
     public function updateDestructive(Connection $connection): void
@@ -78,12 +81,64 @@ class Migration1616677952AddDocumentType extends MigrationStep
             $connection
         );
     }
+    
+    private function addDocumentBaseConfig(Connection $connection, string $documentTypeId): void
+    {
+        $defaultConfig = [
+            'displayPrices' => true,
+            'displayFooter' => true,
+            'displayHeader' => true,
+            'displayLineItems' => true,
+            'diplayLineItemPosition' => true,
+            'displayPageCount' => true,
+            'displayCompanyAddress' => true,
+            'pageOrientation' => 'portrait',
+            'pageSize' => 'a4',
+            'itemsPerPage' => 10,
+            'companyName' => 'Example Company',
+            'taxNumber' => '',
+            'vatId' => '',
+            'taxOffice' => '',
+            'bankName' => '',
+            'bankIban' => '',
+            'bankBic' => '',
+            'placeOfJurisdiction' => '',
+            'placeOfFulfillment' => '',
+            'executiveDirector' => '',
+            'companyAddress' => '',
+            'referencedDocumentType' => self::TYPE,
+        ];
+
+        $documentBaseConfigId = Uuid::randomBytes();
+
+        $connection->insert(
+            'document_base_config',
+            [
+                'id' => $documentBaseConfigId,
+                'name' => self::TYPE,
+                'global' => 1,
+                'filename_prefix' => self::TYPE . '_',
+                'document_type_id' => $documentTypeId,
+                'config' => json_encode($defaultConfig, \JSON_THROW_ON_ERROR),
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+        $connection->insert(
+            'document_base_config_sales_channel',
+            [
+                'id' => Uuid::randomBytes(),
+                'document_base_config_id' => $documentBaseConfigId,
+                'document_type_id' => $documentTypeId,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+    }
 }
 ```
 
 {% endcode %}
 
-So first of all we're creating the new document type with the `technical_name` "example". Make sure to save the ID here, since you're going to need it for the following translations.
+So first we're creating the new document type with the `technical_name` "example". Make sure to save the ID here, since you're going to need it for the following translations.
 
 Afterwards we're inserting the translations, one for German, one for English. For this we're using the `Shopware\Core\Migration\Traits\ImportTranslationsTrait`, which adds the helper method `importTranslation`. There you have to supply the translation table and an instance of `Shopware\Core\Migration\Traits\Translations`. The latter accepts two constructor parameters:
 
@@ -92,97 +147,196 @@ Afterwards we're inserting the translations, one for German, one for English. Fo
 
   It will then take care of properly inserting those translations.
 
-After installing your plugin, your new document type should be available in the Administration. However, it wouldn't work yet, since every document type has to come with a respective `DocumentGeneratorInterface`. This is covered in the next section.
+And the last, We're creating the new document base configuration for the new document type to store some default configuration for out new document type.
 
-## Adding a generator
+After installing your plugin, your new document type should be available in the Administration. However, it wouldn't work yet, since every document type has to come with a respective `AbstractDocumentRenderer`. This is covered in the next section.
 
-The generator for a document type is responsible for actually generating the respective document, including a template. That's why we'll have to create a custom generator for the new type as well, we'll call it `ExampleDocumentGenerator`.
+## Adding a renderer
 
-We'll place it in the same directory like all other default document generators: `<plugin root>/src/Core/Checkout/Document/DocumentGenerator`
+The renderer for a document type is responsible for actually rendering the respective document, including a template. That's why we'll have to create a custom renderer for the new type as well, we'll call it `ExampleDocumentRenderer`.
 
-Your custom document generator has to implement the `Shopware\Core\Checkout\Document\DocumentGenerator\DocumentGeneratorInterface`, which forces you to implement two more methods:
+We'll place it in the same directory as all other default document renderers: `<plugin root>/src/Core/Checkout/Document/Renderer`
 
-* `supports`: Has to return a string of the document type it supports. We named our document type "example", so our generator has to return "example".
-* `generate`: This needs to return the actually rendered template as a string. You will have access to the respective order, the document configuration,
+Your custom document renderer has to implement the `Shopware\Core\Checkout\Document\Renderer\AbstractDocumentRenderer`, which forces you to implement three methods:
 
-  the context and the optional template path.
+* `getDecorated`: Shall return the decorated service (see decoration pattern adr).
+* `supports`: Has to return a string of the document type it supports. We named our document type "example", so our renderer has to return "example".
+* `render`: This needs to return the instance `Shopware\Core\Checkout\Document\Renderer\RendererResult`, which will contain the instance of `Shopware\Core\Checkout\Document\Renderer\RenderedDocument` based on each `orderId`. You will have access to the array of `DocumentGenerateOperation` which contains all respective orderIds, the context and the instance of `Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig` (additional configuration).
 
-* `getFileName`: Return the file name here. This is basically the same for all generators, but if you want to do custom stuff
+Furthermore, your renderer has to be registered to the [service container](../../plugin-fundamentals/dependency-injection.md) using the tag `document.renderer`.
 
-  with the file name, this is the place to go.
+Let's have a look at an example renderer:
 
-Furthermore your generator has to be registered to the [service container](../../plugin-fundamentals/dependency-injection.md) using the tag `document.generator`.
-
-Let's have a look at an example generator:
-
-{% code title="<plugin root>/src/Core/Checkout/Document/DocumentGenerator/ExampleDocumentGenerator.php" %}
+{% code title="<plugin root>/src/Core/Checkout/Document/Render/ExampleDocumentRenderer.php" %}
 
 ```php
 <?php declare(strict_types=1);
 
-namespace Swag\BasicExample\Core\Checkout\Document\DocumentGenerator;
+namespace Swag\BasicExample\Core\Checkout\Document\Render;
 
-use Shopware\Core\Checkout\Document\DocumentConfiguration;
-use Shopware\Core\Checkout\Document\DocumentConfigurationFactory;
-use Shopware\Core\Checkout\Document\DocumentGenerator\DocumentGeneratorInterface;
+use Shopware\Core\Checkout\Document\Renderer\AbstractDocumentRenderer;
+use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
+use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
+use Shopware\Core\Checkout\Document\Renderer\RendererResult;
+use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
+use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
-use Twig\Error\Error;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\Locale\LocaleEntity;
+use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 
-class ExampleDocumentGenerator implements DocumentGeneratorInterface
+class ExampleDocumentRenderer extends AbstractDocumentRenderer
 {
     public const DEFAULT_TEMPLATE = '@SwagBasicExample/documents/example_document.html.twig';
-    public const EXAMPLE_DOC = 'example';
 
-    private string $rootDir;
+    final public const TYPE = 'example';
 
-    private DocumentTemplateRenderer $documentTemplateRenderer;
-
-    public function __construct(DocumentTemplateRenderer $documentTemplateRenderer, string $rootDir)
-    {
-        $this->rootDir = $rootDir;
-        $this->documentTemplateRenderer = $documentTemplateRenderer;
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly EntityRepository $orderRepository,
+        private readonly DocumentConfigLoader $documentConfigLoader,
+        private readonly DocumentTemplateRenderer $documentTemplateRenderer,
+        private readonly NumberRangeValueGeneratorInterface $numberRangeValueGenerator,
+        private readonly string $rootDir,
+    ) {
     }
 
     public function supports(): string
     {
-        return self::EXAMPLE_DOC;
+        return self::TYPE;
     }
 
     /**
-     * @throws Error
+     * @param array<DocumentGenerateOperation> $operations
      */
-    public function generate(OrderEntity $order, DocumentConfiguration $config, Context $context, ?string $templatePath = null): string
+    public function render(array $operations, Context $context, DocumentRendererConfig $rendererConfig): RendererResult
     {
-        $templatePath = $templatePath ?? self::DEFAULT_TEMPLATE;
+        $ids = \array_map(fn (DocumentGenerateOperation $operation) => $operation->getOrderId(), $operations);
 
-        return $this->documentTemplateRenderer->render($templatePath, [
-            'order' => $order,
-            'config' => DocumentConfigurationFactory::mergeConfiguration($config, new DocumentConfiguration())->jsonSerialize(),
-            'rootDir' => $this->rootDir,
-            'context' => $context,
-        ], $context, $order->getSalesChannelId(), $order->getLanguageId(), $order->getLanguage()->getLocale()->getCode());
+        if (empty($ids)) {
+            return new RendererResult();
+        }
+
+        $result = new RendererResult();
+
+        $template = self::DEFAULT_TEMPLATE;
+
+        $orders = $this->orderRepository->search(new Criteria($ids), $context)->getEntities();
+        foreach ($orders as $order) {
+            $orderId = $order->getId();
+
+            try {
+                $operation = $operations[$orderId] ?? null;
+                if ($operation === null) {
+                    continue;
+                }
+
+                $config = clone $this->documentConfigLoader->load(self::TYPE, $order->getSalesChannelId(), $context);
+
+                $config->merge($operation->getConfig());
+
+                $number = $config->getDocumentNumber() ?: $this->getNumber($context, $order, $operation);
+
+                $now = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+                $config->merge([
+                    'documentDate' => $operation->getConfig()['documentDate'] ?? $now,
+                    'documentNumber' => $number,
+                    'custom' => [
+                        'invoiceNumber' => $number,
+                    ],
+                ]);
+
+                // The document that uploaded by manual
+                if ($operation->isStatic()) {
+                    $doc = new RenderedDocument('', $number, $config->buildName(), $operation->getFileType(), $config->jsonSerialize());
+                    $result->addSuccess($orderId, $doc);
+
+                    continue;
+                }
+
+                /** @var LocaleEntity $locale */
+                $locale = $order->getLanguage()->getLocale();
+
+                $html = $this->documentTemplateRenderer->render(
+                    $template,
+                    [
+                        'order' => $order,
+                        'config' => $config,
+                        'rootDir' => $this->rootDir,
+                        'context' => $context,
+                    ],
+                    $context,
+                    $order->getSalesChannelId(),
+                    $order->getLanguageId(),
+                    $locale->getCode()
+                );
+
+                $doc = new RenderedDocument(
+                    $html,
+                    $number,
+                    $config->buildName(),
+                    $operation->getFileType(),
+                    $config->jsonSerialize(),
+                );
+
+                $result->addSuccess($orderId, $doc);
+            } catch (\Throwable $exception) {
+                $result->addError($orderId, $exception);
+            }
+        }
+
+        return $result;
     }
 
-    public function getFileName(DocumentConfiguration $config): string
+    public function getDecorated(): AbstractDocumentRenderer
     {
-        return $config->getFilenamePrefix() . $config->getDocumentNumber() . $config->getFilenameSuffix();
+        throw new DecorationPatternException(self::class);
+    }
+
+    private function getNumber(Context $context, OrderEntity $order, DocumentGenerateOperation $operation): string
+    {
+        return $this->numberRangeValueGenerator->getValue(
+            'document_' . self::TYPE,
+            $context,
+            $order->getSalesChannelId(),
+            $operation->isPreview()
+        );
     }
 }
 ```
 
 {% endcode %}
 
-First of all we're injecting the `rootDir` of the Shopware installation into our generator, since we'll need that for rendering our template, and the `DocumentTemplateRenderer`, which will do the template rendering.
+First we're injecting the `rootDir` of the Shopware installation into our renderer, since we'll need that for rendering our template, and the `DocumentTemplateRenderer`, which will do the template rendering. We also inject `orderRepository` to get all order entity by list of order's id, `documentConfigLoader` to load the document configuration and `numberRangeValueGenerator` to get the document number
 
-The `supports` method just returns the string "example", which is the technical name of our new document type. The `getFileName` method is very default - it just builds a string consisting of the file name prefix, that you configured, the current document number and the file name suffix.
+The `supports` method just returns the string "example", which is the technical name of our new document type.
 
-Now let's have a look at the `generate` method. Technically it's possible to apply a custom template path, which is why this is an optional parameter, which we have to check for. Yet, it can't be defined in the Administration and will most likely be empty. We're using a default template path here, which has to point to a template file for our new document type. This can be an existing default document template, in that case you can use them via the following path: `@Framework/documents/delivery_note.html.twig`
+Now let's have a look at the `render` method. This function contains three parameters:
 
-In this example we're rendering a custom template though, which we will have a short look at in the next section.
+* $operations: An array of `DocumentGenerateOperation` objects.
+* $context: A Context object.
+* $rendererConfig: A `DocumentRendererConfig` object, so we can add additional configuration later.
 
-Afterwards we're using the previously injected `DocumentTemplateRenderer` to actually render and return the template at the said template path.
+The function returns a `RendererResult` object.
+Here's what the function does:
+
+* It creates an array `$ids` which is populated with the `orderId` of each `DocumentGenerateOperation` object in $operations.
+* If `$ids` is empty, the function returns an empty `RendererResult` object.
+* A search is performed on the order repository to find all orders by `$ids`.
+* For each order found, the function attempts to generate a document.
+* If successful, a new `RenderedDocument` object is created. This object is then added to the `RendererResult` object as a success.
+* If an error occurs, an exception is caught, error message are added to the `RendererResult` object as an error.
+* `The RendererResult` object is returned.
+
+In this example we're rendering a specific template, which we will have a short look at in the next section.
 
 ### Adding a document type template
 
@@ -204,7 +358,7 @@ This could be it already. The [base.html.twig](https://github.com/shopware/platf
 
 ## Adding a number range
 
-You're almost done here. You've got a new document type in the database, a generator for your new document type and it even uses a custom template. However, you also need to add a new number range for your documents, otherwise a new number for your documents wouldn't be generated.
+You're almost done here. You've got a new document type in the database, a renderer for your new document type, and it even uses a custom template. However, you also need to add a new number range for your documents, otherwise a new number for your documents wouldn't be generated.
 
 Adding a new number range is also done by using a [plugin database migration](../../plugin-fundamentals/database-migrations.md).
 
@@ -352,7 +506,7 @@ Afterwards we import the translations for the `number_range_translation` and the
 And that's it now! You've just created:
 
 * A custom document type, including translations
-* A custom document generator, including a custom template
+* A custom document renderer
 * A custom number range and number range type, which will now be used by your custom document type
 
 ## Next steps


### PR DESCRIPTION
We rewrote the whole document generation for v6.5.0, but the new system needs to be better documented.

 1. In the docs, the old system is still documented; we need to adapt this page to the new system
 2. We should update the upgrade guide manually in 6.5.0.0 and add more explanations of what to do