### PR TITLE
NEXT-39755 - Update messenger docs to use default symfony bus

### DIFF
--- a/concepts/framework/messaging.md
+++ b/concepts/framework/messaging.md
@@ -13,7 +13,7 @@ Shopware integrates with the [Symfony Messenger](https://symfony.com/doc/current
 
 ### Message Bus
 
-The [Message bus](https://symfony.com/doc/current/components/messenger.html#bus) is used to dispatch your messages to your registered handlers. While dispatching your message it loops through the configured middleware for that bus. The message bus used inside Shopware can be found under the service tag `messenger.bus.shopware`. It is mandatory to use this message bus if your messages should be handled inside Shopware. However, if you want to send messages to external systems, you can define your custom message bus for that.
+The [Message bus](https://symfony.com/doc/current/components/messenger.html#bus) is used to dispatch your messages to your registered handlers. While dispatching your message it loops through the configured middleware for that bus. The message bus used inside Shopware can be found under the service tag `messenger.default_bus`. It is mandatory to use this message bus if your messages should be handled inside Shopware. However, if you want to send messages to external systems, you can define your custom message bus for that.
 
 ### Middleware
 

--- a/guides/hosting/infrastructure/message-queue.md
+++ b/guides/hosting/infrastructure/message-queue.md
@@ -163,7 +163,7 @@ Sometimes, it also makes sense to route messages to a different transport to lim
 
 ### Message bus
 
-The message bus is used to dispatch your messages to your registered handlers. While dispatching your message, it loops through the configured middleware for that bus. The message bus used inside Shopware can be found under the service tag `messenger.bus.shopware`. It is mandatory to use this message bus if your messages should be handled inside Shopware. However, if you want to send messages to external systems, you can define your custom message bus for that.
+The message bus is used to dispatch your messages to your registered handlers. While dispatching your message, it loops through the configured middleware for that bus. The message bus used inside Shopware can be found under the service tag `messenger.bus.default`. It is mandatory to use this message bus if your messages should be handled inside Shopware. However, if you want to send messages to external systems, you can define your custom message bus for that.
 
 You can configure an array of buses and define one default bus in your `framework.yaml`.
 
@@ -171,9 +171,9 @@ You can configure an array of buses and define one default bus in your `framewor
 // <platform root>/src/Core/Framework/Resources/config/packages/framework.yaml
 framework:
     messenger:
-        default_bus: messenger.bus.shopware
+        default_bus: my.messenger.bus
         buses:
-            messenger.bus.shopware:
+            my.messenger.bus:
 ```
 
 For more information on this check the [Symfony docs](https://symfony.com/doc/current/messenger/multiple_buses.html).

--- a/guides/plugins/plugins/framework/message-queue/add-message-to-queue.md
+++ b/guides/plugins/plugins/framework/message-queue/add-message-to-queue.md
@@ -57,7 +57,7 @@ class SmsNotification implements AsyncMessageInterface
 
 ## Send a message
 
-After we've created our notification, we will create a service that will send our `SmsNotification`. We will name this service `ExampleSender`. In this service we need to inject the `Symfony\Component\Messenger\MessageBusInterface`, that is needed to send the message through the desired bus, which is called `messenger.bus.shopware`.
+After we've created our notification, we will create a service that will send our `SmsNotification`. We will name this service `ExampleSender`. In this service we need to inject the `Symfony\Component\Messenger\MessageBusInterface`, that is needed to send the message through the desired bus, which is called `messenger.default_bus`.
 
 ```php
 // <plugin root>/src/Service/ExampleSender.php

--- a/guides/plugins/plugins/framework/message-queue/add-middleware.md
+++ b/guides/plugins/plugins/framework/message-queue/add-middleware.md
@@ -53,12 +53,11 @@ For each defined bus in our `framework.yaml`, we can define the middleware that 
 // <platform root>/src/Core/Framework/Resources/config/packages/framework.yaml
 framework:
     messenger:
-        default_bus: messenger.bus.shopware
         buses:
-            messenger.bus.default:
-              middleware:
-                - 'Swag\BasicExample\MessageQueue\Middleware\ExampleMiddleware'
-                - 'Swag\BasicExample\MessageQueue\Middleware\AnotherExampleMiddleware'
+          messenger.bus.default:
+            middleware:
+              - 'Swag\BasicExample\MessageQueue\Middleware\ExampleMiddleware'
+              - 'Swag\BasicExample\MessageQueue\Middleware\AnotherExampleMiddleware'
 ```
 
 ## More interesting topics


### PR DESCRIPTION
Should be merged for 6.6.10 - will be a bit confusing before hand