### PR TITLE
Update reverse-http-cache.md

### DIFF
--- a/guides/hosting/infrastructure/reverse-http-cache.md
+++ b/guides/hosting/infrastructure/reverse-http-cache.md
@@ -226,7 +226,13 @@ sub vcl_backend_response {
 
     # Save the bereq.url so bans work efficiently
     set beresp.http.x-url = bereq.url;
-    set beresp.http.X-Cacheable = "YES";
+    
+    if(bereq.uncacheable) {
+        set beresp.http.X-Cacheable = "NO";
+    }
+    else {
+        set beresp.http.X-Cacheable = "YES";
+    }
 
     # Remove the exact PHP Version from the response for more security
     unset beresp.http.x-powered-by;
@@ -428,7 +434,12 @@ sub vcl_backend_response {
 
     # Save the bereq.url so bans work efficiently
     set beresp.http.x-url = bereq.url;
-    set beresp.http.X-Cacheable = "YES";
+    if(bereq.uncacheable) {
+        set beresp.http.X-Cacheable = "NO";
+    }
+    else {
+        set beresp.http.X-Cacheable = "YES";
+    }
 
     # Remove the exact PHP Version from the response for more security
     unset beresp.http.x-powered-by;
@@ -660,7 +671,12 @@ sub vcl_backend_response {
 
     # Save the bereq.url so bans work efficiently
     set beresp.http.x-url = bereq.url;
-    set beresp.http.X-Cacheable = "YES";
+    if(bereq.uncacheable) {
+        set beresp.http.X-Cacheable = "NO";
+    }
+    else {
+        set beresp.http.X-Cacheable = "YES";
+    }
 
     # Remove the exact PHP Version from the response for more security
     unset beresp.http.x-powered-by;


### PR DESCRIPTION
Besides the checks Cache-Control Header, there are multiple other possible reasons a side is uncacheable. See also https://www.varnish-software.com/developers/tutorials/varnish-builtin-vcl/  for some reason

* Custom Changes to VCL
* Authorization Headers
* extra Cookies send from the Shop
* Surrogate-Control Headers

