### PR TITLE
Expand rule docs

### DIFF
--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -119,7 +119,7 @@ $customer = $scope->getSalesChannelContext()->getCustomer();
 $loggedIn = $customer !== null;
 ```
 
-It is possible to add config to our rule. This makes it possible to skip the [Custom rule component](https://developer.shopware.com/docs/guides/plugins/plugins/framework/rule/add-custom-rules.html#custom-rule-component) and the [Custom rule Administration template](https://developer.shopware.com/docs/guides/plugins/plugins/framework/rule/add-custom-rules.html#custom-rule-administration-template) parts.
+It is possible to add config to our rule. This makes it possible to skip the [Custom rule component](#custom-rule-component) and the [Custom rule Administration template](#custom-rule-administration-template) parts.
 
 ```php
     public function getConfig(): RuleConfig
@@ -128,7 +128,7 @@ It is possible to add config to our rule. This makes it possible to skip the [Cu
     }
 ```
 
-when [Showing rule in the Administration](https://developer.shopware.com/docs/guides/plugins/plugins/framework/rule/add-custom-rules.html#showing-rule-in-the-administration) we would not use a custom component but we would render the `sw-condition-generic` component.
+when [Showing rule in the Administration](#showing-rule-in-the-administration) we would not use a custom component but we would render the `sw-condition-generic` component.
 
 
 ### Active rules

--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -119,6 +119,18 @@ $customer = $scope->getSalesChannelContext()->getCustomer();
 $loggedIn = $customer !== null;
 ```
 
+It is possible to add config to our rule. This makes it possible to skip the [Custom rule component](https://developer.shopware.com/docs/guides/plugins/plugins/framework/rule/add-custom-rules.html#custom-rule-component) and the [Custom rule Administration template](https://developer.shopware.com/docs/guides/plugins/plugins/framework/rule/add-custom-rules.html#custom-rule-administration-template) parts.
+
+```php
+    public function getConfig(): RuleConfig
+    {
+        return (new RuleConfig())->booleanField('isFirstMondayOfTheMonth');
+    }
+```
+
+when [Showing rule in the Administration](https://developer.shopware.com/docs/guides/plugins/plugins/framework/rule/add-custom-rules.html#showing-rule-in-the-administration) we would not use a custom component but we would render the `sw-condition-generic` component.
+
+
 ### Active rules
 
 You can access all active rules by using the `getRuleIds` method of the context.

--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -141,7 +141,7 @@ $context->getRuleIds();
 
 ### Showing rule in the Administration
 
-Now we want to implement our new rule in the Administration so that we can manage it. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by decorating this service. The decoration of services in the Administration will be covered in our [Adding services](../../administration/add-custom-service#Decorating%20a%20service) guide.
+Now we want to implement our new rule in the Administration so that we can manage it. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.6.0.0/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.ts), by decorating this service. The decoration of services in the Administration will be covered in our [Adding services](../../administration/add-custom-service#Decorating%20a%20service) guide.
 
 Create a new directory called `<plugin root>/src/Resources/app/administration/src/decorator`. In this directory we create a new file called `rule-condition-service-decoration.js`.
 
@@ -174,7 +174,7 @@ It may be possible that rules, with your newly created condition, aren't selecta
 :::
 
 #### Creating a new group in the administration
-The rule will now be added to the list of rules in the admin. It might be useful to create a new group for your rules. We can create a new group by using the `upsertGroup` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js).
+The rule will now be added to the list of rules in the admin. It might be useful to create a new group for your rules. We can create a new group by using the `upsertGroup` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.6.0.0/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.ts).
 
 ```javascript
   // <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js

--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -129,19 +129,39 @@ $context->getRuleIds();
 
 ### Showing rule in the Administration
 
-Now we want to implement our new rule in the Administration so that we can manage it. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by decorating this service. The decoration of services in the Administration will be covered in our [Adding services](../../administration/add-custom-service#Decorating%20a%20service) guide.
+Now we want to implement our new rule in the Administration so that we can manage it. If we would like our rule to be shown in a new group in the rule builder, we can create a new group using the `upsertGroup` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by decorating this service. The decoration of services in the Administration will be covered in our [Adding services](../../administration/add-custom-service#Decorating%20a%20service) guide.
 
 Create a new directory called `<plugin root>/src/Resources/app/administration/src/decorator`. In this directory we create a new file called `rule-condition-service-decoration.js`.
+
+```javascript
+  // <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
+  Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {
+      ruleConditionService.upsertGroup('days_of_the_month', {
+        id: 'days_of_the_month',
+        name: 'Days of the month',
+      });
+  
+      return ruleConditionService;
+  });
+```
+
+Now that we have our group, we have to create our condition. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by adding this to our decorated service.
 
 ```javascript
 // <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
 import '../../core/component/swag-first-monday';
 
 Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {
+    ruleConditionService.upsertGroup('days_of_the_month', {
+        id: 'days_of_the_month',
+        name: 'Days of the month',
+    });
+  
     ruleConditionService.addCondition('first_monday', {
         component: 'swag-first-monday',
         label: 'Is first monday of the month',
-        scopes: ['global']
+        scopes: ['global'],
+        group: 'days_of_the_month',
     });
 
     return ruleConditionService;

--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -141,39 +141,19 @@ $context->getRuleIds();
 
 ### Showing rule in the Administration
 
-Now we want to implement our new rule in the Administration so that we can manage it. If we would like our rule to be shown in a new group in the rule builder, we can create a new group using the `upsertGroup` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by decorating this service. The decoration of services in the Administration will be covered in our [Adding services](../../administration/add-custom-service#Decorating%20a%20service) guide.
+Now we want to implement our new rule in the Administration so that we can manage it. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by decorating this service. The decoration of services in the Administration will be covered in our [Adding services](../../administration/add-custom-service#Decorating%20a%20service) guide.
 
 Create a new directory called `<plugin root>/src/Resources/app/administration/src/decorator`. In this directory we create a new file called `rule-condition-service-decoration.js`.
-
-```javascript
-  // <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
-  Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {
-      ruleConditionService.upsertGroup('days_of_the_month', {
-        id: 'days_of_the_month',
-        name: 'Days of the month',
-      });
-  
-      return ruleConditionService;
-  });
-```
-
-Now that we have our group, we have to create our condition. To achieve this, we have to call the `addCondition` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js), by adding this to our decorated service.
 
 ```javascript
 // <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
 import '../../core/component/swag-first-monday';
 
 Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {
-    ruleConditionService.upsertGroup('days_of_the_month', {
-        id: 'days_of_the_month',
-        name: 'Days of the month',
-    });
-  
     ruleConditionService.addCondition('first_monday', {
         component: 'swag-first-monday',
         label: 'Is first monday of the month',
-        scopes: ['global'],
-        group: 'days_of_the_month',
+        scopes: ['global']
     });
 
     return ruleConditionService;
@@ -192,6 +172,39 @@ import './decorator/rule-condition-service-decoration';
 ::: info
 It may be possible that rules, with your newly created condition, aren't selectable in some places inside the Administration — for example, inside the promotion module. That is because rules are "context-aware". To learn more about that feature [click here](#context-awareness)
 :::
+
+#### Creating a new group in the administration
+The rule will now be added to the list of rules in the admin. It might be useful to create a new group for your rules. We can create a new group by using the `upsertGroup` method of the [RuleConditionService](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.js).
+
+```javascript
+  // <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
+  Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {
+      ruleConditionService.upsertGroup('days_of_the_month', {
+        id: 'days_of_the_month',
+        name: 'Days of the month',
+      });
+  
+      return ruleConditionService;
+  });
+```
+
+Now that we have our group, we have to link this group to our condition. This is easily done by adding the `group` property to our condition.
+
+```javascript
+// <plugin root>src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
+import '../../core/component/swag-first-monday';
+
+Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {
+    ruleConditionService.addCondition('first_monday', {
+        component: 'swag-first-monday',
+        label: 'Is first monday of the month',
+        scopes: ['global'],
+        group: 'days_of_the_month', // [!code highlight]
+    });
+
+    return ruleConditionService;
+});
+```
 
 ### Custom rule component
 

--- a/guides/plugins/plugins/framework/rule/add-custom-rules.md
+++ b/guides/plugins/plugins/framework/rule/add-custom-rules.md
@@ -199,7 +199,7 @@ Shopware.Application.addServiceProviderDecorator('ruleConditionDataProviderServi
         component: 'swag-first-monday',
         label: 'Is first monday of the month',
         scopes: ['global'],
-        group: 'days_of_the_month', // [!code highlight]
+        group: 'days_of_the_month', // [!code focus]
     });
 
     return ruleConditionService;


### PR DESCRIPTION
The current documentation overlooks adding a new group, which would be quite useful to include in the default example. Additionally, it doesn't highlight the efficiency gain achievable by utilizing the \Shopware\Core\Framework\Rule\Rule::getConfig function. This feature seems really handy, particularly for simpler rules, as it could save a significant amount of time and work.