### PR TITLE
Add specific section for CDN and fix language and grammar

### DIFF
--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -15,7 +15,7 @@ Shopware 6 stores and processes a wide variety of files. This goes from product 
 
 Shopware 6 can be used with several cloud storage providers. It uses [Flysystem](https://flysystem.thephpleague.com/docs/) to provide a common interface between different providers as well as the local file system. This enables your shops to read and write files through a common interface.
 
-The file system can be divided into multiple adapters. Each adapter can handle one or more of the following directories: media. sitemaps, and more. Of course, you can also use the same configuration for:
+The file system can be divided into multiple adapters. Each adapter can handle one or more of the following directories: media, sitemaps, and more. Of course, you can also use the same configuration for:
 
 * private files: invoices, delivery notes, plugin files, etc.
 * public files: product pictures, media files, plugin files in general
@@ -37,7 +37,7 @@ The configuration for file storage of Shopware 6 resides in the general bundle c
 To set up a non-default filesystem for your shop, you need to add the `filesystem:` map to the `shopware.yml`. Under this key, you can separately define your storage for the public, private, theme, sitemap, and asset \(bundle assets\).
 
 ::: info
-You can also change only the URL of the file systems. This is useful if you want to use a different domain for your files. For example, you can use a CDN for your public files.
+You can also change the URL of the file systems. This is useful if you want to use a different domain for your files. For example, you can use a CDN for your public files.
 :::
 
 ```yaml
@@ -61,7 +61,7 @@ shopware:
 ```
 
 If you want to regulate the uploaded file types, then you could add the keys `allowed_extensions`for the public filesystem or `private_local_download_strategy` for the private filesystem.
-With the `private_local_download_strategy` key you could choose the download strategy for private files (e.g. the downloadable products):
+With the `private_local_download_strategy` key you could choose the download strategy for private files (e.g., the downloadable products):
 
 ```yaml
 shopware:
@@ -75,11 +75,30 @@ shopware:
     private_local_download_strategy: # Name of the download strategy: php, x-sendfile or x-accel
 ```
 
-Following download strategies are valid:
+The following download strategies are valid:
 
 * `php` (default): A streamed response of content type `application/octet-stream` with binary data
 * `x-sendfile` (Apache only): X-Sendfile allows you to use PHP to instruct the server to send a file to a user, without having to load that file into PHP. You must have the [`mod_xsendfile`](https://github.com/nmaier/mod_xsendfile) Apache module installed.
 * `x-accel` (Nginx only): X-accel allows for internal redirection to a location determined by a header returned from a backend. See the [example configuration](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/).
+
+## CDN configuration
+
+If your public files are available on a CDN, you can use the following config to serve images and other assets via that CDN.
+
+```yaml
+# <project root>/config/packages/prod/shopware.yml
+shopware:
+  filesystem:
+    public:
+      url: "YOUR_CDN_URL"
+      type: "local"
+      config:
+        root: "%kernel.project_dir%/public"
+```
+
+::: info
+Be aware of the **prod** in the config path. CDNs are typically for production environments, but you can also set them for all environments in `config/packackes/shopware.yml`.
+:::
 
 ## Integrated adapter configurations
 

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -97,7 +97,7 @@ shopware:
 ```
 
 ::: info
-Be aware of the **prod** in the config path. CDNs are typically for production environments, but you can also set them for all environments in `config/packackes/shopware.yml`.
+Be aware of the **prod** in the config path. CDNs are typically for production environments, but you can also set them for all environments in `config/packages/shopware.yml`.
 :::
 
 ## Integrated adapter configurations


### PR DESCRIPTION
https://shopware.atlassian.net/browse/DX-438

Got a few requests already after updates from 6.4 to 6.5 - most often about the CDN config. To be ahead there was a specific config added for the old `shopware.cdn.url` config.