### PR TITLE
Add usage of `Shopware.Snippet.tc()` to admin js

### DIFF
--- a/guides/plugins/plugins/administration/adding-snippets.md
+++ b/guides/plugins/plugins/administration/adding-snippets.md
@@ -61,7 +61,7 @@ Component.register('my-custom-page', {
 });
 ```
 
-Or use `Shopware.Snippet.tc('swag-example.general.myCustomText')` when `this` doesn't point to a component (see also [Vue3 upgrade](../../../../resources/references/upgrades/administration/vue3) update)
+Or use `Shopware.Snippet.tc('swag-example.general.myCustomText')` when `this` doesn't point to a component (see also [Vue3 upgrade](../../../../resources/references/upgrades/administration/vue3))
 
 ## Using the snippets in templates
 

--- a/guides/plugins/plugins/administration/adding-snippets.md
+++ b/guides/plugins/plugins/administration/adding-snippets.md
@@ -61,6 +61,8 @@ Component.register('my-custom-page', {
 });
 ```
 
+Or use `Shopware.Snippet.tc('swag-example.general.myCustomText')` when `this` doesn't point to a component.
+
 ## Using the snippets in templates
 
 The same `$tc` helper function can be used in the templates to access translations.

--- a/guides/plugins/plugins/administration/adding-snippets.md
+++ b/guides/plugins/plugins/administration/adding-snippets.md
@@ -61,7 +61,7 @@ Component.register('my-custom-page', {
 });
 ```
 
-Or use `Shopware.Snippet.tc('swag-example.general.myCustomText')` when `this` doesn't point to a component.
+Or use `Shopware.Snippet.tc('swag-example.general.myCustomText')` when `this` doesn't point to a component (see also [Vue3 upgrade](../../../../resources/references/upgrades/administration/vue3) update)
 
 ## Using the snippets in templates
 


### PR DESCRIPTION
Real live example:

```JS
import CMS from '../../constant/custom.constant'
import template from './custom-anchor.html.twig';

export default {
    template,

    inject: ['repositoryFactory'],

    props: {
        anchor: {
            type: String,
            default: {
                type: 'anchor',
                value: '#anchor',
                content: 'Lorem Ipsum',
                entityId: null
            }
        },
        hideContent: {
            type: Boolean,
            default: false
        }
    },

    emits: [
        'update:anchor',
    ],

    data: () => {
        return {
            CMS,
            types: [
                {
                    name: Shopware.Snippet.tc('custom.general.anchor'),
                    id: 'anchor'
                },
                {
                    name: Shopware.Snippet.tc('global.entities.category'),
                    id: 'category'
                },
                {
                    name: Shopware.Snippet.tc('global.entities.landing_page'),
                    id: 'landing_page'
                },
                {
                    name: Shopware.Snippet.tc('global.entities.product'),
                    id: 'product'
                },
            ]
        };
    },

    computed: {
        anchor: {
            get() {
                return this.anchor;
            },
            set(value) {
                this.$emit('update:anchor', value);
            }
        },

        onChangeType() {
            // trigger type change to change template
            this.$emit('update:anchor', this.anchor);
        }
    },
};
```