### PR TITLE
docs: adjust contribution guidelines after move to GitHub

### DIFF
--- a/resources/guidelines/code/contribution.md
+++ b/resources/guidelines/code/contribution.md
@@ -48,6 +48,7 @@ You are responsible for maintaining and updating your pull request. This include
 * Responding to review comments in a timely manner
 * Updating the code according to review feedback
 * Keeping the PR up to date with the target branch if conflicts arise
+* Making sure that all pipeline checks succeed on your PR
 
 ::: tip
 Once your PR is public, avoid rebasing or force-pushing to the branch. Adding new commits makes it easier for reviewers to track changes and see what was updated in response to feedback. The PR will be automatically squashed when merged.
@@ -70,12 +71,8 @@ Your PR will normally get the first review within a week. We do regular meetings
 
 ## What happens after a pull request has been created
 
-Everyday weekdays, we assign the pull request to an Area (team) which is responsible for the specific part of the Shopware software. The Area will then review your pull request and decide what to do next.
-The Area can either accept your pull request, decline it, or ask you to update it with more information or changes.
-
-The next step is that the pull request gets a "Scheduled" label.
-This means that your pull request is now imported into our internal ticket system and will go through our internal workflow.
-You will find a comment containing the GitHub Issue to follow the process.
+Everyday weekdays, we assign the pull request to a Domain (team) which is responsible for the specific part of the Shopware software. The Area will then review your pull request and decide what to do next.
+The team can either accept your pull request, decline it, or ask you to update it with more information or changes.
 
 ## Why a pull request gets declined
 


### PR DESCRIPTION
Importing PRs is not necessary anymore 🎉 
But the pipeline is now actually meaningful on GH, so contributors should make sure that it suceeds