### PR TITLE
fix: add missing import to add-scheduled-task.md

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
@@ -89,6 +89,7 @@ Following will be the respective task handler:
 namespace Swag\BasicExample\Service\ScheduledTask;
 
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler(handles: ExampleTask::class)]
 class ExampleTaskHandler extends ScheduledTaskHandler


### PR DESCRIPTION
The Import "use Symfony\Component\Messenger\Attribute\AsMessageHandler;" is required for the scheduled task handler to properly work.

It should be part of the guide to create scheduled tasks.