### PR TITLE
Update using-composer-dependencies.md

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/using-composer-dependencies.md
+++ b/guides/plugins/plugins/plugin-fundamentals/using-composer-dependencies.md
@@ -17,7 +17,7 @@ Now we can simply install `exporter` by running `composer require sebastian/expo
 After that we have to add our dependency to shopware back in.
 
 {% hint style="warning" %}
-The `vendor` directory, where the Composer saves the dependencies, has to be included in the plugin bundle. The plugin bundle size is not allowed to exceed 5 MB.
+The `vendor` directory, where the Composer saves the dependencies, must not be included in the plugin bundle. Shopware adds the vendor folder on plugin installation, see "Executing composer commands during plugin installation".
 {% endhint %}
 
 ## Executing composer commands during plugin installation


### PR DESCRIPTION
Not 100% sure on this, but I thought the whole idea of the **executeComposerCommands** function was that we add the vendor folder on plugin installation and the dependencies are installed in the root vendor folder and not in the plugin's vendor folder?