### PR TITLE
Fix broken links on Mixins Documentation

### DIFF
--- a/guides/plugins/plugins/administration/mixins-directives/add-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/add-mixins.md
@@ -69,8 +69,3 @@ Component.register('swag-basic-example', {
 ```
 
 This can also be done with Shopware provided mixins, learn more about them here: [Using Mixins](using-mixins)
-
-## More interesting topics
-
-* [Adding filters](add-filter)
-* [Using utils](using-utils)

--- a/guides/plugins/plugins/administration/mixins-directives/add-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/add-mixins.md
@@ -69,3 +69,9 @@ Component.register('swag-basic-example', {
 ```
 
 This can also be done with Shopware provided mixins, learn more about them here: [Using Mixins](using-mixins)
+
+## More interesting topics
+
+* [Adding filters](../services-utilities/add-filter.md)
+* [Using utility functions](../services-utilities/using-utils.md)
+

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -17,7 +17,7 @@ All you need for this guide is a running Shopware 6 instance and full access to 
 
 ## Finding a mixin
 
-The Shopware 6 Administration comes with a few predefined [mixins](../../../../resources/references/administration-reference/mixins.md)
+The Shopware 6 Administration comes with a few predefined [mixins](../../../../../resources/references/administration-reference/mixins.md)
 
 If you want to learn how to create your own mixin look at this guide: [Creating mixins](add-mixins)
 

--- a/guides/plugins/plugins/administration/services-utilities/using-utils.md
+++ b/guides/plugins/plugins/administration/services-utilities/using-utils.md
@@ -4,7 +4,6 @@ nav:
   position: 250
 
 ---
-eee
 
 # Using utility functions
 

--- a/guides/plugins/plugins/administration/services-utilities/using-utils.md
+++ b/guides/plugins/plugins/administration/services-utilities/using-utils.md
@@ -4,6 +4,7 @@ nav:
   position: 250
 
 ---
+eee
 
 # Using utility functions
 

--- a/resources/references/administration-reference/directives.md
+++ b/resources/references/administration-reference/directives.md
@@ -8,7 +8,7 @@ nav:
 # Directives reference
 
 This is an overview of all the directives registered globally to Vue.
-Directives are the same as normally in Vue. Checkout the [Using directives](../../../guides/plugins/plugins/administration/adding-directives.md) article
+Directives are the same as normally in Vue. Checkout the [Using directives](../../../guides/plugins/plugins/administration/mixins-directives/adding-directives.md) article
 or refer to the [directives](https://github.com/shopware/shopware/tree/trunk/src/Administration/Resources/app/administration/src/app/directive) folder in the GIT repository.
 
 ## Overview of directives

--- a/resources/references/administration-reference/mixins.md
+++ b/resources/references/administration-reference/mixins.md
@@ -9,20 +9,22 @@ nav:
 
 This is an overview of all the mixins provided by the Shopware 6 Administration. Mixins in the Shopware 6 Administration are essentially the same in default Vue. They behave generally the same as they do in Vue normally, differing only in the registration and the way mixins are included in a component. Learn more about them in the official [Vue documentation](https://vuejs.org/v2/guide/mixins.html).
 
-Also take a look at [how to use them in your plugin](../../../guides/plugins/plugins/administration/using-mixins.md) and [how to register your own mixin](../../../guides/plugins/plugins/administration/add-mixins.md).
+Also take a look at [how to use them in your plugin](../../../guides/plugins/plugins/administration/mixins-directives/using-mixins.md) and [how to register your own mixin](../../../guides/plugins/plugins/administration/mixins-directives/add-mixins.md).
 
 ## Overview of all the mixins
 
 | Name | Description | Link |
 | :--- | :--- | :--- |
-| `discard-detail-page-changes` | Mixin which resets entity changes on page leave or if the id of the entity changes. This also affects changes in associations of the entity | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/discard-detail-page-changes.mixin.js) |
-| `listing` | Mixin which is used in almost all listing pages to for example keep track of the current page of the administration | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.js) |
-| `notification` | This mixin is used to create notifications in the administrations more easily | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/notification.mixin.js) |
-| `placeholder` | Provides a function to localize placeholders | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/placeholder.mixin.js) |
-| `position` | A Mixin which contains helpers to work with position integers | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/position.mixin.js) |
-| `remove-api-error` | This mixin removes API errors e.g. after the user corrected a invalid input i.e. leaving the product name field blank | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/remove-api-error.mixin.js) |
-| `ruleContainer` | Provides common functions between the `sw-condition-or-container` and the `sw-condition-and-container` | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/rule-container.mixin.js) |
-| `salutation` | A common adapter for the `salutation` filter | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/salutation.mixin.js) |
-| `sw-form-field` | This mixin is used to provide common functionality between form fields | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.js) |
-| `sw-inline-snippet` | Makes it possible to use snippets inline | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/sw-inline-snippet.mixin.js) |
-| `validation` | Is used to validate inputs in various form fields | [link](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/app/mixin/validation.mixin.js) |
+| `discard-detail-page-changes` | Mixin which resets entity changes on page leave or if the id of the entity changes. This also affects changes in associations of the entity | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/discard-detail-page-changes.mixin.ts) |
+| `form-field` | This mixin is used to provide common functionality between form fields | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts) |
+| `generic-condition` | placeholder | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/generic-condition.mixin.ts) |
+| `listing` | Mixin which is used in almost all listing pages to for example keep track of the current page of the administration | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts) |
+| `notification` | This mixin is used to create notifications in the administrations more easily | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/notification.mixin.ts) |
+| `placeholder` | Provides a function to localize placeholders | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/placeholder.mixin.ts) |
+| `position` | A Mixin which contains helpers to work with position integers | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/position.mixin.ts) |
+| `remove-api-error` | This mixin removes API errors e.g. after the user corrected a invalid input i.e. leaving the product name field blank | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/remove-api-error.mixin.ts) |
+| `rule-container` | Provides common functions between the `sw-condition-or-container` and the `sw-condition-and-container` | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/rule-container.mixin.ts) |
+| `salutation` | A common adapter for the `salutation` filter | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/salutation.mixin.ts) |
+| `sw-inline-snippet` | Makes it possible to use snippets inline | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/sw-inline-snippet.mixin.ts) |
+| `user-settings` | placeholder | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts) |
+| `validation` | Is used to validate inputs in various form fields | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/validation.mixin.ts) |

--- a/resources/references/administration-reference/mixins.md
+++ b/resources/references/administration-reference/mixins.md
@@ -17,7 +17,7 @@ Also take a look at [how to use them in your plugin](../../../guides/plugins/plu
 | :--- | :--- | :--- |
 | `discard-detail-page-changes` | Mixin which resets entity changes on page leave or if the id of the entity changes. This also affects changes in associations of the entity | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/discard-detail-page-changes.mixin.ts) |
 | `form-field` | This mixin is used to provide common functionality between form fields | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts) |
-| `generic-condition` | placeholder | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/generic-condition.mixin.ts) |
+| `generic-condition` |  | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/generic-condition.mixin.ts) |
 | `listing` | Mixin which is used in almost all listing pages to for example keep track of the current page of the administration | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/listing.mixin.ts) |
 | `notification` | This mixin is used to create notifications in the administrations more easily | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/notification.mixin.ts) |
 | `placeholder` | Provides a function to localize placeholders | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/placeholder.mixin.ts) |
@@ -26,5 +26,5 @@ Also take a look at [how to use them in your plugin](../../../guides/plugins/plu
 | `rule-container` | Provides common functions between the `sw-condition-or-container` and the `sw-condition-and-container` | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/rule-container.mixin.ts) |
 | `salutation` | A common adapter for the `salutation` filter | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/salutation.mixin.ts) |
 | `sw-inline-snippet` | Makes it possible to use snippets inline | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/sw-inline-snippet.mixin.ts) |
-| `user-settings` | placeholder | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts) |
+| `user-settings` |  | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/form-field.mixin.ts) |
 | `validation` | Is used to validate inputs in various form fields | [link](https://github.com/shopware/shopware/blob/v6.6.9.0/src/Administration/Resources/app/administration/src/app/mixin/validation.mixin.ts) |

--- a/resources/references/administration-reference/utils.md
+++ b/resources/references/administration-reference/utils.md
@@ -7,7 +7,7 @@ nav:
 
 # Utils
 
-This is an overview of all the utility functions bound to the shopware global object. Utility functions provide many useful shortcuts for common tasks, see how to use them in your plugin [here](../../../guides/plugins/plugins/administration/using-utils). Or see the code that registers them [here](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/core/service/util.service.js)
+This is an overview of all the utility functions bound to the shopware global object. Utility functions provide many useful shortcuts for common tasks, see how to use them in your plugin [here](../../../guides/plugins/plugins/administration/services-utilities/using-utils.md). Or see the code that registers them [here](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Administration/Resources/app/administration/src/core/service/util.service.js)
 
 ## General functions
 


### PR DESCRIPTION
I fixed the broken links on https://developer.shopware.com/docs/resources/references/administration-reference/mixins.html and some of the related pages. 

We still need a description for the `generic-condition` and `user-settings` mixins, which were not listed previously https://developer.shopware.com/docs/resources/references/administration-reference/mixins.html.