### PR TITLE
don't overwrite host header in varnish vcl

### DIFF
--- a/guides/hosting/infrastructure/reverse-http-cache.md
+++ b/guides/hosting/infrastructure/reverse-http-cache.md
@@ -273,8 +273,6 @@ acl purgers {
 }
 
 sub vcl_recv {
-    set req.http.host = "sw6.dev.localhost";
-
     # Mitigate httpoxy application vulnerability, see: https://httpoxy.org/
     unset req.http.Proxy;
 


### PR DESCRIPTION
Please don't overwrite the host header in the varnish vcl. In most cases you can just forward the host header from the client.

In other cases, this is nothing specific to "soft purge" it isn't done in the other two vcls and a rare edge case. 

Copying this line, will actually break stores through.