### PR TITLE
Update app-base-guide.md and recommend PascalCase for the technical name

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -878,6 +878,7 @@ mr
 MRs
 MultiWarehouse
 MVC
+MyExampleApp
 myNewMethod
 MyPlugin
 myPluginLogHandler
@@ -1018,6 +1019,7 @@ ParentFk
 ParentFkField
 parsers
 PasswordField
+PaymentGatewayApp
 PaymentHandlerIdentifierSubscriber
 PaymentMethod
 PaymentMethodRoute

--- a/guides/plugins/apps/app-base-guide.md
+++ b/guides/plugins/apps/app-base-guide.md
@@ -15,6 +15,11 @@ This guide will walk you through the process of adding your own app to Shopware 
 
 If you are not familiar with the app system, take a look at the [App concept](../../../concepts/extensions/apps-concept) first.
 
+## Name your app
+
+First, you need to find a name for your app. We're talking about a technical name here, so it needs to describe your plugins functionality as short as possible, written in UpperCamelCase.
+For this example guide we'll use the app name "MyExampleApp".
+
 ## File structure
 
 To get started with your app, create an `apps` folder inside the `custom` folder of your Shopware dev installation. In there, create another folder for your application and provide a manifest file in it.

--- a/guides/plugins/apps/app-base-guide.md
+++ b/guides/plugins/apps/app-base-guide.md
@@ -17,8 +17,9 @@ If you are not familiar with the app system, take a look at the [App concept](..
 
 ## Name your app
 
-First, you need to find a name for your app. We're talking about a technical name here, so it needs to describe your plugins functionality as short as possible, written in UpperCamelCase.
-For this example guide we'll use the app name "MyExampleApp".
+Choose a technical name for your application that accurately reflects its plugin functionality. Specify the name using UpperCamelCase. For instance: "PaymentGatewayApp".
+
+However, throught this section "MyExampleApp" is used as it serves as an illustrative example of the plugin.
 
 ## File structure
 

--- a/guides/plugins/apps/app-base-guide.md
+++ b/guides/plugins/apps/app-base-guide.md
@@ -19,7 +19,7 @@ If you are not familiar with the app system, take a look at the [App concept](..
 
 Choose a technical name for your application that accurately reflects its plugin functionality. Specify the name using UpperCamelCase. For instance: "PaymentGatewayApp".
 
-However, throught this section "MyExampleApp" is used as it serves as an illustrative example of the plugin.
+However, through out this section "MyExampleApp" is used as it serves as an illustrative example of the plugin.
 
 ## File structure
 


### PR DESCRIPTION
In the plugin base guide we explicitly recommend using PascalCase or UpperCamelCase for the plugins technical name.

https://developer.shopware.com/docs/guides/plugins/plugins/plugin-base-guide.html#name-your-plugin

This is inconsistent to the app base guide, there it is not said explicitly and only the code examples "indirectly" recommend it.