### PR TITLE
Dx adhoc/update manifest

### DIFF
--- a/guides/plugins/apps/app-base-guide.md
+++ b/guides/plugins/apps/app-base-guide.md
@@ -99,18 +99,7 @@ If there is no SDK available for your language, you can implement the registrati
 
 The registration request is made as a `GET` request against a URL you provide in your app's manifest file.
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        ...
-    </meta>
-    <setup>
-        <registrationUrl>https://my.example.com/registration</registrationUrl>
-    </setup>
-</manifest>
-```
+<<< @/docs/snippets/config/app/setup.xml
 
 The following query parameters will be sent with the request:
 

--- a/guides/plugins/apps/custom-data/custom-fields.md
+++ b/guides/plugins/apps/custom-data/custom-fields.md
@@ -8,35 +8,11 @@ nav:
 # Custom Data
 
 You can add custom fields to Shopware and thus add your own fields to extending data records. The user is able to modify this fields from within the Shopware Administration.  
-To make use of the custom fields register your custom field sets in your manifest file:
+To make use of the custom fields, register your custom field sets in your manifest file:
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        ...
-    </meta>
-    <custom-fields>
-        <custom-field-set>
-            <name>swag_example_set</name>
-            <label>Example Set</label>
-            <label lang="de-DE">Beispiel-Set</label>
-            <related-entities>
-                <order/>
-            </related-entities>
-            <fields>
-                <text name="swag_code">
-                    <position>1</position>
-                    <label>Example field</label>
-                </text>
-            </fields>
-        </custom-field-set>
-    </custom-fields>
-</manifest>
-```
+<<< @/docs/snippets/config/app/custom-fields-simple.xml
 
-For a complete reference of the structure of the manifest file take a look at the [Manifest reference](../../../../resources/references/app-reference/manifest-reference).
+For a complete reference of the structure of the manifest file, take a look at the [Manifest reference](../../../../resources/references/app-reference/manifest-reference).
 
 For the data needed, please refer to the custom fields in general: At first, you need a custom field set, as [custom fields](../../plugins/framework/custom-field/) in Shopware are organised in sets. Here you need to consider some important fields:
 

--- a/guides/plugins/apps/payment.md
+++ b/guides/plugins/apps/payment.md
@@ -7,7 +7,7 @@ nav:
 
 # Payment
 
-Starting with version 6.4.1.0, Shopware also provides functionality for your app to be able to integrate payment providers. You can choose between just a simple request for approval in the background \(synchronous payment\) and the user being forwarded to a provider for payment \(asynchronous payment\). You provide one or two endpoints, one for starting the payment and providing a redirect URL and one for finalization to check for the resulting status of the payment. The requests and responses of all of your endpoints will be signed and feature JSON content.
+Starting with version `6.4.1.0`, Shopware also provides functionality for your app to be able to integrate payment providers. You can choose between just a simple request for approval in the background \(synchronous payment\) and the user being forwarded to a provider for payment \(asynchronous payment\). You provide one or two endpoints, one for starting the payment and providing a redirect URL and one for finalization to check for the resulting status of the payment. The requests and responses of all of your endpoints will be signed and feature JSON content.
 
 ## Prerequisites
 
@@ -24,88 +24,11 @@ If your app should provide one or multiple payment methods, you need to define t
 
 You may choose between a synchronous and an asynchronous payment method. These two types are differentiated by defining a `finalize-url` or not. If no `finalize-url` is defined, the internal Shopware payment handler will default to a synchronous payment. If you do not want or need any communication during the payment process with your app, you can also choose not to provide a `pay-url`, then the payment will remain on open on checkout.
 
-Below you can see different definitions of payment methods.
+Below, you can see different definitions of payment methods.
 
 Depending on the URLs you provide, Shopware knows which kind of payment flow your payment method supports.
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        <!-- The name of the app should not change. Otherwise, all payment methods are created as duplicates. -->
-        <name>PaymentApp</name>
-        <!-- ... -->
-    </meta>
-
-    <payments>
-        <payment-method>
-            <!-- The identifier of the payment method should not change. Otherwise, a separate method is created. -->
-            <identifier>asynchronousPayment</identifier>
-            <name>Asynchronous payment</name>
-            <name lang="de-DE">Asynchrone Zahlung</name>
-            <description>This payment method requires forwarding to payment provider.</description>
-            <description lang="de-DE">Diese Zahlungsmethode erfordert eine Weiterleitung zu einem Zahlungsanbieter.</description>
-            <pay-url>https://payment.app/async/pay</pay-url>
-            <finalize-url>https://payment.app/async/finalize</finalize-url>
-            <!-- This optional path to this icon must be relative to the manifest.xml -->
-            <icon>Resources/paymentLogo.png</icon>
-        </payment-method>
-
-        <payment-method>
-            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
-            <identifier>synchronousPayment</identifier>
-            <name>Synchronous payment</name>
-            <name lang="de-DE">Synchrone Zahlung</name>
-            <description>This payment method does everything in one request.</description>
-            <description lang="de-DE">Diese Zahlungsmethode arbeitet in einem Request.</description>
-            <!-- This URL is optional for synchronous payments (see below). -->
-            <pay-url>https://payment.app/sync/process</pay-url>
-        </payment-method>
-
-        <payment-method>
-            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
-            <identifier>simpleSynchronousPayment</identifier>
-            <name>Simple Synchronous payment</name>
-            <name lang="de-DE">Einfache synchrone Zahlung</name>
-            <description>This payment will not do anything and stay on 'open' after order.</description>
-            <description lang="de-DE">Diese Zahlungsmethode wird die Transaktion auf 'offen' belassen.</description>
-            <!-- No URL is provided. -->
-        </payment-method>
-
-        <payment-method>
-            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
-            <identifier>preparedPayment</identifier>
-            <name>Payment, that offers everything</name>
-            <name lang="de-DE">Eine Zahlungsart, die alles kann</name>
-            <validate-url>https://payment.app/prepared/validate</validate-url>
-            <capture-url>https://payment.app/prepared/capture</capture-url>
-            <!-- This optional path to this icon must be relative to the manifest.xml -->
-            <icon>Resources/paymentLogo.png</icon>
-        </payment-method>
-
-        <payment-method>
-            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
-            <identifier>refundPayment</identifier>
-            <name>Refund payments</name>
-            <name lang="de-DE">Einfache Erstattungen</name>
-            <refund-url>https://payment.app/refund</refund-url>
-            <!-- This optional path to this icon must be relative to the manifest.xml -->
-            <icon>Resources/paymentLogo.png</icon>
-        </payment-method>
-
-        <payment-method>
-            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
-            <identifier>recurringPayment</identifier>
-            <name>Recurring payments</name>
-            <name lang="de-DE">Einfache wiederkehrende Zahlungen</name>
-            <recurring-url>https://payment.app/recurring</recurring-url>
-            <!-- This optional path to this icon must be relative to the manifest.xml -->
-            <icon>Resources/paymentLogo.png</icon>
-        </payment-method>
-    </payments>
-</manifest>
-```
+<<< @/docs/snippets/config/app/payments.xml
 
 ## Synchronous payments
 

--- a/guides/plugins/apps/rule-builder/add-custom-rule-conditions.md
+++ b/guides/plugins/apps/rule-builder/add-custom-rule-conditions.md
@@ -9,7 +9,7 @@ nav:
 
 ## Overview
 
-In this guide you'll learn how to make your app introduce custom conditions for use in the [Rule Builder](../../../../concepts/framework/rules). Custom conditions can be defined with fields to be rendered in the Administration and with their own logic, using the same approach as [App Scripts](../app-scripts/).
+In this guide, you'll learn how to make your app introduce custom conditions for use in the [Rule Builder](../../../../concepts/framework/rules). Custom conditions can be defined with fields to be rendered in the Administration and with their own logic, using the same approach as [App Scripts](../app-scripts/).
 
 ::: info
 Note that app rule conditions were introduced in Shopware 6.4.12.0, and are not supported in previous versions.
@@ -25,7 +25,7 @@ You should also be familiar with the general concept of the Rule Builder.
 
 <PageRef page="../../../../concepts/framework/rules" />
 
-For the attached logic of your custom conditions you'll use [twig files](https://twig.symfony.com/). Please refer to the App Scripts guide for a general introduction.
+For the attached logic of your custom conditions, you'll use [twig files](https://twig.symfony.com/). Please refer to the App Scripts guide for a general introduction.
 
 <PageRef page="../app-scripts/" />
 
@@ -33,50 +33,11 @@ For the attached logic of your custom conditions you'll use [twig files](https:/
 
 App Rule Conditions are defined in the `manifest.xml` file of your app:
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        ...
-    </meta>
-    <rule-conditions>
-        <rule-condition>
-            <identifier>my_custom_condition</identifier>
-            <name>Custom condition</name>
-            <name lang="de-DE">Eigene Bedingung</name>
-            <group>misc</group>
-            <script>custom-condition.twig</script>
-            <constraints>
-                <single-select name="operator">
-                    <placeholder>Choose an operator...</placeholder>
-                    <placeholder lang="de-DE">Bitte Operatoren wählen</placeholder>
-                    <options>
-                        <option value="=">
-                            <name>Is equal to</name>
-                            <name lang="de-DE">Ist gleich</name>
-                        </option>
-                        <option value="!=">
-                            <name>Is not equal to</name>
-                            <name lang="de-DE">Ist nicht gleich</name>
-                        </option>
-                    </options>
-                    <required>true</required>
-                </single-select>
-                <text name="firstName">
-                    <placeholder>Enter first name</placeholder>
-                    <placeholder lang="de-DE">Bitte Vornamen eingeben</placeholder>
-                    <required>true</required>
-                </text>
-            </constraints>
-        </rule-condition>
-    </rule-conditions>
-</manifest>
-```
+<<< @/docs/snippets/config/app/rule-conditions.xml
 
-For a complete reference of the structure of the manifest file take a look at the [Manifest reference](../../../../resources/references/app-reference/manifest-reference).
+For a complete reference of the structure of the manifest file, take a look at the [Manifest reference](../../../../resources/references/app-reference/manifest-reference).
 
-Following fields are required:
+The following fields are required:
 
 * `identifier`: A technical name for the condition that should be unique within the scope of the app. The name is being used to identify existing conditions when updating the app, so it should not be changed.
 * `name`: A descriptive and translatable name for the condition. The name will be shown within the Rule Builder's selection of conditions in the Administration.
@@ -139,7 +100,7 @@ If either one or both of `value` and `comparable` are an array, then only `=` an
 
 In the example above, we first check whether we can retrieve the current customer from the instance of `RuleScope` and return `false` otherwise.
 
-We then use the variables `operator` and `firstName`, provided by the constraints of the condition, to evaluate whether the first name in question matches the first name of the current customer. To do so we make use of the `compare` helper function.
+We then use the variables `operator` and `firstName`, provided by the constraints of the condition, to evaluate whether the first name in question matches the first name of the current customer. To do so, we make use of the `compare` helper function.
 
 ### Line item condition example
 
@@ -193,7 +154,7 @@ We then use the variables `operator` and `firstName`, provided by the constraint
 {% return false %}
 ```
 
-In this example we first check if the current scope is `LineItemScope` and refers to a specific line item. If so we compare that specific line item. Otherwise we check if the scope has a cart and return false if it doesn't. We have a multi select for product selection in the Administration which provides an array of product IDs in the script. We iterate the current cart's line items to check if the product is included and return `true` if that is the case.
+In this example we first check if the current scope is `LineItemScope` and refers to a specific line item. If so, we compare that specific line item. Otherwise we check if the scope has a cart and return false if it doesn't. We have a multi select for product selection in the Administration which provides an array of product IDs in the script. We iterate the current cart's line items to check if the product is included and return `true` if that is the case.
 
 ### Date condition example
 
@@ -214,4 +175,4 @@ In this example we first check if the current scope is `LineItemScope` and refer
 {% return compare('=', scope.getCurrentTime()|date_modify('first day of this month')|date_modify('second wednesday of this month')|date('Y-m-d'), scope.getCurrentTime()|date('Y-m-d')) %}
 ```
 
-For this example we don't have to define constraints. We retrieve the current date from the scope, calling `getCurrentTime`. We modify the date to set it to the first day of the month, then modify it again to set it to the second wednesday from that point in time. We then compare that date against the current date for a condition that matches only on the second wednesday of each month.
+For this example, we don't have to define constraints. We retrieve the current date from the scope, calling `getCurrentTime`. We modify the date to set it to the first day of the month, then modify it again to set it to the second wednesday from that point in time. We then compare that date against the current date for a condition that matches only on the second wednesday of each month.

--- a/guides/plugins/apps/shipping-methods.md
+++ b/guides/plugins/apps/shipping-methods.md
@@ -30,7 +30,7 @@ Ensure that the `<identifier>` of your shipping method remains unchanged, as Sho
 
 <?xml version="1.0" encoding="UTF-8" ?>
 <manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
     <meta>
         <!-- Make sure that the name of your app does not change anymore, otherwise there will be duplicates of your shipping methods -->
         <name>NameOfYourShippingMethodApp</name>

--- a/guides/plugins/apps/tax-provider.md
+++ b/guides/plugins/apps/tax-provider.md
@@ -26,26 +26,7 @@ To indicate to Shopware that your app uses a custom tax calculation, you must pr
 
 Below, you can see an example definition of a working tax provider.
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        <!-- The name of the app should not change. Otherwise all payment methods are created as duplicates. -->
-        <name>PaymentApp</name>
-        <!-- ... -->
-    </meta>
-    
-    <tax>
-        <tax-provider>
-            <identifier>myCustomTaxProvider</identifier>                        <!-- Unique identifier of the tax provider -->
-            <name>My custom tax provider</name>                                 <!-- Display name of the tax provider -->    
-            <priority>1</priority>                                              <!-- Priority of the tax provider - can be changed in the administration as well -->
-            <process-url>https://tax-provider.app/provide-taxes</process-url>     <!-- Url of your implementation - is called during checkout to provide taxes -->
-        </tax-provider>
-    </tax>
-</manifest>
-```
+<<< @/docs/snippets/config/app/tax.xml
 
 After successful installation of your app, the tax provider will already be used during checkout to provide taxes. You should also see the new tax provider showing up in the administration in `Settings > Tax`.
 

--- a/guides/plugins/apps/webhook.md
+++ b/guides/plugins/apps/webhook.md
@@ -11,18 +11,7 @@ With webhooks, you can subscribe to events occurring in Shopware. Whenever such 
 
 To use webhooks in your app, you need to implement a `<webhooks>` element in your manifest file as shown below:
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        ...
-    </meta>
-    <webhooks>
-        <webhook name="product-changed" url="https://example.com/event/product-changed" event="product.written"/>
-    </webhooks>
-</manifest>
-```
+<<< @/docs/snippets/config/app/webhooks.xml
 
 This example illustrates how to define a webhook with the name `product-changed` and the URL `https://example.com/event/product-changed`, which will be triggered if the event `product.written` is fired. So every time a product is changed, your custom logic will get executed. Further down, you will find a list of the most important events you can hook into.
 

--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -7,237 +7,87 @@ nav:
 
 # Manifest Reference
 
-```xml
-// manifest.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
-    <meta>
-        <!-- This is the element for the technical name of your app and must equal the name of the folder your app is contained in -->
-        <name>MyExampleApp</name>
-        <!-- In this element, you can set a label for your app. To include translations use the `lang` attribute -->
-        <label>Label</label>
-        <label lang="de-DE">Name</label>
-        <!-- Translatable, a description of your app -->
-        <description>A description</description>
-        <description lang="de-DE">Eine Beschreibung</description>
+## Meta information (required)
+Meta-information about your app.
 
-        <author>Your Company Ltd.</author>
-        <copyright>(c) by Your Company Ltd.</copyright>
-        <version>1.0.0</version>
-        <license>MIT</license>
-        <!-- Optional, you can set the path to an icon that should be shown for your app, the icon needs to a `png` file -->
-        <icon>icon.png</icon>
-        <!-- Optional, in this element you can link to your privacy policy -->
-        <privacy>https://your-company.com/privacy</privacy>
-        <!-- Optional, Translatable, in this element you can describe the changes the shop owner needs to apply to his shops privacy policy, e.g. because you process personal information on an external server -->
-        <privacyPolicyExtensions>
-            This app processes following personal information on servers based in the U.S.:
-            - Address information
-            - Order positions
-            - Order value
-        </privacyPolicyExtensions>
-        <privacyPolicyExtensions lang="de-DE">
-            Diese App verarbeitet folgende personenbezogene Daten auf Servern in den USA:
-            - Adress-Informationen
-            - Bestellpositionen
-            - Bestellsumme
-        </privacyPolicyExtensions>
-    </meta>
-    <!-- Optional, can be omitted if no communication between Shopware and your app is needed -->
-    <setup>
-        <!-- The URL which will be used for the registration -->
-        <registrationUrl>https://my.example.com/registration</registrationUrl>
-        <!-- Dev only, the secret that is used to sign the registration request -->
-        <secret>mysecret</secret>
-    </setup>
-    <!-- Optional, can be omitted if your app template needs higher load priority then other plugins/apps -->
-    <storefront>
-        <template-load-priority>100</template-load-priority>
-    </storefront>
-    <!-- Optional, can be omitted if your app does not need permissions -->
-    <permissions>
-        <!-- request each permission your app needs -->
-        <read>product</read>
-        <create>product</create>
-        <update>product</update>
+<<< @/docs/snippets/config/app/meta.xml
 
-        <delete>order</delete>
+:::info
+The following configurations are all optional. 
+:::
 
-        <!-- Since version 6.4.12.0 your app can request additional non-CRUD privileges-->
-        <permission>user_change_me</permission>
-    </permissions>
-    <!-- Optional, a list of all external endpoints your app communicates with (since 6.4.12.0) -->
-    <allowed-hosts>
-        <host>example.com</host>
-    </allowed-hosts>
-    <!-- Optional -->
-    <webhooks>
-        <!-- register webhooks you want to receive, keep in mind that the name needs to be unique -->
-        <webhook name="product-changed" url="https://example.com/event/product-changed" event="product.written"/>
-    </webhooks>
-    <!-- Optional, can be omitted if the Administration should not be extended -->
-    <admin>
-        <!-- Optional, entry point for the Admin Extension API (since 6.4.12.0) -->
-        <base-app-url>https://app.example.com</base-app-url>
-        <!-- Register a custom module that is used as a parent menu entry for other modules -->
-        <module name="myAdminModules"
-                parent="sw-marketing"
-                position="50"
-        >
-            <label>My modules</label>
-            <label lang="de-DE">Meine Module</label>
-        </module>
-        <!-- Register a custom module (iframe), that should be loaded from the given source -->
-        <module name="exampleModule"
-                source="https://example.com/promotion/view/promotion-module"
-                parent="app-MyExampleApp-myAdminModules"
-        >
-            <label>Example Module</label>
-            <label lang="de-DE">Beispiel Modul</label>
-        </module>
-        <!-- Register a module that is opened from the app store and your list of installed apps -->
-        <main-module source="https://example.com/main-module"/>
-        <!-- Register action buttons that should be displayed in the detail and listing pages of the Administration -->
-        <!-- view is one of: "list", "detail" -->
-        <action-button action="setPromotion" entity="promotion" view="detail" url="https://example.com/promotion/set-promotion">
-            <label>set Promotion</label>
-        </action-button>
-        <action-button action="deletePromotion" entity="promotion" view="detail" url="https://example.com/promotion/delete-promotion">
-            <label>delete Promotion</label>
-        </action-button>
-        <action-button action="restockProduct" entity="product" view="list" url="https://example.com/restock">
-            <label>restock</label>
-        </action-button>
-    </admin>
-    <!-- Optional -->
-    <custom-fields>
-        <!-- register each custom field set you may want to add -->
-        <custom-field-set>
-            <!-- the technical name of the custom field set, needs to be unique, therefor use your vendor prefix -->
-            <name>swag_example_set</name>
-            <!-- Translatable, the label of the field set -->
-            <label>Example Set</label>
-            <label lang="de-DE">Beispiel-Set</label>
-            <!-- define the entities to which your field set should be assigned -->
-            <related-entities>
-                <order/>
-            </related-entities>
-            <!-- define the fields in your set -->
-            <fields>
-                <!-- the element type, defines the type of the field -->
-                <!-- the name needs to be unique, therefore use your vendor prefix -->
-                <text name="swag_code">
-                    <!-- Translatable, the label of the field -->
-                    <label>Example field</label>
-                    <!-- Optional, Default = 1, order your fields by specifying the position -->
-                    <position>1</position>
-                    <!-- Optional, Default = false, mark a field as required -->
-                    <required>false</required>
-                    <!-- Optional, Translatable, the help text for the field -->
-                    <help-text>Example field</help-text>
-                </text>
-                <float name="swag_test_float_field">
-                    <label>Test float field</label>
-                    <label lang="de-DE">Test-Kommazahlenfeld</label>
-                    <help-text>This is an float field.</help-text>
-                    <position>2</position>
-                    <!-- some elements allow more configuration, like placeholder, main and max values etc. -->
-                    <!-- Your IDE should give you pretty good autocompletion support to explore the configuration for a given type -->
-                    <placeholder>Enter an float...</placeholder>
-                    <min>0.5</min>
-                    <max>1.6</max>
-                    <steps>0.2</steps>
-                </float>
-            </fields>
-        </custom-field-set>
-    </custom-fields>
-    <cookies>
-        <!-- Add a single cookie to cookie consent manager -->
-        <cookie>
-            <!-- The technical name of the cookie -->
-            <cookie>my-cookie</cookie>
-            <!-- Key of a Storefront snippet that represents the cookie's label in the consent manager -->
-            <snippet-name>example-app-with-cookies.my-cookie.name</snippet-name>
-            <!-- Key of a Storefront snippet that represents the cookie's description in the consent manager -->
-            <snippet-description>example-app-with-cookies.my-cookie.description</snippet-description>
-            <!-- A value that should be set to the cookie when the user accepts it -->
-            <value>a static value for the cookie</value>
-            <!-- Expiration in days -->
-            <expiration>1</expiration>
-        </cookie>
-        <!-- Add a cookie group to cookie consent manager -->
-        <group>
-            <!-- Key of a Storefront snippet that represents the cookie group's label in the consent manager -->
-            <snippet-name>example-app-with-cookies.cookie-group.name</snippet-name>
-            <!-- Key of a Storefront snippet that represents the cookie group's description in the consent manager -->
-            <snippet-description>example-app-with-cookies.cookie-group.description</snippet-description>
-            <!-- Add a collection of single cookies to the group -->
-            <entries>
-                <cookie>
-                    <cookie>my-cookie</cookie>
-                    <snippet-name>example-app-with-cookies.my-cookie.name</snippet-name>
-                    <snippet-description>example-app-with-cookies.my-cookie.description</snippet-description>
-                    <value>a static value for the cookie</value>
-                    <expiration>1</expiration>
-                </cookie>
-            </entries>
-        </group>
-    </cookies>
-    <payments>
-        <payment-method>
-            <!-- The identifier of the payment method (and the app name) should not change. Otherwise a separate method is created. -->
-            <identifier>myAsynchronousPayment</identifier>
-            <!-- Translatable, a name of your payment method -->
-            <name>Asynchronous payment</name>
-            <name lang="de-DE">Asynchrone Zahlung</name>
-            <!-- Optional, Translatable, a description of your payment method -->
-            <description>This payment method requires forwarding to payment provider.</description>
-            <description lang="de-DE">Diese Zahlungsmethode erfordert eine Weiterleitung zu einem Zahlungsanbieter.</description>
-            <!-- Optional for synchronous payments, required for asynchronous payments. -->
-            <pay-url>https://payment.app/async/pay</pay-url>
-            <!-- Optional, without the payment method becomes synchronous. -->
-            <finalize-url>https://payment.app/async/finalize</finalize-url>
-            <!-- Optional, you can set the path relative to the manifest.xml to an icon that should be shown for your payment app -->
-            <icon>Resources/paymentLogo.png</icon>
-        </payment-method>
-    </payments>
-    <rule-conditions>
-        <rule-condition>
-            <!-- The identifier of the rule condition must be unique should not change. Otherwise a separate rule condition is created and uses of the old one are lost. -->
-            <identifier>my_custom_condition</identifier>
-            <!-- Translatable, a name of your rule condition -->
-            <name>Custom condition</name>
-            <name lang="de-DE">Eigene Bedingung</name>
-            <!-- A thematic group the condition should be assigned too, available groups are: general, customer, cart, item, promotion, misc -->
-            <group>misc</group>
-            <!-- The *.twig file that contains the corresponding script for the condition. It must be placed in the directory Resources/scripts/rule-conditions starting from your app's root directory -->
-            <script>custom-condition.twig</script>
-            <!-- Define the fields you want the user to fill out for use as data within your condition -->
-            <constraints>
-                <!-- the element type, defines the type of the field -->
-                <!-- the elements available here are the same as for custom fields -->
-                <single-select name="operator">
-                    <placeholder>Choose an operator...</placeholder>
-                    <placeholder lang="de-DE">Bitte Operatoren wählen</placeholder>
-                    <options>
-                        <option value="=">
-                            <name>Is equal to</name>
-                            <name lang="de-DE">Ist gleich</name>
-                        </option>
-                        <option value="!=">
-                            <name>Is not equal to</name>
-                            <name lang="de-DE">Ist nicht gleich</name>
-                        </option>
-                    </options>
-                    <required>true</required>
-                </single-select>
-                <text name="firstName">
-                    <placeholder>Enter first name</placeholder>
-                    <placeholder lang="de-DE">Bitte Vornamen eingeben</placeholder>
-                    <required>true</required>
-                </text>
-            </constraints>
-        </rule-condition>
-    </rule-conditions>
-</manifest>
-```
+## Setup
+
+Can be omitted if no communication between Shopware and your app is needed. For more follow the [app base guide](../../../guides/plugins/apps/app-base-guide#registration-request).
+
+<<< @/docs/snippets/config/app/setup.xml
+
+## Storefront
+
+Can be omitted if your app template needs higher load priority than other plugins/apps. For more follow the [storefront guide](../../../guides/plugins/apps/storefront/index).
+
+<<< @/docs/snippets/config/app/storefront.xml
+
+## Permissions
+
+_Optional_, can be omitted if your app does not need permissions. For more follow the [app base guide](../../../guides/plugins/apps/app-base-guide).
+
+<<< @/docs/snippets/config/app/permissions.xml
+
+## Allowed hosts
+
+A list of all external endpoints your app communicates with (since `6.4.12.0`)
+
+<<< @/docs/snippets/config/app/allowed-hosts.xml
+
+## Webhooks
+
+Register webhooks you want to receive, keep in mind that the name needs to be unique. For more follow the [app webhook guide](../../../guides/plugins/apps/webhook).
+
+<<< @/docs/snippets/config/app/webhooks.xml
+
+## Admin extension
+
+Only needed if the Administration should be extended. For more follow the [add custom module guide](../../../guides/plugins/apps/administration/add-custom-modules).
+
+<<< @/docs/snippets/config/app/admin.xml
+
+## Custom fields
+
+Add your custom fields easily via the manifest.xml. For more follow the [custom fields app guide](../../../guides/plugins/apps/custom-data/custom-fields).
+
+<<< @/docs/snippets/config/app/custom-fields.xml
+
+## Cookies
+
+Add a single cookie to the consent manager. For more follow the [cookies with apps guide](../../../guides/plugins/apps/storefront/cookies-with-apps).
+
+<<< @/docs/snippets/config/app/cookies.xml
+
+Add a cookie group to the consent manager. For more follow the [cookies with apps guide](../../../guides/plugins/apps/storefront/cookies-with-apps).
+
+<<< @/docs/snippets/config/app/cookies-group.xml
+
+## Payments
+
+Add your payment methods via payments and handle your synchronous and asynchronous via an external app-server. For more follow the [app payment guide](../../../guides/plugins/apps/payment).
+
+<<< @/docs/snippets/config/app/payments.xml
+
+## Shipping methods
+
+Add your shipping methods via shipping-methods and handle your synchronous and asynchronous via an external app-server. For more follow the [shipping methods guide](../../../guides/plugins/apps/shipping-methods).
+
+<<< @/docs/snippets/config/app/shipping-methods.xml
+
+## Rule conditions
+
+The identifier of the rule condition must be unique should not change. Otherwise a separate rule condition is created, and uses of the old one are lost. For more follow the [rule conditions guide](../../../guides/plugins/apps/rule-builder/add-custom-rule-conditions).
+
+<<< @/docs/snippets/config/app/rule-conditions.xml
+
+## Tax
+
+Add an external tax provider to your app that is calculating your taxes on the fly for complex tax setups. For more follow the [tax provider guide](../../../guides/plugins/apps/tax-provider).
+
+<<< @/docs/snippets/config/app/tax.xml

--- a/snippets/config/app/admin.xml
+++ b/snippets/config/app/admin.xml
@@ -1,0 +1,33 @@
+<admin>
+    <!-- Optional, entry point for the Admin Extension API (since 6.4.12.0) -->
+    <base-app-url>https://app.example.com</base-app-url>
+    <!-- Register a custom module that is used as a parent menu entry for other modules -->
+    <module name="myAdminModules"
+            parent="sw-marketing"
+            position="50"
+    >
+        <label>My modules</label>
+        <label lang="de-DE">Meine Module</label>
+    </module>
+    <!-- Register a custom module (iframe), that should be loaded from the given source -->
+    <module name="exampleModule"
+            source="https://example.com/promotion/view/promotion-module"
+            parent="app-MyExampleApp-myAdminModules"
+    >
+        <label>Example Module</label>
+        <label lang="de-DE">Beispiel Modul</label>
+    </module>
+    <!-- Register a module that is opened from the app store and your list of installed apps -->
+    <main-module source="https://example.com/main-module"/>
+    <!-- Register action buttons that should be displayed in the detail and listing pages of the Administration -->
+    <!-- view is one of: "list", "detail" -->
+    <action-button action="setPromotion" entity="promotion" view="detail" url="https://example.com/promotion/set-promotion">
+        <label>set Promotion</label>
+    </action-button>
+    <action-button action="deletePromotion" entity="promotion" view="detail" url="https://example.com/promotion/delete-promotion">
+        <label>delete Promotion</label>
+    </action-button>
+    <action-button action="restockProduct" entity="product" view="list" url="https://example.com/restock">
+        <label>restock</label>
+    </action-button>
+</admin>

--- a/snippets/config/app/allowed-hosts.xml
+++ b/snippets/config/app/allowed-hosts.xml
@@ -1,0 +1,3 @@
+<allowed-hosts>
+    <host>example.com</host>
+</allowed-hosts>

--- a/snippets/config/app/cookies-group.xml
+++ b/snippets/config/app/cookies-group.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        <name>ExampleAppWithCookies</name>
+        <version>1.0.0</version>
+        <!-- other meta data goes here -->
+    </meta>
+    <cookies>
+        <group>
+            <snippet-name>example-app-with-cookies.cookie-group.name</snippet-name>
+            <snippet-description>example-app-with-cookies.cookie-group.description</snippet-description>
+            <entries>
+                <cookie>
+                    <cookie>my-cookie</cookie>
+                    <snippet-name>example-app-with-cookies.my-cookie.name</snippet-name>
+                    <snippet-description>example-app-with-cookies.my-cookie.description</snippet-description>
+                    <value>a static value for the cookie</value>
+                    <!-- Expiration in days -->
+                    <expiration>1</expiration>
+                </cookie>
+            </entries>
+        </group>
+    </cookies>
+</manifest>

--- a/snippets/config/app/cookies.xml
+++ b/snippets/config/app/cookies.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        <name>ExampleAppWithCookies</name>
+        <version>1.0.0</version>
+        <!-- other meta data goes here -->
+    </meta>
+    <cookies>
+        <cookie>
+            <cookie>my-cookie</cookie>
+            <snippet-name>example-app-with-cookies.my-cookie.name</snippet-name>
+            <snippet-description>example-app-with-cookies.my-cookie.description</snippet-description>
+            <value>a static value for the cookie</value>
+            <!-- Expiration in days -->
+            <expiration>1</expiration>
+        </cookie>
+    </cookies>
+</manifest>

--- a/snippets/config/app/custom-fields-simple.xml
+++ b/snippets/config/app/custom-fields-simple.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        ...
+    </meta>
+    <custom-fields>
+        <custom-field-set>
+            <name>swag_example_set</name>
+            <label>Example Set</label>
+            <label lang="de-DE">Beispiel-Set</label>
+            <related-entities>
+                <order/>
+            </related-entities>
+            <fields>
+                <text name="swag_code">
+                    <position>1</position>
+                    <label>Example field</label>
+                </text>
+            </fields>
+        </custom-field-set>
+    </custom-fields>
+</manifest>

--- a/snippets/config/app/custom-fields.xml
+++ b/snippets/config/app/custom-fields.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        ...
+    </meta>
+    <custom-fields>
+        <!-- register each custom field set you may want to add -->
+        <custom-field-set>
+            <!-- the technical name of the custom field set, needs to be unique, therefor use your vendor prefix -->
+            <name>swag_example_set</name>
+            <!-- Translatable, the label of the field set -->
+            <label>Example Set</label>
+            <label lang="de-DE">Beispiel-Set</label>
+            <!-- define the entities to which your field set should be assigned -->
+            <related-entities>
+                <order/>
+            </related-entities>
+            <!-- define the fields in your set -->
+            <fields>
+                <!-- the element type, defines the type of the field -->
+                <!-- the name needs to be unique, therefore use your vendor prefix -->
+                <text name="swag_code">
+                    <!-- Translatable, the label of the field -->
+                    <label>Example field</label>
+                    <!-- Optional, Default = 1, order your fields by specifying the position -->
+                    <position>1</position>
+                    <!-- Optional, Default = false, mark a field as required -->
+                    <required>false</required>
+                    <!-- Optional, Translatable, the help text for the field -->
+                    <help-text>Example field</help-text>
+                </text>
+                <float name="swag_test_float_field">
+                    <label>Test float field</label>
+                    <label lang="de-DE">Test-Kommazahlenfeld</label>
+                    <help-text>This is an float field.</help-text>
+                    <position>2</position>
+                    <!-- some elements allow more configuration, like placeholder, main and max values etc. -->
+                    <!-- Your IDE should give you pretty good autocompletion support to explore the configuration for a given type -->
+                    <placeholder>Enter an float...</placeholder>
+                    <min>0.5</min>
+                    <max>1.6</max>
+                    <steps>0.2</steps>
+                </float>
+            </fields>
+        </custom-field-set>
+    </custom-fields>
+</manifest>

--- a/snippets/config/app/meta.xml
+++ b/snippets/config/app/meta.xml
@@ -1,0 +1,33 @@
+<meta>
+    <!-- This is the element for the technical name of your app and must equal the name of the folder your app is contained in -->
+    <name>MyExampleApp</name>
+    <!-- In this element, you can set a label for your app. To include translations use the `lang` attribute -->
+    <label>Label</label>
+    <label lang="de-DE">Name</label>
+    <!-- Translatable, a description of your app -->
+    <description>A description</description>
+    <description lang="de-DE">Eine Beschreibung</description>
+    
+    <author>Your Company Ltd.</author>
+    <copyright>(c) by Your Company Ltd.</copyright>
+    <version>1.0.0</version>
+    <license>MIT</license>
+    <compatibility>~6.5.0</compatibility>
+    <!-- Optional, you can set the path to an icon that should be shown for your app, the icon needs to a `png` file -->
+    <icon>icon.png</icon>
+    <!-- Optional, in this element you can link to your privacy policy -->
+    <privacy>https://your-company.com/privacy</privacy>
+    <!-- Optional, Translatable, in this element you can describe the changes the shop owner needs to apply to his shops privacy policy, e.g. because you process personal information on an external server -->
+    <privacyPolicyExtensions>
+        This app processes following personal information on servers based in the U.S.:
+        - Address information
+        - Order positions
+        - Order value
+    </privacyPolicyExtensions>
+    <privacyPolicyExtensions lang="de-DE">
+        Diese App verarbeitet folgende personenbezogene Daten auf Servern in den USA:
+        - Adress-Informationen
+        - Bestellpositionen
+        - Bestellsumme
+    </privacyPolicyExtensions>
+</meta>

--- a/snippets/config/app/payments.xml
+++ b/snippets/config/app/payments.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        <!-- The name of the app should not change. Otherwise, all payment methods are created as duplicates. -->
+        <name>PaymentApp</name>
+        <!-- ... -->
+    </meta>
+
+    <payments>
+        <payment-method>
+            <!-- The identifier of the payment method should not change. Otherwise, a separate method is created. -->
+            <identifier>asynchronousPayment</identifier>
+            <name>Asynchronous payment</name>
+            <name lang="de-DE">Asynchrone Zahlung</name>
+            <description>This payment method requires forwarding to payment provider.</description>
+            <description lang="de-DE">Diese Zahlungsmethode erfordert eine Weiterleitung zu einem Zahlungsanbieter.</description>
+            <pay-url>https://payment.app/async/pay</pay-url>
+            <finalize-url>https://payment.app/async/finalize</finalize-url>
+            <!-- This optional path to this icon must be relative to the manifest.xml -->
+            <icon>Resources/paymentLogo.png</icon>
+        </payment-method>
+
+        <payment-method>
+            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
+            <identifier>synchronousPayment</identifier>
+            <name>Synchronous payment</name>
+            <name lang="de-DE">Synchrone Zahlung</name>
+            <description>This payment method does everything in one request.</description>
+            <description lang="de-DE">Diese Zahlungsmethode arbeitet in einem Request.</description>
+            <!-- This URL is optional for synchronous payments (see below). -->
+            <pay-url>https://payment.app/sync/process</pay-url>
+        </payment-method>
+
+        <payment-method>
+            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
+            <identifier>simpleSynchronousPayment</identifier>
+            <name>Simple Synchronous payment</name>
+            <name lang="de-DE">Einfache synchrone Zahlung</name>
+            <description>This payment will not do anything and stay on 'open' after order.</description>
+            <description lang="de-DE">Diese Zahlungsmethode wird die Transaktion auf 'offen' belassen.</description>
+            <!-- No URL is provided. -->
+        </payment-method>
+
+        <payment-method>
+            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
+            <identifier>preparedPayment</identifier>
+            <name>Payment, that offers everything</name>
+            <name lang="de-DE">Eine Zahlungsart, die alles kann</name>
+            <validate-url>https://payment.app/prepared/validate</validate-url>
+            <capture-url>https://payment.app/prepared/capture</capture-url>
+            <!-- This optional path to this icon must be relative to the manifest.xml -->
+            <icon>Resources/paymentLogo.png</icon>
+        </payment-method>
+
+        <payment-method>
+            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
+            <identifier>refundPayment</identifier>
+            <name>Refund payments</name>
+            <name lang="de-DE">Einfache Erstattungen</name>
+            <refund-url>https://payment.app/refund</refund-url>
+            <!-- This optional path to this icon must be relative to the manifest.xml -->
+            <icon>Resources/paymentLogo.png</icon>
+        </payment-method>
+
+        <payment-method>
+            <!-- The identifier of the payment method should not change. Otherwise a separate method is created. -->
+            <identifier>recurringPayment</identifier>
+            <name>Recurring payments</name>
+            <name lang="de-DE">Einfache wiederkehrende Zahlungen</name>
+            <recurring-url>https://payment.app/recurring</recurring-url>
+            <!-- This optional path to this icon must be relative to the manifest.xml -->
+            <icon>Resources/paymentLogo.png</icon>
+        </payment-method>
+    </payments>
+</manifest>

--- a/snippets/config/app/permissions.xml
+++ b/snippets/config/app/permissions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        ...
+    </meta>
+    <permissions>
+        <read>product</read>
+        <create>product</create>
+        <update>product</update>
+
+        <delete>order</delete>
+
+        <!-- Since version 6.4.12.0 your app can request additional non-CRUD privileges-->
+        <permission>system:cache:info</permission>
+    </permissions>
+</manifest>

--- a/snippets/config/app/rule-conditions.xml
+++ b/snippets/config/app/rule-conditions.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        <!-- ... -->
+    </meta>
+    <rule-conditions>
+        <rule-condition>
+            <!-- The identifier of the rule condition must be unique should not change. Otherwise a separate rule condition is created and uses of the old one are lost. -->
+            <identifier>my_custom_condition</identifier>
+            <!-- Translatable, a name of your rule condition -->
+            <name>Custom condition</name>
+            <name lang="de-DE">Eigene Bedingung</name>
+            <!-- A thematic group the condition should be assigned too, available groups are: general, customer, cart, item, promotion, misc -->
+            <group>misc</group>
+            <!-- The *.twig file that contains the corresponding script for the condition. It must be placed in the directory Resources/scripts/rule-conditions starting from your app's root directory -->
+            <script>custom-condition.twig</script>
+            <!-- Define the fields you want the user to fill out for use as data within your condition -->
+            <constraints>
+                <!-- the element type, defines the type of the field -->
+                <!-- the elements available here are the same as for custom fields -->
+                <single-select name="operator">
+                    <placeholder>Choose an operator...</placeholder>
+                    <placeholder lang="de-DE">Bitte Operatoren wählen</placeholder>
+                    <options>
+                        <option value="=">
+                            <name>Is equal to</name>
+                            <name lang="de-DE">Ist gleich</name>
+                        </option>
+                        <option value="!=">
+                            <name>Is not equal to</name>
+                            <name lang="de-DE">Ist nicht gleich</name>
+                        </option>
+                    </options>
+                    <required>true</required>
+                </single-select>
+                <text name="firstName">
+                    <placeholder>Enter first name</placeholder>
+                    <placeholder lang="de-DE">Bitte Vornamen eingeben</placeholder>
+                    <required>true</required>
+                </text>
+            </constraints>
+        </rule-condition>
+    </rule-conditions>
+</manifest>

--- a/snippets/config/app/setup.xml
+++ b/snippets/config/app/setup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        ...
+    </meta>
+    <setup>
+        <!-- The URL which will be used for the registration -->
+        <registrationUrl>https://my.example.com/registration</registrationUrl>
+        <!-- Dev only, the secret that is used to sign the registration request -->
+        <secret>mysecret</secret>
+    </setup>
+</manifest>

--- a/snippets/config/app/shipping-methods.xml
+++ b/snippets/config/app/shipping-methods.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        <!-- Make sure that the name of your app does not change anymore, otherwise there will be duplicates of your shipping methods -->
+        <name>NameOfYourShippingMethodApp</name>
+        <!-- ... -->
+    </meta>
+    <shipping-methods>
+        <shipping-method>
+            <!-- The identifier should not change after the first release -->
+            <identifier>NameOfYourFirstShippingMethod</identifier>
+            <name>First shipping method</name>
+
+            <delivery-time>
+                <!-- Requires a new generated UUID for your new delivery time -->
+                <id>c8864e36a4d84bd4a16cc31b5953431b</id>
+                <name>From 2 to 4 days</name>
+                <min>2</min>
+                <max>4</max>
+                <unit>day</unit>
+            </delivery-time>
+        </shipping-method>
+    </shipping-methods>
+</manifest>

--- a/snippets/config/app/storefront.xml
+++ b/snippets/config/app/storefront.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        ....
+    </meta>
+    <storefront>
+        <template-load-priority>100</template-load-priority>
+    </storefront>
+</manifest>

--- a/snippets/config/app/tax.xml
+++ b/snippets/config/app/tax.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        <!-- The name of the app should not change. Otherwise all payment methods are created as duplicates. -->
+        <name>PaymentApp</name>
+        <!-- ... -->
+    </meta>
+    <tax>
+        <tax-provider>
+            <!-- Unique identifier of the tax provider -->
+            <identifier>myCustomTaxProvider</identifier>
+            <!-- Display name of the tax provider -->
+            <name>My custom tax provider</name>
+            <!-- Priority of the tax provider - can be changed in the administration as well -->
+            <priority>1</priority>
+            <!-- Url of your implementation - is called during checkout to provide taxes -->
+            <process-url>https://tax-provider.app/provide-taxes</process-url>
+        </tax-provider>
+    </tax>
+</manifest>

--- a/snippets/config/app/webhooks.xml
+++ b/snippets/config/app/webhooks.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd">
+    <meta>
+        ...
+    </meta>
+    <webhooks>
+        <webhook name="product-changed" url="https://example.com/event/product-changed" event="product.written"/>
+    </webhooks>
+</manifest>


### PR DESCRIPTION
**Problem**
Often we add the correct docs in the guides section but forget about updating the reference. 3 references were missing in the current manifest.xml ref.

**Solution**
To avoid duplicate maintenance on both, we use the include function of vitepress and import the general config / manifest.xml files multiple times.

_Info_
Some of them are not suitable to import completely and have a separate file or are split up (cookies) - this is because the guide is not using the reference in full.


For review without a local setup check the video

https://github.com/shopware/docs/assets/8600299/5cde045a-e100-4ff8-ac4d-000bb06f8856


