### PR TITLE
Update add-middleware.md

### DIFF
--- a/guides/plugins/plugins/framework/message-queue/add-middleware.md
+++ b/guides/plugins/plugins/framework/message-queue/add-middleware.md
@@ -55,7 +55,7 @@ framework:
     messenger:
         default_bus: messenger.bus.shopware
         buses:
-            messenger.bus.shopware:
+            messenger.bus.default:
               middleware:
                 - 'Swag\BasicExample\MessageQueue\Middleware\ExampleMiddleware'
                 - 'Swag\BasicExample\MessageQueue\Middleware\AnotherExampleMiddleware'


### PR DESCRIPTION
Using 'messenger.bus.shopware' here causes a circular reference: "Circular reference detected for service "messenger.bus.shopware", path: "messenger.bus.shopware -> messenger.default_bus -> messenger.bus.shopware"."