### PR TITLE
Update add-dynamic-content-via-ajax-calls.md

### DIFF
--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -63,6 +63,9 @@ The following `services.xml` and `routes.xml` are identical as in the before men
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
+            <call method="setTwig">
+              <argument type="service" id="twig"/>
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
The twig service will be private with upcoming Symfony 6.0. To resolve this deprecation, a new method setTwig was added to the StorefrontController. All controllers which extends from StorefrontController need to call this method in the dependency injection definition file (services.xml) to set the Twig instance. The controllers will work like before until the Symfony 6.0 update will be done, but they will create a deprecation message on each usage. Below is an example how to add a method call for the service using the XML definition.