### PR TITLE
Formatting fix and question

### DIFF
--- a/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
@@ -126,7 +126,7 @@ To ensure that the code remains accessible to all developers, the uncompiled ver
     * Video content increases awareness, trust and has proven to convert potential customers better than other content types. Help your customers better understand your app or service with explainer videos, product demos, tutorials, etc. You can embed maximum 2 YouTube videos in your app description.
 
 ::: info
-    You can no longer advertise your Shopware certificates within the app description, in your app images, or in your manufacturer profile. The manufacturer/partner certificates are dynamically loaded at the end of each app description and published by us.
+You can no longer advertise your Shopware certificates within the app description, in your app images, or in your manufacturer profile. The manufacturer/partner certificates are dynamically loaded at the end of each app description and published by us.
 :::
 
 * Include several screenshots and descriptive images from the Storefront and backend that represent the app functionality. They must show the app "in action", its configuration options, and how to use it.


### PR DESCRIPTION
Hopefully fixing this:

![image](https://github.com/shopware/docs/assets/1087128/2240fbab-5075-4371-9483-7fb034a47ed3)


Bonus question:

> We always test with the [actual SW6 version](https://www.shopware.com/de/download/#shopware-6). So set it to the
> actual SW6 version e.g., shopware/testenv:6.4.3. Always test with the app`s highest supported Shopware version.

What does actual mean here? Is this bad translation from "aktuelle" ? Or does it mean the one selected? Should be clarified
