### PR TITLE
fix: adjust the way the indexing can be disabled

### DIFF
--- a/guides/plugins/plugins/framework/data-handling/add-data-indexer.md
+++ b/guides/plugins/plugins/framework/data-handling/add-data-indexer.md
@@ -167,7 +167,7 @@ public function update(EntityWrittenContainerEvent $event): ?EntityIndexingMessa
     }
 
     $context = $event->getContext();
-    $context->addExtension(EntityIndexerRegistry::DISABLE_INDEXING, new ArrayEntity());
+    $context->addState(EntityIndexerRegistry::DISABLE_INDEXING);
 
     return new EntityIndexingMessage(array_values($updates), null, $context);
 }


### PR DESCRIPTION
Seems like this changed a while ago to using states instead of extensions