### PR TITLE
Fix custom commands guide for symfony 7 / Shopware 6.6

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md
@@ -70,11 +70,10 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+// Command name
+#[AsCommand(name: 'swag-commands:example')]
 class ExampleCommand extends Command
 {
-    // Command name
-    protected static $defaultName = 'swag-commands:example';
-
     // Provides a description, printed out in bin/console
     protected function configure(): void
     {
@@ -86,8 +85,7 @@ class ExampleCommand extends Command
     {
         $output->writeln('It works!');
 
-        // Exit code 0 for success
-        return 0;
+        return Command::SUCCESS;
     }
 }
 ```


### PR DESCRIPTION
In Symfony 7 the way you set a command's name changed and now only supports using either the constructor parameter or more commonly the `#[AsCommand]` attribute.

This is caused by the following code snippet: https://github.com/symfony/console/blob/9b008f2d7b21c74ef4d0c3de6077a642bc55ece3/Command/Command.php#L57-L64 

Additionally I changed the return statement to use the corresponding const var for better readability.