### PR TITLE
Update plugin-base-guide.md

### DIFF
--- a/guides/plugins/plugins/plugin-base-guide.md
+++ b/guides/plugins/plugins/plugin-base-guide.md
@@ -110,7 +110,7 @@ Here's an example `composer.json` for this guide, which will do the trick:
         }
     ],
     "require": {
-        "shopware/core": "6.5.*"
+        "shopware/core": "~6.6.0"
     },
     "extra": {
         "shopware-plugin-class": "Swag\\BasicExample\\SwagBasicExample",


### PR DESCRIPTION
- update shopware version, fixes:

```sh
[Shopware\Core\Framework\Plugin\Requirement\Exception\RequirementStackException]            
  Could not install plugin, got 1 failure(s).                                                 
  Required plugin/package "shopware/core 6.5.*" does not match installed version == 6.6.8.1
```