### PR TITLE
Update example code snippets in add-custom-controller.md

### DIFF
--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -96,7 +96,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Route(defaults: ['_routeScope' => ['storefront']])]
 class ExampleController extends StorefrontController
 {
-    #[Route(path: '/example', name: 'frontend.example.example', methods: ['GET'], defaults: ['_routeScope' => 'storefront'])]
+    #[Route(path: '/example', name: 'frontend.example.example', methods: ['GET'], defaults: ['_routeScope' => ['storefront']])]
     public function showExample(): Response
     {
         ...
@@ -143,7 +143,7 @@ Once we‘ve registered our new controller, we have to tell Shopware how we want
         xsi:schemaLocation="http://symfony.com/schema/routing
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <import resource="../../Storefront/Controller/**/*Controller.php" type="attribute" />
+    <import resource="../../Storefront/Controller/*Controller.php" type="attribute" />
 </routes>
 ```
 


### PR DESCRIPTION
1. `_routeScope` value should be an array, not a string
2. Controller in the given example is located in the `../../Storefront/Controller/` folder