### PR TITLE
Extending services Code Example Update

### DIFF
--- a/guides/plugins/plugins/administration/extending-services.md
+++ b/guides/plugins/plugins/administration/extending-services.md
@@ -31,7 +31,7 @@ With Shopware you have to reset the providers before extending Service.
 Let's look at an example:
 
 ```javascript
-Shopware.Application.$container.resetProviders();
+Shopware.Application.$container.resetProviders(['acl']);
 
 Shopware.Application.addServiceProviderDecorator('acl', (aclService) => {
   aclService.foo = 'bar';
@@ -50,7 +50,7 @@ As mentioned before with Shopware you have to reset the providers, before extend
 Let's look at an Example:
 
 ```javascript
-Shopware.Application.$container.resetProviders();
+Shopware.Application.$container.resetProviders(['acl']);
 
 Shopware.Application.addServiceProviderMiddleware('acl', (service, next) => {
     console.log('ACL service gets called');


### PR DESCRIPTION
Extends Code example to not break admin ui.

"name" param should always be defined? Example will break the admin ui in certain modules because data is missing. In our case, permission view was empty because all permission the resettet.