### PR TITLE
Add plugin list with available infos

### DIFF
--- a/resources/references/storefront-reference/plugin-reference.md
+++ b/resources/references/storefront-reference/plugin-reference.md
@@ -1,0 +1,64 @@
+# Storefront plugins
+
+This is a list of available javascript plugins that can be used and extended.
+
+{% hint style="warning" %}
+{% endhint %}
+
+## Plugins
+
+| Plugin          | Description                                                                                                                                                                                      | Notes |
+|:----------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| :--- |
+| `AccountGuestAbortButtonPlugin` | ---                                                                                                                                                                                              | --- |
+| `AddToCartPlugin` | ---                                                                                                                                                                                              | --- |
+| `AddToWishlistPlugin` | ---                                                                                                                                                                                              | --- |
+| `AddressEditorPlugin` | ---                                                                                                                                                                                              | --- |
+| `AjaxModalPlugin` | This class extends the Bootstrap modal functionality by adding an event listener to modal triggers that contain a special "data-url" attribute which is needed to load the modal content by AJAX | --- |
+| `BaseSliderPlugin` | ---                                                                                                                                                                                              | --- |
+| `BaseWishlistStoragePlugin` | ---                                                                                                                                                                                              | --- |
+| `BasicCaptchaPlugin` | ---                                                                                                                                                                                              | --- |
+| `BuyBoxPlugin` | ---                                                                                                                                                                                              | --- |
+| `CartWidgetPlugin` | ---                                                                                                                                                                                              | --- |
+| `ClearInputPlugin` | Adds clear functionality to input fields                                                                                                                                                         | --- |
+| `CmsGdprVideoElement` | ---                                                                                                                                                                                              | --- |
+| `CollapseCheckoutConfirmMethodsPlugin` | ---                                                                                                                                                                                              | --- |
+| `CollapseFooterColumnsPlugin` | ---                                                                                                                                                                                              | --- |
+| `CookieConfiguration` | ---                                                                                                                                                                                              | --- |
+| `CookiePermissionPlugin` | ---                                                                                                                                                                                              | --- |
+| `CountryStateSelectPlugin` | ---                                                                                                                                                                                              | --- |
+| `CrossSellingPlugin` | ---                                                                                                                                                                                              | --- |
+| `DateFormat` | This plugin formats date and converts it to the local timezone if the data attribute date-format is set                                                                                          | --- |
+| `DatePickerPlugin` | Controls the date picker component                                                                                                                                                               | --- |
+| `EllipsisPlugin` | ---                                                                                                                                                                                              | --- |
+| `FadingPlugin` | ---                                                                                                                                                                                              | --- |
+| `FilterBasePlugin` | ---                                                                                                                                                                                              | --- |
+| `FlyoutMenuPlugin` | This Plugin handles the Subcategory display of the main navigation                                                                                                                               | --- |
+| `FormAddHistoryPlugin` | ---                                                                                                                                                                                              | --- |
+| `FormAjaxSubmitPlugin` | This plugin automatically submits a form, when the element or the form itself has changed                                                                                                        | --- |
+| `FormAutoSubmitPlugin` | This plugin automatically submits a form, when the element or the form itself has changed                                                                                                        | --- |
+| `FormCmsHandler` | ---                                                                                                                                                                                              | --- |
+| `FormFieldTogglePlugin` | ---                                                                                                                                                                                              | --- |
+| `FormPreserverPlugin` | This plugin preserves a form, if the element or the form itself has changed. After a reload of the page the form is filled up with the stored values                                             | --- |
+| `FormScrollToInvalidFieldPlugin` | This plugin scrolls to invalid form fields when the form is submitted                                                                                                                            | --- |
+| `FormSubmitLoaderPlugin` | This plugin shows a loading indicator on the form submit button when the form is submitted                                                                                                       | --- |
+| `FormValidation` | This plugin validates fields of a form. Also styles the field elements with the bootstrap style if enabled                                                                                       | --- |
+| `GoogleAnalyticsPlugin` | ---                                                                                                                                                                                              | --- |
+| `GoogleReCaptchaBasePlugin` | ---                                                                                                                                                                                              | --- |
+| `GuestWishlistPagePlugin` | ---                                                                                                                                                                                              | --- |
+| `ImageZoomPlugin` | ---                                                                                                                                                                                              | --- |
+| `ListingPlugin` | ---                                                                                                                                                                                              | --- |
+| `MagnifierPlugin` | Handles the magnifier lens functionality on the detail page                                                                                                                                      | --- |
+| `OffCanvasAccountMenu` | ---                                                                                                                                                                                              | --- |
+| `OffCanvasCartPlugin` | ---                                                                                                                                                                                              | --- |
+| `OffCanvasFilter` | ---                                                                                                                                                                                              | --- |
+| `OffCanvasTabs` | ---                                                                                                                                                                                              | --- |
+| `OffcanvasMenuPlugin` | ---                                                                                                                                                                                              | --- |
+| `QuantitySelectorPlugin` | ---                                                                                                                                                                                              | --- |
+| `RatingSystemPlugin` | ---                                                                                                                                                                                              | --- |
+| `RemoteClickPlugin` | This plugin is used to remotely click on another element                                                                                                                                         | --- |
+| `ScrollUpPlugin` | ---                                                                                                                                                                                              | --- |
+| `SearchWidgetPlugin` | ---                                                                                                                                                                                              | --- |
+| `SetBrowserClassPlugin` | ---                                                                                                                                                                                              | --- |
+| `VariantSwitchPlugin` | This plugin submits the variant form with the correct data option                                                                                                                                | --- |
+| `WishlistWidgetPlugin` | ---                                                                                                                                                                                              | --- |
+| `ZoomModalPlugin` | ---                                                                                                                                                                                              | --- |


### PR DESCRIPTION
Adding all plugins that extend from `plugin` to get an overview for developers.


A lot of info is missing, the question would be are we adding this or do we plan to replace most of them anyways mid-longterm?