### PR TITLE
Update add-product-entity-extension-to-elasticsearch.md. Add missing buildTermQuery function

### DIFF
--- a/guides/plugins/plugins/elasticsearch/add-product-entity-extension-to-elasticsearch.md
+++ b/guides/plugins/plugins/elasticsearch/add-product-entity-extension-to-elasticsearch.md
@@ -232,6 +232,11 @@ class MyProductEsDecorator extends AbstractElasticsearchDefinition
         return $this->productDefinition->getEntityDefinition();
     }
 
+    public function buildTermQuery(Context $context, Criteria $criteria): BoolQuery
+    {
+        return $this->decoratedService->buildTermQuery($context, $criteria);
+    }
+
     /**
      * Extend the mapping with your own changes
      * Take care to get the default mapping first by `$this->productDefinition->getMapping($context);`


### PR DESCRIPTION
Add missing buildTermQuery function. Without this function search will not return any results after decorating ElasticsearchProductDefinition.