### PR TITLE
There is no StoreApiClient in 6.5

### DIFF
--- a/guides/plugins/plugins/storefront/fetching-data-with-javascript.md
+++ b/guides/plugins/plugins/storefront/fetching-data-with-javascript.md
@@ -61,35 +61,3 @@ export default class ExamplePlugin extends Plugin {
 The `get` method takes three arguments. The first one is the `url` which we want to call. In the example we are going to fetch a widget which contains some HTML. The second parameter is a `callback` function. It will be invoked when the API call was done. In the example below we pass in the `handleData` method of our plugin. The callback function then receives the `response` of the API call. We can now use this in our plugin to display the widget in the DOM, for example.
 
 The third parameter of the `get` method is the `contentType` which will be sent in the request header of the API call. It is optional and by default set to be `application/json`.
-
-## Call the Store API from the Storefront
-
-There's an extension of the client above - the `StoreApiClient` which automatically injects the correct credentials, so you can make calls from the Storefront to the [Store API](../../../../concepts/api/store-api.md).
-
-It works the same as the `HttpClient`:
-
-```javascript
-const client = new StoreApiClient();
-
-
-import Plugin from 'src/plugin-system/plugin.class';
-import StoreApiClient from 'src/service/store-api-client.service';
-
-export default class ExamplePlugin extends Plugin {
-    init() {
-        this._client = new StoreApiClient();
-
-        this.fetchData();
-    }
-
-    fetchData() {
-        this._client.get('store-api/checkout/cart', this.handleData);
-    }
-
-    // ...
-}
-```
-
-{% hint style="info" %}
-To see a list of available endpoints in our Store API, head to the [Store API Endpoint Reference](https://shopware.stoplight.io/docs/store-api).
-{% endhint %}


### PR DESCRIPTION
see https://github.com/shopware/platform/blob/trunk/UPGRADE-6.5.md#removal-of-the--_proxystore-api-api-route Would be nice to update this section with some clarity on how to work with the store api from the storefront.