### PR TITLE
Exchange term 'user' with more descriptive words

### DIFF
--- a/guides/plugins/apps/payment.md
+++ b/guides/plugins/apps/payment.md
@@ -359,7 +359,7 @@ class PaymentController {
 
 ## Prepared payments
 
-With Shopware 6.4.9.0, you can use prepared payments to enhance your checkout process beyond forwarding to a payment provider.
+With Shopware `6.4.9.0`, you can use prepared payments to enhance your checkout process beyond forwarding to a payment provider.
 This feature enables you to integrate more deeply into the checkout process.
 This method allows you to prepare the payment before placing the order, e.g., with credit card fields on the checkout confirmation page.
 Once you add specific parameters to the order placement request in the Storefront, which is also known as the checkout confirmation form, you can pass these parameters to your prepared payment handler.

--- a/guides/plugins/apps/payment.md
+++ b/guides/plugins/apps/payment.md
@@ -7,7 +7,10 @@ nav:
 
 # Payment
 
-Starting with version `6.4.1.0`, Shopware also provides functionality for your app to be able to integrate payment providers. You can choose between just a simple request for approval in the background \(synchronous payment\) and the user being forwarded to a provider for payment \(asynchronous payment\). You provide one or two endpoints, one for starting the payment and providing a redirect URL and one for finalization to check for the resulting status of the payment. The requests and responses of all of your endpoints will be signed and feature JSON content.
+Starting with version `6.4.1.0`, Shopware also provides functionality for your app to be able to integrate payment providers.
+You can choose between just a simple request for approval in the background \(synchronous payment\) and the customer being forwarded to a provider for payment \(asynchronous payment\).
+You provide one or two endpoints, one for starting the payment and providing a redirect URL and one for finalization to check for the resulting status of the payment.
+The requests and responses of all of your endpoints will be signed and feature JSON content.
 
 ## Prerequisites
 
@@ -20,9 +23,14 @@ You can use a tunneling service like [ngrok](https://ngrok.com/) for development
 
 ## Manifest configuration
 
-If your app should provide one or multiple payment methods, you need to define these in your manifest. The created payment methods in Shopware will be identified by the name of your app and the identifier you define per payment method. You should therefore not change the identifier after release, otherwise new payment methods will be created.
+If your app should provide one or multiple payment methods, you need to define these in your manifest.
+The created payment methods in Shopware will be identified by the name of your app and the identifier you define per payment method.
+You should therefore not change the identifier after release, otherwise new payment methods will be created.
 
-You may choose between a synchronous and an asynchronous payment method. These two types are differentiated by defining a `finalize-url` or not. If no `finalize-url` is defined, the internal Shopware payment handler will default to a synchronous payment. If you do not want or need any communication during the payment process with your app, you can also choose not to provide a `pay-url`, then the payment will remain on open on checkout.
+You may choose between a synchronous and an asynchronous payment method.
+These two types are differentiated by defining a `finalize-url` or not.
+If no `finalize-url` is defined, the internal Shopware payment handler will default to a synchronous payment.
+If you do not want or need any communication during the payment process with your app, you can also choose not to provide a `pay-url`, then the payment will remain on open on checkout.
 
 Below, you can see different definitions of payment methods.
 
@@ -32,7 +40,14 @@ Depending on the URLs you provide, Shopware knows which kind of payment flow you
 
 ## Synchronous payments
 
-There are different types of payments. Synchronous payment is the simplest of all and does not need any additional interaction with the user. If you have defined a `pay-url`, you can choose to be informed about and possibly process the payment or not. If you do not need to communicate with your app, you can stop reading here and the transaction will stay open. But if you do define a `pay-url`, you can respond to the request with a different transaction status like authorize, paid, or failed. This is useful if you want to add a payment provider that only needs the information if the user has already provided it in the checkout process or not. For example, a simple credit check for payment upon invoice. Below you can see an example of a simple answer from your app to mark a payment as authorized.
+There are different types of payments.
+Synchronous payment is the simplest of all and does not need any additional interaction with the customer.
+If you have defined a `pay-url`, you can choose to be informed about and possibly process the payment or not.
+If you do not need to communicate with your app, you can stop reading here and the transaction will stay open.
+But if you do define a `pay-url`, you can respond to the request with a different transaction status like authorize, paid, or failed.
+This is useful if you want to add a payment provider that only needs the information if the customer has already provided it in the checkout process or not.
+For example, a simple credit check for payment upon invoice.
+Below you can see an example of a simple answer from your app to mark a payment as authorized.
 
 <Tabs>
 
@@ -64,7 +79,8 @@ Refer to an example on [payment payload](https://github.com/shopware/app-php-sdk
 }
 ```
 
-Refer to possible [status values](#all-possible-payment-states). Failing states can also have a `message` property with the reason displayed to the user.
+Refer to possible [status values](#all-possible-payment-states).
+Failing states can also have a `message` property with the reason, which will be logged and could be seen as information for the merchant.
 
 ```json
 {
@@ -131,16 +147,19 @@ class PaymentController {
 
 ## Asynchronous payments
 
-Asynchronous payments are more complicated than synchronous payments. They require interaction with the user and a redirect to the payment provider, such as PayPal or Stripe.
+Asynchronous payments are more complicated than synchronous payments.
+They require interaction with the customer and a redirect to the payment provider, such as PayPal or Stripe.
 
 Here is how it works:
 
-* Shopware sends the first pay `POST` request to start the payment with the payment provider. The request includes all necessary data such as the `order`, `orderTransaction`, and a `returnUrl`, where the user should be redirected once the payment process with the payment provider has been finished.
+* Shopware sends the first pay `POST` request to start the payment with the payment provider.
+  The request includes all necessary data such as the `order`, `orderTransaction`, and a `returnUrl`,
+  where the customer should be redirected once the payment process with the payment provider has been finished.
 * Your app server returns a response with a `redirectUrl` to the payment provider.
-* The browser will be redirected to this URL and processes his order, and the payment provider will redirect the user
-  back to the `returnUrl` provided in the first request.
+* The browser will be redirected to this URL and processes his order,
+  and the payment provider will redirect the customer back to the `returnUrl` provided in the first request.
 * Shopware sends a second `POST` request to the `finalize-url` with the `orderTransaction` and all the query parameters passed by the payment provider to Shopware.
-* Our app server responds with a `status` and a `message` if necessary, like in the synchronous payment.
+* Your app server responds with a `status` and a `message` if necessary, like in the synchronous payment.
 
 <Tabs>
 
@@ -171,7 +190,7 @@ and your response should look like this:
 
 ```json
 {
-  "redirectUrl": "https://payment.app/user/gotoPaymentProvider"
+  "redirectUrl": "https://payment.app/customer/gotoPaymentProvider"
 }
 ```
 
@@ -197,7 +216,7 @@ function pay(RequestInterface $request): ResponseInterface
     $payment = $contextResolver->assemblePaymentPay($serverRequest, $shop);
     
     // Implement your logic here based on the information provided in $payment. 
-    // Payment providers should redirect the user to $payment->returnUrl once the payment process has been finished.
+    // Payment providers should redirect the customer to $payment->returnUrl once the payment process has been finished.
     
     return $signer->signResponse(PaymentResponse::redirect($paymentProviderRediectUrl), $shop);
 }
@@ -231,17 +250,16 @@ class PaymentController {
 
 </Tabs>
 
-The second `finalize` POST request will be called once the user has been redirected back to the shop.
-This second request is only provided with the `orderTransaction` for identification purposes and `requestData` with all query parameters
-passed by the payment provider.
+The second `finalize` POST request will be called once the customer has been redirected back to the shop.
+This second request is only provided with the `orderTransaction` for identification purposes and `requestData` with all query parameters passed by the payment provider.
 The response `status` value determines the outcome of the payment, e.g.:
 
-| Status      | Description                                                 |
-|:------------|:------------------------------------------------------------|
-| `cancel`    | User has aborted the payment at the payment provider's site |
-| `fail`      | Payment has failed \(e.g. missing funds\)                   |
-| `paid`      | Successful immediate payment                                |
-| `authorize` | Delayed payment                                             |
+| Status      | Description                                                     |
+|:------------|:----------------------------------------------------------------|
+| `cancel`    | Customer has aborted the payment at the payment provider's site |
+| `fail`      | Payment has failed \(e.g. missing funds\)                       |
+| `paid`      | Successful immediate payment                                    |
+| `authorize` | Delayed payment                                                 |
 
 <Tabs>
 
@@ -273,7 +291,8 @@ and your response should look like this:
 }
 ```
 
-Refer possible [status values](#all-possible-payment-states). Failing states can also have a `message` property with the reason displayed to the user.
+Refer possible [status values](#all-possible-payment-states).
+Failing states can also have a `message` property with the reason, which will be logged and could be seen as information for the merchant.
 
 ```json
 {
@@ -340,11 +359,22 @@ class PaymentController {
 
 ## Prepared payments
 
-With Shopware 6.4.9.0, you can use prepared payments to enhance your checkout process beyond forwarding to a payment provider. This feature enables you to integrate more deeply into the checkout process. This method allows you to prepare the payment before placing the order, e.g., with credit card fields on the checkout confirmation page. Once you add specific parameters to the order placement request in the Storefront, which is also known as the checkout confirmation form, you can pass these parameters to your prepared payment handler. This enables your payment handler to capture the payment successfully when the order is placed.
+With Shopware 6.4.9.0, you can use prepared payments to enhance your checkout process beyond forwarding to a payment provider.
+This feature enables you to integrate more deeply into the checkout process.
+This method allows you to prepare the payment before placing the order, e.g., with credit card fields on the checkout confirmation page.
+Once you add specific parameters to the order placement request in the Storefront, which is also known as the checkout confirmation form, you can pass these parameters to your prepared payment handler.
+This enables your payment handler to capture the payment successfully when the order is placed.
 
-For this, you have two calls available during the order placement, the `validate` call to verify, that the payment reference is valid and if not, stop the placement of the order, and the `capture` call, which then allows the payment to be processed to completion after the order has been placed and persisted.
+For this, you have two calls available during the order placement, the `validate` call to verify,
+that the payment reference is valid and if not, stop the placement of the order, and the `capture` call,
+which then allows the payment to be processed to completion after the order has been placed and persisted.
 
-Let's first talk about the `validate` call. Here, you will receive three items to validate your payment. The `cart` with all its line items, the `requestData` from the `CartOrderRoute` request and the current `salesChannelContext`. This allows you to validate, if the payment reference you may have given your payment handler via the Storefront implementation is valid and will be able to be used to pay the order which is about to be placed. The array data you may send as the `preOrderPayment` object in your response will be forwarded to your `capture` call, so you don't have to worry about identifying the order by looking at the cart from the `validate` call. If the payment is invalid, either return a response with an error response code or provide a `message` in your response.
+Let's first talk about the `validate` call.
+Here, you will receive three items to validate your payment.
+The `cart` with all its line items, the `requestData` from the `CartOrderRoute` request and the current `salesChannelContext`.
+This allows you to validate, if the payment reference you may have given your payment handler via the Storefront implementation is valid and will be able to be used to pay the order which is about to be placed.
+The array data you may send as the `preOrderPayment` object in your response will be forwarded to your `capture` call, so you don't have to worry about identifying the order by looking at the cart from the `validate` call.
+If the payment is invalid, either return a response with an error response code or provide a `message` in your response.
 
 <Tabs>
 
@@ -438,7 +468,8 @@ class PaymentController {
 
 </Tabs>
 
-If the payment has been validated and the order has been placed, you then receive another call to your `capture` endpoint. You will receive the `order`, the `orderTransaction` and also the `preOrderPayment` array data, that you have sent in your validate call.
+If the payment has been validated and the order has been placed, you then receive another call to your `capture` endpoint.
+You will receive the `order`, the `orderTransaction` and also the `preOrderPayment` array data, that you have sent in your validate call.
 
 <Tabs>
 
@@ -474,7 +505,7 @@ and your response should look like this:
 ```
 
 You can find all possible status values [here](#all-possible-payment-states).
-Failing states can have also a `message` property with the reason displayed to the user.
+Failing states can also have a `message` property with the reason, which will be logged and could be seen as information for the merchant.
 
 ```json
 {
@@ -543,14 +574,20 @@ class PaymentController {
 </Tabs>
 
 ::: warning
-Keep in mind that if the integration into the checkout process does not work as expected, your customer might not be able to use the prepared payment. This is especially valid for after order payments, since there the order already exists. For these cases, you should still offer a traditional synchronous / asynchronous payment flow. Don't worry, if you have set the transaction state in your capture call to anything but open, the asynchronous payment process will not be started immediately after the prepared payment flow.
+Keep in mind that if the integration into the checkout process does not work as expected,
+your customer might not be able to use the prepared payment.
+This is especially valid for after order payments, since there the order already exists.
+For these cases, you should still offer a traditional synchronous / asynchronous payment flow.
+Don't worry, if you have set the transaction state in your capture call to anything but open, the asynchronous payment process will not be started immediately after the prepared payment flow.
 :::
 
 ## Refund
 
-With Shopware 6.4.12.0, we have also added basic functionality to be able to refund payments. Your app will need to register captured amounts and create and persist a refund beforehand for Shopware to be able to process a refund of a capture.
+With Shopware 6.4.12.0, we have also added basic functionality to be able to refund payments.
+Your app will need to register captured amounts and create and persist a refund beforehand for Shopware to be able to process a refund of a capture.
 
-Similar to the other requests, on your `refund` call you will receive the data required to process your refund. This is the `order` with all its details and also the `refund` which holds the information on the `amount`, the referenced `capture` and, if provided, a `reason` and specific `positions` which items are being refunded.
+Similar to the other requests, on your `refund` call you will receive the data required to process your refund.
+This is the `order` with all its details and also the `refund` which holds the information on the `amount`, the referenced `capture` and, if provided, a `reason` and specific `positions` which items are being refunded.
 
 <Tabs>
 
@@ -620,7 +657,11 @@ function refund(RequestInterface $request): ResponseInterface
 Recurring orders and payments require the Subscriptions feature, available exclusively in our [paid plans](https://www.shopware.com/en/pricing/).
 :::
 
-Recurring payments are a special case of payment that is used for handling recurring orders, such as subscriptions. The request and response payloads are similar to the synchronous payment flow. At this point, a valid running billing agreement between the customer and the PSP should exist. Use any of the other payment flows to capture the initial order and create such an agreement during the checkout. Afterwards, the payment can be captured via this flow for every recurring payment order.
+Recurring payments are a special case of payment that is used for handling recurring orders, such as subscriptions.
+The request and response payloads are similar to the synchronous payment flow.
+At this point, a valid running billing agreement between the customer and the PSP should exist.
+Use any of the other payment flows to capture the initial order and create such an agreement during the checkout.
+Afterwards, the payment can be captured via this flow for every recurring payment order.
 
 <Tabs>
 

--- a/guides/plugins/apps/payment.md
+++ b/guides/plugins/apps/payment.md
@@ -661,7 +661,7 @@ Recurring payments are a special case of payment that is used for handling recur
 The request and response payloads are similar to the synchronous payment flow.
 At this point, a valid running billing agreement between the customer and the PSP should exist.
 Use any of the other payment flows to capture the initial order and create such an agreement during the checkout.
-Afterwards, the payment can be captured via this flow for every recurring payment order.
+Afterward, this flow can capture the payment for every recurring payment order.
 
 <Tabs>
 

--- a/guides/plugins/apps/payment.md
+++ b/guides/plugins/apps/payment.md
@@ -583,7 +583,7 @@ Don't worry, if you have set the transaction state in your capture call to anyth
 
 ## Refund
 
-With Shopware 6.4.12.0, we have also added basic functionality to be able to refund payments.
+With Shopware `6.4.12.0`, we have also added basic functionality to be able to refund payments.
 Your app will need to register captured amounts and create and persist a refund beforehand for Shopware to be able to process a refund of a capture.
 
 Similar to the other requests, on your `refund` call you will receive the data required to process your refund.


### PR DESCRIPTION
Using the term "user" in this guide, let to misunderstandings of the payment feature. In this particular case it was the "message" which could be send if the payment fails. 

I exchanged all occurrences, with "customer" or "merchant"