### PR TITLE
»Writing templates« page: replace `slot="content"` with `#content`

### DIFF
--- a/guides/plugins/plugins/administration/writing-templates.md
+++ b/guides/plugins/plugins/administration/writing-templates.md
@@ -24,7 +24,7 @@ Let's look at all of this in practice, with the example of a component staticall
 ```html
 {% block swag_basic_example_page %}
     <sw-page class="swag-example-list">
-        <template slot="content">
+        <template #content>
             <h2>Hello world!</h2>
         </template>
     </sw-page>


### PR DESCRIPTION
Maybe I’m doing something wrong, but the `<template slot="content">` doesn’t work for me in Shopware 6.6, it needs to be `<template #content>`