### PR TITLE
Use --no-scripts when updating Shopware

### DIFF
--- a/guides/installation/template.md
+++ b/guides/installation/template.md
@@ -248,7 +248,7 @@ composer require fastly
 
 There are two ways to update Shopware:
 
-* Initially run `bin/console system:update:prepare` to enable the maintenance mode and then update all Composer packages using `composer update`. However, to disable the maintenance mode, run `bin/console system:update:finish`.
+* Initially run `bin/console system:update:prepare` to enable the maintenance mode and then update all Composer packages using `composer update --no-scripts`. The `--no-scripts` flag instructs composer to not run any scripts that may reference Shopware CLI commands. They will only be functional after updating the recipes. To disable the maintenance mode, run `bin/console system:update:finish`.
 
 * To force-update all config files, run `composer recipes:update`.
 


### PR DESCRIPTION
So that scripts are not executed while for example `bin/console` is referencing code which does not exist (it would be fixed with the recipe update).