### PR TITLE
Update add-scss-variables-via-subscriber.md

### DIFF
--- a/guides/plugins/plugins/storefront/add-scss-variables-via-subscriber.md
+++ b/guides/plugins/plugins/storefront/add-scss-variables-via-subscriber.md
@@ -49,7 +49,7 @@ You can add a new subscriber according to the [Listening to events](../plugin-fu
 
 namespace Swag\BasicExample\Subscriber;
 
-use Shopware\Storefront\Event\ThemeCompilerEnrichScssVariablesEvent;
+use Shopware\Storefront\Theme\Event\ThemeCompilerEnrichScssVariablesEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ThemeVariableSubscriber implements EventSubscriberInterface


### PR DESCRIPTION
## Moved and changed the `ThemeCompilerEnrichScssVariablesEvent`

We moved the event `ThemeCompilerEnrichScssVariablesEvent` from `\Shopware\Storefront\Event\ThemeCompilerEnrichScssVariablesEvent` to `\Shopware\Storefront\Theme\Event\ThemeCompilerEnrichScssVariablesEvent`.