### PR TITLE
Fix docs for custom admin search

### DIFF
--- a/guides/plugins/plugins/administration/search-custom-data.md
+++ b/guides/plugins/plugins/administration/search-custom-data.md
@@ -45,14 +45,14 @@ Shopware.Module.register('swag-plugin', {
     entity: 'swag_example',
     defaultSearchConfiguration: {
         _searchable: true,
-            name: {
+        name: {
             _searchable: true,
-                _score: 500,
+            _score: 500,
         },
         description: {
             name: {
                 _searchable: true,
-                    _score: 500,
+                _score: 500,
             },
         },
     },

--- a/guides/plugins/plugins/administration/search-custom-data.md
+++ b/guides/plugins/plugins/administration/search-custom-data.md
@@ -30,7 +30,7 @@ For this guide, it's necessary to have a running Shopware 6 instance and full ac
 
 In addition, you need a custom entity to add to the search to begin with. Head over to the following guide to learn how to achieve that:
 
-<PageRef page="../../framework/data-handling/add-custom-complex-data" />
+<PageRef page="../framework/data-handling/add-custom-complex-data" />
 
 ## Support custom entity via search API
 


### PR DESCRIPTION
The page about adding a custom entity search is outdated and still based on Shopware 6.4.
This PR updates the documentation so that it is correct again for 6.6.

In short:
- `shopware.composite_search.definition` has been deprecated
- The ApiServices have been deprecated
- Search configuration is managed through Administration Modules
- `hideOnGlobalSearchBar` is a new configuration option
- Change component snippets to work with the new async loading