### PR TITLE
Updated reference for backround image

### DIFF
--- a/guides/plugins/plugins/storefront/add-custom-assets.md
+++ b/guides/plugins/plugins/storefront/add-custom-assets.md
@@ -72,7 +72,7 @@ There's one more interesting possibility though. If you want, you can use your c
 ```css
 // <plugin root>/src/Resources/app/storefront/src/scss/base.scss
 body {
-    background-image: url("/bundles/swagbasicexample/image.png");
+    background-image: url("#{$sw-asset-public-url}/bundles/swagbasicexample/image.png");
 }
 ```
 


### PR DESCRIPTION
Updated reference for backround image as it will not be loaded if the Shop URL is something like this:

https//www.testenvironment.com/public/shop