### PR TITLE
Remove cache warmer docs

### DIFF
--- a/guides/hosting/performance/caches.md
+++ b/guides/hosting/performance/caches.md
@@ -22,10 +22,6 @@ The HTTP cache configuration takes place completely in the `.env file.` The foll
 | `SHOPWARE_HTTP_CACHE_ENABLED` | Enables the HTTP cache         |
 | `SHOPWARE_HTTP_DEFAULT_TTL`   | Defines the default cache time |
 
-### How to trigger the HTTP cache warmer
-
-To warm up the HTTP cache, you can simply use the console command `http:cache:warm:up`. This command sends a message to the message queue for each sales channel domain to warm it up as fast as possible. It is important that queue workers are started according to our [message queue](../infrastructure/message-queue).
-
 ### How to change the cache storage
 
 The standard Shopware HTTP cache can be exchanged or reconfigured in several ways. The standard cache comes with an `adapter.filesystem`. The configuration can be found in the `shopware/src/Core/Framework/Resources/config/packages/framework.yaml` file.


### PR DESCRIPTION
THe cache warmer was removed with 6.6, but the docs mentioning it survived