### PR TITLE
NEXT-33884 - quickfixes for Meteor Admin SDK

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -618,6 +618,7 @@ goto
 Grafana
 grantable
 Grantable
+granularly
 graphviz
 gridActions
 gridColumns
@@ -1285,6 +1286,7 @@ setToInitialState
 SFTP
 sha
 SHA
+shakable
 shallowMount
 shippable
 ShippingCountryRule

--- a/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
+++ b/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
@@ -305,7 +305,7 @@ Here, you have the main rendering logic for the Administration's CMS element. Th
 
 It initially fetches the `element` data, as you've already seen it in the config file. After that, using `data.subscribe(id, method)` it subscribes to the publishing key, which will update the element data automatically if something changes. It doesn't matter if the changes originate from our config modal outside Shopware or from somewhere else inside Shopware.
 
-![Dailymotion CMS element](../../../../../assets/add-cms-element-via-admin-sdk-element.png)
+![Dailymotion CMS element](../../../../assets/add-cms-element-via-admin-sdk-element.png)
 
 ### The preview file
 
@@ -323,7 +323,7 @@ export default Vue.extend({
 });
 ```
 
-![Dailymotion element preview](../../../../../assets/add-cms-element-via-admin-sdk-preview.png)
+![Dailymotion element preview](../../../../assets/add-cms-element-via-admin-sdk-preview.png)
 
 ## Storefront implementation
 

--- a/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
+++ b/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
@@ -1,11 +1,11 @@
 ---
 nav:
-  title: Add CMS element via MeteorAdminSDK
-  position: 30
+  title: Add CMS element
+  position: 25
 
 ---
 
-# Add CMS Element via Meteor Admin SDK
+# Add CMS Element
 
 ## Overview
 

--- a/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
+++ b/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
@@ -241,7 +241,7 @@ So, now you need a simple input field to get a `dailyUrl` for the Dailymotion vi
 
 With these small additions to typical CMS element behavior, you have already done with the config modal.
 
-![Dailymotion config modal](../../../../../assets/add-cms-element-via-admin-sdk-config.png)
+![Dailymotion config modal](../../../../assets/add-cms-element-via-admin-sdk-config.png)
 
 ### The element file
 

--- a/guides/plugins/apps/administration/add-custom-action-button.md
+++ b/guides/plugins/apps/administration/add-custom-action-button.md
@@ -8,9 +8,9 @@ nav:
 # Add custom action button
 
 :::info
-This guide will show you how to add custom action buttons to the Shopware Administration using your manifest file. This works for simple applications. But if you want to write more advanced applications, we recommend you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) instead. It has many more features and is more flexible.
+This guide will show you how to add custom action buttons to the Shopware Administration using your manifest file. This works for simple applications; however, if you want to write more advanced applications, the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) is recommended. It has many more features and is more flexible.
 
-The documentation for the action button in the SDK can be found [here](https://shopware.github.io/meteor-admin-sdk/docs/guide/api-reference/ui/actionButton).
+For further details and guidance on custom action buttons, refer to the documentation provided on the Meteor Admin SDK's [action button](https://shopware.github.io/meteor-admin-sdk/docs/guide/api-reference/ui/actionButton) section.
 :::
 
 One extension possibility in the Administration is the ability to add custom action buttons to the smartbar. For now, you can add them in the smartbar of detail and list views:

--- a/guides/plugins/apps/administration/add-custom-action-button.md
+++ b/guides/plugins/apps/administration/add-custom-action-button.md
@@ -7,6 +7,12 @@ nav:
 
 # Add custom action button
 
+:::info
+This guide will show you how to add custom action buttons to the Shopware Administration using your manifest file. This works for simple applications. But if you want to write more advanced applications, we recommend you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) instead. It has many more features and is more flexible.
+
+The documentation for the action button in the SDK can be found [here](https://shopware.github.io/meteor-admin-sdk/docs/guide/api-reference/ui/actionButton).
+:::
+
 One extension possibility in the Administration is the ability to add custom action buttons to the smartbar. For now, you can add them in the smartbar of detail and list views:
 
 ![Custom action buttons in the Administration](../../../../assets/custom-buttons.png)

--- a/guides/plugins/apps/administration/add-custom-modules.md
+++ b/guides/plugins/apps/administration/add-custom-modules.md
@@ -7,6 +7,12 @@ nav:
 
 # Add custom module
 
+:::info
+This guide will show you how to add custom modules to the Shopware Administration using your manifest file. This works for simple applications. But if you want to write more advanced applications, we recommend you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) instead. It has many more features and is more flexible.
+
+The documentation for custom modules in the SDK can be found [here](https://shopware.github.io/meteor-admin-sdk/docs/guide/api-reference/ui/mainModule).
+:::
+
 ## Overview
 
 In your app, you are able to add your own modules to the Administration. Your custom modules are loaded as iframes which are embedded in the Shopware Administration and within this iframe, your website will be loaded and shown.

--- a/guides/plugins/apps/administration/add-custom-modules.md
+++ b/guides/plugins/apps/administration/add-custom-modules.md
@@ -8,9 +8,9 @@ nav:
 # Add custom module
 
 :::info
-This guide will show you how to add custom modules to the Shopware Administration using your manifest file. This works for simple applications. But if you want to write more advanced applications, we recommend you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) instead. It has many more features and is more flexible.
+This guide will show you how to add custom modules to the Shopware Administration using your manifest file. This works for simple applications; however, if you want to write more advanced applications, the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) is recommended. It has many more features and is more flexible.
 
-The documentation for custom modules in the SDK can be found [here](https://shopware.github.io/meteor-admin-sdk/docs/guide/api-reference/ui/mainModule).
+For further details and guidance on custom modules, refer to the documentation provided on the Meteor Admin SDK's [custom modules](https://shopware.github.io/meteor-admin-sdk/docs/guide/api-reference/ui/mainModule) section.
 :::
 
 ## Overview

--- a/guides/plugins/apps/administration/meteor-admin-sdk.md
+++ b/guides/plugins/apps/administration/meteor-admin-sdk.md
@@ -6,18 +6,16 @@ nav:
 
 # Meteor Admin SDK
 
-Most of the following articles will show you how to do simple admin things with your app. But if you want to write more advanced apps, we recommend that you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) instead. It has many more features and is more flexible. The documentation for this library is separate and can be found [here](https://shopware.github.io/meteor-admin-sdk/).
+The [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) is an NPM library for Shopware 6 apps and plugins that need an easy way to extend or customize the administration.
 
-The Meteor Admin SDK is an NPM library for Shopware 6 apps and plugins that need an easy way to extend or customize the administration.
+To write advanced apps, its recommended that you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/). It contains helper functions to communicate with the Administration, execute actions, subscribe to data or extend the user interface. It has many more features and is more flexible.
 
-It contains helper functions to communicate with the Administration, execute actions, subscribe to data or extend the user interface.
-
-- 🏗  **Works with Shopware 6 Apps and Plugins:** you can use the SDK for your plugins or apps. API usage is identical.
-- 🎢  **Shallow learning curve:** you don't need to have extensive knowledge about the internals of the Shopware 6 Administration. Our SDK hides the complicated stuff behind a beautiful API.
-- 🧰  **Many extension capabilities:** from throwing notifications, accessing context information or extending the current UI. The feature set of the SDK will gradually be extended, providing more possibilities and flexibility for your ideas and solutions.
-- 🪨  **A stable API with great backwards compatibility:** don't fear Shopware updates anymore. Breaking changes in this SDK are an exception. If you use the SDK, your apps and plugins will stay stable for a longer time, without any need for code maintenance.
-- 🧭  **Type safety:** the whole SDK is written in TypeScript which provides great autocompletion support and more safety for your apps and plugins.
-- 💙  **Developer experience:** have a great development experience right from the start. And it will become better and better in the future.
-- 🪶  **Lightweight:** the whole library is completely tree-shakable and dependency-free. Every functionality can be imported granularly to keep your bundle as small and fast as possible.
+- 🏗  **Works with Shopware 6 Apps and Plugins:** You can use the SDK for your plugins or apps. API usage is identical.
+- 🎢  **Shallow learning curve:** You don't need to have extensive knowledge about the internals of the Shopware 6 Administration. Our SDK hides the complicated stuff behind a beautiful API.
+- 🧰  **Many extension capabilities:** Includes throwing notifications, accessing context information, extending the current UI and more. The feature set of the SDK will gradually be extended, providing more possibilities and flexibility for your ideas and solutions.
+- 🪨  **A stable API with great backwards compatibility:** Don't fear Shopware updates anymore. Breaking changes in this SDK are an exception. If you use the SDK, your apps and plugins will stay stable for a longer time, without any need for code maintenance.
+- 🧭  **Type safety:** The whole SDK is written in TypeScript which provides great autocompletion support and more safety for your apps and plugins.
+- 💙  **Developer experience:** Have a great development experience right from the start. And it will become better and better in the future.
+- 🪶  **Lightweight:** The whole library is completely tree-shakable and dependency-free. Every functionality can be imported granularly to keep your bundle as small and fast as possible.
 
 Go to [Installation](https://shopware.github.io/meteor-admin-sdk/docs/guide/getting-started/installation/) to get started. Or check out the [quick start guide](https://shopware.github.io/meteor-admin-sdk/docs/guide#quick-start).

--- a/guides/plugins/apps/administration/meteor-admin-sdk.md
+++ b/guides/plugins/apps/administration/meteor-admin-sdk.md
@@ -1,0 +1,23 @@
+---
+nav:
+  title: Meteor Admin SDK
+  position: 5
+---
+
+# Meteor Admin SDK
+
+Most of the following articles will show you how to do simple admin things with your app. But if you want to write more advanced apps, we recommend that you use the [Meteor Admin SDK](https://shopware.github.io/meteor-admin-sdk/) instead. It has many more features and is more flexible. The documentation for this library is separate and can be found [here](https://shopware.github.io/meteor-admin-sdk/).
+
+The Meteor Admin SDK is an NPM library for Shopware 6 apps and plugins that need an easy way to extend or customize the administration.
+
+It contains helper functions to communicate with the Administration, execute actions, subscribe to data or extend the user interface.
+
+- 🏗  **Works with Shopware 6 Apps and Plugins:** you can use the SDK for your plugins or apps. API usage is identical.
+- 🎢  **Shallow learning curve:** you don't need to have extensive knowledge about the internals of the Shopware 6 Administration. Our SDK hides the complicated stuff behind a beautiful API.
+- 🧰  **Many extension capabilities:** from throwing notifications, accessing context information or extending the current UI. The feature set of the SDK will gradually be extended, providing more possibilities and flexibility for your ideas and solutions.
+- 🪨  **A stable API with great backwards compatibility:** don't fear Shopware updates anymore. Breaking changes in this SDK are an exception. If you use the SDK, your apps and plugins will stay stable for a longer time, without any need for code maintenance.
+- 🧭  **Type safety:** the whole SDK is written in TypeScript which provides great autocompletion support and more safety for your apps and plugins.
+- 💙  **Developer experience:** have a great development experience right from the start. And it will become better and better in the future.
+- 🪶  **Lightweight:** the whole library is completely tree-shakable and dependency-free. Every functionality can be imported granularly to keep your bundle as small and fast as possible.
+
+Go to [Installation](https://shopware.github.io/meteor-admin-sdk/docs/guide/getting-started/installation/) to get started. Or check out the [quick start guide](https://shopware.github.io/meteor-admin-sdk/docs/guide#quick-start).

--- a/guides/plugins/apps/starter/starter-admin-extension.md
+++ b/guides/plugins/apps/starter/starter-admin-extension.md
@@ -9,10 +9,6 @@ nav:
 
 In this guide, you will learn how to set up an extension for the Administration UI.
 
-::: info
-When you are using a self-hosted Shopware version, make sure to set the feature flag `FEATURE_NEXT_17950=1` to enable the Admin Extension API.
-:::
-
 ![An admin notification](../../../../assets/extension-api-notification.png)
 
 ## Prerequisites


### PR DESCRIPTION
The current documentation has outdated parts in terms of developing apps for administration. This PR isn't going to rewrite everything to use our recommended way of extending applications, the Meteor Admin SDK. Instead, it only contains some small quickfixes and wins. This is to make it clearer to the reader that the current articles are only suitable for extremely small applications.

It also contains some structure fixes, e.g. moving the CMS Element creation article to the correct apps directory instead of the plugins directory, adding a small article at the beginning of each article in the admin app series, etc.