### PR TITLE
BC-44 Improve PaaS Recipe & Docs

### DIFF
--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -56,7 +56,7 @@ shopware variable:create --sensitive 1 --level project --name env:$(echo $line |
 done
 ```
 
-Run this command from your project directory so that the `shopware` command knows which project to update.
+Run this command from your project directory so the `shopware` command knows which project to update.
 
 The command connects to the application server to generate the JWT keys. It then sets the `JWT_PUBLIC_KEY` and `JWT_PRIVATE_KEY` as private environment variables.
 
@@ -64,7 +64,7 @@ Finally, execute the `shopware redeploy` command to proceed with the build- and 
 
 ##### Shopware Config
 
-By default, Shopware looks for the JWT keys on the file system. The configuration has to be updates to use the keys in the environment variables.
+By default, Shopware looks for the JWT keys on the file system. The configuration must be updated to use the keys in the environment variables.
 
 If you use the Shopware Flex Paas template, [the configuration](https://github.com/shopware/recipes/blob/main/shopware/paas-meta/6.4/config/packages/paas.yaml) will have been applied automatically.
 
@@ -100,8 +100,7 @@ The PaaS recipe uses the [Composer plugin loader](https://developer.shopware.com
 
 Sometimes you might want to trigger a rebuild and deploy of your environment without pushing new code to your project.
 
-Assuming you want to do this for your main environment, first create a REBUILD_DATE environment variable. This triggers a build right away to propagate the variable.
-
+If you want to do this for your main environment, create a REBUILD_DATE environment variable first. This triggers a build right away to propagate the variable.
 ```bash
 shopware variable:create --environment main --level environment --prefix env --name REBUILD_DATE --value "$(date)" --visible-build true
 ```

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -91,3 +91,22 @@ shopware variable:create --level project --name env:COMPOSER_AUTH --json true --
 ```
 
 Make sure to replace `%place your key here%` with your actual token. You can find your token by clicking 'Install with Composer' in your Shopware Account.
+
+## Manually trigger rebuilds
+
+Sometimes you might want to trigger a rebuild and deploy of your environment without pushing new code to your project.
+
+Assuming you want to do this for your main environment, first create a REBUILD_DATE environment variable. This triggers a build right away to propagate the variable.
+
+```bash
+shopware variable:create --environment main --level environment --prefix env --name REBUILD_DATE --value "$(date)" --visible-build true
+```
+
+To force a rebuild at any time, update the variable with a new value:
+
+```bash
+shopware variable:update --environment main --value "$(date)" "env:REBUILD_DATE"
+```
+
+This forces your application to be built even if no code has changed.
+

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -41,7 +41,8 @@ The installer will create an administrator account with the default credentials.
 Make sure to change this password immediately in your Administration account settings. Not doing so is a security risk.
 
 ### Manual steps
-After the first deploy, some steps have to be done manually once before the environment is up and running completely.
+
+After the first deploy, some steps must be done manually before the environment is entirely up and running.
 
 #### JWT Keys
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -100,12 +100,10 @@ The PaaS recipe uses the [Composer plugin loader](https://developer.shopware.com
 
 ## Manually trigger rebuilds
 
-Sometimes you might want to trigger a rebuild and deploy of your environment without pushing new code to your project.
+Sometimes, you might want to trigger a rebuild and deploy of your environment without pushing new code to your project. To do this for your main environment, create a `REBUILD_DATE` environment variable. This triggers a build right away to propagate the variable.
 
-If you want to do this for your main environment, create a REBUILD_DATE environment variable first. This triggers a build right away to propagate the variable.
 ```bash
 shopware variable:create --environment main --level environment --prefix env --name REBUILD_DATE --value "$(date)" --visible-build true
-```
 
 To force a rebuild at any time, update the variable with a new value:
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -44,7 +44,7 @@ Make sure to change this password immediately in your Administration account set
 
 After the first deploy, some steps must be done manually before the environment is entirely up and running.
 
-#### JWT Keys
+#### JWT keys
 
 The JWT keys, used for the Administration authentication, need to be generated for your project. The keys will be stored securely in the Shopware Paas environment variable storage and should not be committed to the Git repository or be available on the file system.
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -96,7 +96,7 @@ Make sure to replace `%place your key here%` with your actual token. You can fin
 
 ## Extending Shopware - plugins and apps
 
-The PaaS recipe uses the [Composer plugin loader](https://developer.shopware.com/docs/guides/hosting/installation-updates/cluster-setup#composer-plugin-loader).
+The PaaS recipe uses the [Composer plugin loader](../../guides/hosting/installation-updates/cluster-setup.md#composer-plugin-loader).
 
 ## Manually trigger rebuilds
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -46,7 +46,7 @@ After the first deploy, some steps must be done manually before the environment 
 
 #### JWT Keys
 
-The JWT keys, used for the Administration authentication, need to be generated for your project. The keys will be stored securely in the Shopware Paas Environment variable storage and should not be committed to the git repository or be available on the file system.
+The JWT keys, used for the Administration authentication, need to be generated for your project. The keys will be stored securely in the Shopware Paas environment variable storage and should not be committed to the Git repository or be available on the file system.
 
 To generate the keys and add them to the storage, run the following command:
 ```bash

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -68,7 +68,7 @@ Finally, execute the `shopware redeploy` command to proceed with the build-and-d
 
 By default, Shopware looks for the JWT keys on the file system. The configuration must be updated to use the keys in the environment variables.
 
-If you use the Shopware Flex Paas template, [the configuration](https://github.com/shopware/recipes/blob/main/shopware/paas-meta/6.4/config/packages/paas.yaml) will have been applied automatically.
+If you use the Shopware Flex Paas template, [the configuration](https://github.com/shopware/recipes/blob/main/shopware/paas-meta/6.4/config/packages/paas.yaml) will be applied automatically.
 
 ```yaml
  shopware:

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -64,7 +64,7 @@ The command connects to the application server to generate the JWT keys. It then
 
 Finally, execute the `shopware redeploy` command to proceed with the build-and-deploy process.
 
-##### Shopware Config
+##### Shopware config
 
 By default, Shopware looks for the JWT keys on the file system. The configuration must be updated to use the keys in the environment variables.
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -94,7 +94,7 @@ shopware variable:create --level project --name env:COMPOSER_AUTH --json true --
 
 Make sure to replace `%place your key here%` with your actual token. You can find your token by clicking 'Install with Composer' in your Shopware Account.
 
-## Extending Shopware: Plugins & Apps
+## Extending Shopware - plugins and apps
 
 The PaaS recipe uses the [Composer plugin loader](https://developer.shopware.com/docs/guides/hosting/installation-updates/cluster-setup#composer-plugin-loader).
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -92,6 +92,10 @@ shopware variable:create --level project --name env:COMPOSER_AUTH --json true --
 
 Make sure to replace `%place your key here%` with your actual token. You can find your token by clicking 'Install with Composer' in your Shopware Account.
 
+## Extending Shopware: Plugins & Apps
+
+The PaaS recipe uses the [Composer plugin loader](https://developer.shopware.com/docs/guides/hosting/installation-updates/cluster-setup#composer-plugin-loader).
+
 ## Manually trigger rebuilds
 
 Sometimes you might want to trigger a rebuild and deploy of your environment without pushing new code to your project.
@@ -109,4 +113,3 @@ shopware variable:update --environment main --value "$(date)" "env:REBUILD_DATE"
 ```
 
 This forces your application to be built even if no code has changed.
-

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -62,7 +62,7 @@ Run this command from your project directory so the `shopware` command knows whi
 
 The command connects to the application server to generate the JWT keys. It then sets the `JWT_PUBLIC_KEY` and `JWT_PRIVATE_KEY` as private environment variables.
 
-Finally, execute the `shopware redeploy` command to proceed with the build- and deploy process.
+Finally, execute the `shopware redeploy` command to proceed with the build-and-deploy process.
 
 ##### Shopware Config
 

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -49,6 +49,7 @@ After the first deploy, some steps must be done manually before the environment 
 The JWT keys, used for the Administration authentication, need to be generated for your project. The keys will be stored securely in the Shopware Paas environment variable storage and should not be committed to the Git repository or be available on the file system.
 
 To generate the keys and add them to the storage, run the following command:
+
 ```bash
 shopware ssh --app=app "bin/console system:generate-jwt-secret --use-env" |\
 grep -E "^JWT_(PUBLIC|PRIVATE)_KEY=" |\

--- a/products/paas/build-deploy.md
+++ b/products/paas/build-deploy.md
@@ -78,7 +78,7 @@ If you use the Shopware Flex Paas template, [the configuration](https://github.c
        public_key_path: '%env(base64:JWT_PUBLIC_KEY)%'  
 ```
 
-#### Theme Assets
+#### Theme assets
 
 It is a known issue that after the first deployment, theme assets are not compiled during the deployment. For that reason, your store will look unstyled. The [Theme Build](./theme-build.md) section explains how to resolve that issue.
 

--- a/products/paas/repository.md
+++ b/products/paas/repository.md
@@ -18,7 +18,7 @@ Secondly, create a new Git repository and push it to your favourite Git hosting 
 
 You can update the recipe to the latest version using the `composer recipes:update` [command](https://symfony.com/blog/fast-smart-flex-recipe-upgrades-with-recipes-update).
 
-However, the template may receive breaking changes. For example, when making certain changes to file mounts (like using a "service mount" instead of a "local mount"), there is no way to migrate your existing data into the updated mount automatically. Due to this, we recommend to always manually check all changes the recipes:update command provides for our `paas` package, as some updates to the .platform-yaml files might need extra manual actions. Every `paas` recipe update should be deemed a 'breaking' update and thus be validated before applying it to your project.
+However, the template may receive breaking changes. For example, when making certain changes to file mounts (like using a "service mount" instead of a "local mount"), there is no way to migrate your existing data into the updated mount automatically. Due to this, we always recommend manually checking all changes in the `recipes:update` command provided for the PaaS package, as some updates to the `.platform-yaml` files might need extra manual actions. Every PaaS recipe update should be deemed a **breaking** update and thus be validated before applying it to your project.
 
 ## Add PaaS remote
 

--- a/products/paas/repository.md
+++ b/products/paas/repository.md
@@ -14,7 +14,7 @@ This will create a brand new Shopware 6 project in the given folder. Now, change
 
 Secondly, create a new Git repository and push it to your favourite Git hosting service.
 
-### Updating the PaaS Template recipe
+### Updating the PaaS template recipe
 
 You can update the recipe to the latest version using the `composer recipes:update` command: [a diff-powered, smart recipe-updating system](https://symfony.com/blog/fast-smart-flex-recipe-upgrades-with-recipes-update).
 

--- a/products/paas/repository.md
+++ b/products/paas/repository.md
@@ -14,6 +14,12 @@ This will create a brand new Shopware 6 project in the given folder. Now, change
 
 Secondly, create a new Git repository and push it to your favourite Git hosting service.
 
+### Updating the PaaS Template recipe
+
+You can update the recipe to the latest version using the `composer recipes:update` command: [a diff-powered, smart recipe-updating system](https://symfony.com/blog/fast-smart-flex-recipe-upgrades-with-recipes-update).
+
+However, it is possible that we the template receives breaking changes. For example when making certain changes to file mounts (like using a "service mount" instead of a "local mount"), there is no way to automatically migrate your existing data into the updated mount. Due to this we recommend to always manually check all changes the recipes:update command provides for our `paas` package as some updates to the .platform-yaml files might need extra manual actions. Every `paas` recipe update should be deemed as a 'breaking' update and should thus be validated before applying it to your project. 
+
 ## Add PaaS remote
 
 Lastly, add a second remote, which allows us to push code towards the PaaS environment and trigger a deployment.

--- a/products/paas/repository.md
+++ b/products/paas/repository.md
@@ -16,7 +16,7 @@ Secondly, create a new Git repository and push it to your favourite Git hosting 
 
 ### Updating the PaaS template recipe
 
-You can update the recipe to the latest version using the `composer recipes:update` command: [a diff-powered, smart recipe-updating system](https://symfony.com/blog/fast-smart-flex-recipe-upgrades-with-recipes-update).
+You can update the recipe to the latest version using the `composer recipes:update` [command](https://symfony.com/blog/fast-smart-flex-recipe-upgrades-with-recipes-update).
 
 However, the template may receive breaking changes. For example, when making certain changes to file mounts (like using a "service mount" instead of a "local mount"), there is no way to migrate your existing data into the updated mount automatically. Due to this, we recommend to always manually check all changes the recipes:update command provides for our `paas` package, as some updates to the .platform-yaml files might need extra manual actions. Every `paas` recipe update should be deemed a 'breaking' update and thus be validated before applying it to your project.
 

--- a/products/paas/repository.md
+++ b/products/paas/repository.md
@@ -18,7 +18,7 @@ Secondly, create a new Git repository and push it to your favourite Git hosting 
 
 You can update the recipe to the latest version using the `composer recipes:update` command: [a diff-powered, smart recipe-updating system](https://symfony.com/blog/fast-smart-flex-recipe-upgrades-with-recipes-update).
 
-However, it is possible that we the template receives breaking changes. For example when making certain changes to file mounts (like using a "service mount" instead of a "local mount"), there is no way to automatically migrate your existing data into the updated mount. Due to this we recommend to always manually check all changes the recipes:update command provides for our `paas` package as some updates to the .platform-yaml files might need extra manual actions. Every `paas` recipe update should be deemed as a 'breaking' update and should thus be validated before applying it to your project. 
+However, the template may receive breaking changes. For example, when making certain changes to file mounts (like using a "service mount" instead of a "local mount"), there is no way to migrate your existing data into the updated mount automatically. Due to this, we recommend to always manually check all changes the recipes:update command provides for our `paas` package, as some updates to the .platform-yaml files might need extra manual actions. Every `paas` recipe update should be deemed a 'breaking' update and thus be validated before applying it to your project.
 
 ## Add PaaS remote
 


### PR DESCRIPTION
Provides documentation for: 

- Move JWT keys to variables instead of file system
- Enable composer plugin loader by default
- Flex recipe updates

Docs are only valid after merging of https://github.com/shopware/recipes/pull/57