### PR TITLE
fix: add criteria association with language

### DIFF
--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -231,7 +231,11 @@ class ExampleDocumentRenderer extends AbstractDocumentRenderer
 
         $template = self::DEFAULT_TEMPLATE;
 
-        $orders = $this->orderRepository->search(new Criteria($ids), $context)->getEntities();
+        $criteria = new Criteria($ids);
+        $criteria->addAssociation('language');
+        $criteria->addAssociation('language.locale');
+
+        $orders = $this->orderRepository->search($criteria, $context)->getEntities();
         foreach ($orders as $order) {
             $orderId = $order->getId();
 


### PR DESCRIPTION
order->langue is null.

Following line would throw an error if order repository is not instructed to load language and language.locale
```$locale = $order->getLanguage()->getLocale();```
