### PR TITLE
docs: add missing PHP import in storefront controller example

### DIFF
--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -38,6 +38,7 @@ Go ahead and create a new file `ExampleController.php` in the directory `<plugin
 namespace Swag\BasicExample\Storefront\Controller;
 
 use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\Routing\Attribute\Route;
 
 #[Route(defaults: ['_routeScope' => ['storefront']])]
 class ExampleController extends StorefrontController


### PR DESCRIPTION
When copy/pasting the example, the `#[Route()]` use statement is missing 😉