### PR TITLE
Update add-custom-component.md

### DIFF
--- a/guides/plugins/plugins/administration/module-component-management/add-custom-component.md
+++ b/guides/plugins/plugins/administration/module-component-management/add-custom-component.md
@@ -114,7 +114,7 @@ A component's template is being defined by using the `template` property. For th
 
 ```javascript
 // <plugin-root>/src/Resources/app/administration/src/component/custom-component/hello-world
-export default Shopware.Component.wrapComponentConfig('hello-world', {
+export default Shopware.Component.wrapComponentConfig({
     template: '<h2>Hello world!</h2>'
 });
 ```


### PR DESCRIPTION
Removed identifier, which is causing issues when **loading asynchronous components**, because the parameter probably is no longer expected in Shopware 6.6.  If it were to be retained, there would be too many parameters in the function and the JavaScript code of the administration could not be built.