### PR TITLE
Fixed broken Link to Differentiator Clusters

### DIFF
--- a/resources/guidelines/testing/store/index.md
+++ b/resources/guidelines/testing/store/index.md
@@ -7,7 +7,7 @@ nav:
 
 # Testing Guidelines for Shopware Extensions
 
-This section guides you with the criteria used to test your extension. Detailed information is available on [quality guidelines for apps](../store/quality-guidelines-apps/),[quality guidelines for plugins](../store/quality-guidelines-plugins/) and [differentiator cluster](../testing/differentiator-cluster/).
+This section guides you with the criteria used to test your extension. Detailed information is available on [quality guidelines for apps](../store/quality-guidelines-apps/),[quality guidelines for plugins](../store/quality-guidelines-plugins/) and [differentiator cluster](../Differentiator-Clusters.html).
 
 Check out the points that affect your extension and go through them before submitting it for testing.
 


### PR DESCRIPTION
Fixed broken Link to Differentiator Clusters: https://developer.shopware.com/docs/resources/guidelines/testing/Differentiator-Clusters.html