### PR TITLE
Update use-csrf-protection.md, fix function name sw_csrf

### DIFF
--- a/guides/plugins/plugins/storefront/use-csrf-protection.md
+++ b/guides/plugins/plugins/storefront/use-csrf-protection.md
@@ -60,7 +60,7 @@ Shopware 6 provides two different mechanisms for token generation:
 
 Therefore, the two new lines are the following:
 
-* The `{{ sw_csrf }}` function is used to generate a valid CSRF token with twig and append it as a hidden input field to the form.
+* The `sw_csrf` function is used to generate a valid CSRF token with twig and append it as a hidden input field to the form.
 
   It also accepts a `mode` parameter which can be set to `token` or `input`\(default\):
 


### PR DESCRIPTION
Do not use the curly braces. Otherwise the function name (sw_csrf) won't be displayed on the page.
![Bildschirmfoto vom 2024-04-04 12-39-43](https://github.com/shopware/docs/assets/2432190/e5e880f5-8ed5-4353-861d-c1e7ff0d48aa)
