### PR TITLE
Add max mysql version for 6 5

### DIFF
--- a/guides/installation/requirements.md
+++ b/guides/installation/requirements.md
@@ -57,7 +57,7 @@ You can use these commands to check your actual environment:
 
   * Recommended version: 8.0
   * Minimum version: 8.0.17
-  * Problematic versions: 8.0.20, 8.0.21
+  * Not supported versions: 8.0.20, 8.0.21. 8.4.x onwards
 
 * MariaDB
 


### PR DESCRIPTION
Mysql 8.4 is not supported for 6.5, see https://github.com/shopware/shopware/issues/3809