### PR TITLE
refactor: Remove module.hot.accept()

### DIFF
--- a/guides/plugins/plugins/storefront/override-existing-javascript.md
+++ b/guides/plugins/plugins/storefront/override-existing-javascript.md
@@ -92,11 +92,6 @@ import MyCookiePermission from './my-cookie-permission/my-cookie-permission.plug
 
 const PluginManager = window.PluginManager;
 PluginManager.override('CookiePermission', MyCookiePermission, '[data-cookie-permission]');
-
-// Necessary for the webpack hot module reloading server
-if (module.hot) {
-    module.hot.accept();
-}
 ```
 
 ### Testing your changes

--- a/guides/plugins/plugins/storefront/reacting-to-cookie-consent-changes.md
+++ b/guides/plugins/plugins/storefront/reacting-to-cookie-consent-changes.md
@@ -47,11 +47,6 @@ Just like with every custom JavaScript file, you have to load this one as well i
 
 ```javascript
 import './reacting-cookie/reacting-cookie'
-
-// Necessary for the webpack hot module reloading server
-if (module.hot) {
-    module.hot.accept();
-}
 ```
 
 {% endcode %}


### PR DESCRIPTION
As far as I know this is not needed anymore, at least I never included it in my plugins and it is not mentioned anywhere else anymore.