### PR TITLE
Update add-translations.md folder name

### DIFF
--- a/guides/plugins/plugins/storefront/add-translations.md
+++ b/guides/plugins/plugins/storefront/add-translations.md
@@ -28,9 +28,9 @@ So your structure could then look like this:
     └── src
         ├─ Resources
         │  └─ snippet
-        │     ├─ de_DE
+        │     ├─ de-DE
         │     │  └─ example.de-DE.json
-        │     └─ en_GB
+        │     └─ en-GB
         │        └─ example.en-GB.json
         └─ SwagBasicExample.php
 ```


### PR DESCRIPTION
Translation snippet is registered only with " - " and not with "_". Folder name inside documentation says de_DE / en_GB but it should be de-DE / en-GB to make translation automatically works with newest shopware core version.