### PR TITLE
Sync php version requirements with composer.json

### DIFF
--- a/guides/installation/requirements.md
+++ b/guides/installation/requirements.md
@@ -27,7 +27,7 @@ You can use these commands to check your actual environment:
 
 ### PHP
 
-* Compatible version: 8.1 and 8.2
+* Compatible version: 8.1, 8.2 and 8.3
 * `memory_limit`: 512M minimum
 * `max_execution_time`: 30 seconds minimum
 * Extensions:


### PR DESCRIPTION
The [`composer.json`](https://github.com/shopware/shopware/blob/6.5.x/composer.json) of `shopware/shopware` 6.5.x allows PHP 8.1 - 8.3. 

This change reflects this in the documented System Requirements. 