### PR TITLE
Add minimum mysql 8.0 version

### DIFF
--- a/guides/installation/requirements.md
+++ b/guides/installation/requirements.md
@@ -56,8 +56,8 @@ You can use these commands to check your actual environment:
 * MySQL
 
   * Recommended version: 8.0
-
-  * Problematic versions: 8.0.20
+  * Minimum version: 8.0.17
+  * Problematic versions: 8.0.20, 8.0.21
 
 * MariaDB
 


### PR DESCRIPTION
We did some testing today and found that MySQL 8.0.17 is the minimum version where our tests pass. So we should probably state that as the min version.