### PR TITLE
Fix typo in https://developer.shopware.com/docs/guides/plugins/plugins/storefront/customize-templates.html

### DIFF
--- a/guides/plugins/plugins/storefront/customize-templates.md
+++ b/guides/plugins/plugins/storefront/customize-templates.md
@@ -84,7 +84,7 @@ Of course this example is very simplified and does not use any variables, even t
 But rather than that, how do you know which variables are available to use? For this case, you can just dump all available variables:
 
 ```twig
-{% dump() }}
+{{ dump() }}
 ```
 
 This `dump()` call will print out all variables available on this page.


### PR DESCRIPTION
You have a typo in this page https://developer.shopware.com/docs/guides/plugins/plugins/storefront/customize-templates.html:
![image](https://github.com/shopware/docs/assets/14080617/8a7eb51a-d836-4341-a05c-eceb02944c13)

Just replaced with `{{ dump() }}`.