### PR TITLE
fix: changed cache invalidation run_interval from minutes to seconds

### DIFF
--- a/guides/hosting/performance/performance-tweaks.md
+++ b/guides/hosting/performance/performance-tweaks.md
@@ -36,7 +36,7 @@ shopware:
 ### Delayed invalidation
 
 A delay for cache invalidation can be activated for systems with a high update frequency for the inventory (products, categories). Once the instruction to delete the cache entries for a specific product or category occurs, they are not deleted instantly but processed by a background task later. Thus, if two processes invalidate the cache in quick succession, the timer for the invalidation of this cache entry will only reset.
-By default, the scheduled task will run every 20 minutes, but the interval can be adjusted over the `scheduled_taks` DB table, by setting the `run_interval` to the desired value (it is configured in minutes) for the entry with the name `shopware.invalidate_cache`. 
+By default, the scheduled task will run every 20 seconds, but the interval can be adjusted over the `scheduled_taks` DB table, by setting the `run_interval` to the desired value (it is configured in seconds) for the entry with the name `shopware.invalidate_cache`. 
 ```yaml
 # config/packages/prod/shopware.yaml
 shopware:


### PR DESCRIPTION
Updated the performance tweaks documentation to reflect that that `run_interval` in the `scheduled_tasks` DB table is configured in seconds.

See [4771](https://github.com/shopware/shopware/issues/4771) in shopware/shopware.