### PR TITLE
Add hint for the plugin name

### DIFF
--- a/guides/hosting/installation-updates/deployments/deployment-helper.md
+++ b/guides/hosting/installation-updates/deployments/deployment-helper.md
@@ -9,7 +9,7 @@ nav:
 
 The Deployment Helper is a tool that unifies the steps executed after the Code has been uploaded to the server.
 On a traditional deployment, you would run it after the files have been uploaded.
-When using a Containerized environment you would run Deployment Helper with the new source code and then switch over the traffic.
+When using a Containerized environment, you would run Deployment Helper with the new source code and then switch over the traffic.
 
 ## Installing the Deployment Helper
 
@@ -137,10 +137,22 @@ When you open the extension manager, you will see that you are not logged in. Th
 
 ## Removal of extensions
 
-To find the name of the extension you want to remove, you can use the `./bin/console plugin:list` command.
-The composer or label name will not work.
+To find the name (for example `SwagPlatformDemoData`) of the extension you want to remove, use the `./bin/console plugin:list` command.
 
-If you want to remove an extension you need to do it in two steps:
+```shell
+./bin/console plugin:list
+
+Shopware Plugin Service
+=======================
+
+ ----------------------------- ------------------------------------------ ---------------------------------------------- --------- ----------------- ------------------- ----------- -------- ------------- ---------------------- 
+  Plugin                        Label                                      Composer name                                  Version   Upgrade version   Author              Installed   Active   Upgradeable   Required by composer  
+ ----------------------------- ------------------------------------------ ---------------------------------------------- --------- ----------------- ------------------- ----------- -------- ------------- ----------------------
+  SwagPlatformDemoData          Shopware 6 Demo data                       swag/demo-data                                 2.0.1                       shopware AG         Yes         No       No            No 
+ ----------------------------- ------------------------------------------ ---------------------------------------------- --------- ----------------- ------------------- ----------- -------- ------------- ----------------------
+```
+
+If you want to remove an extension, you need to do it in two steps:
 
 1.) Set the extension to `remove` in the `.shopware-project.yml` file
 
@@ -171,7 +183,7 @@ After the deployment, you can remove the extension from the source code, remove 
 In a Docker environment, you have a base image with a running PHP Webserver.
 From that image you make a new image with your Shopware source code.
 To prepare the Shopware source code, you can run [shopware-cli project ci](https://sw-cli.fos.gg) to install the dependencies and build the assets.
-On deployment you spawn a second container or init a container, which runs the Deployment Helper.
+On deployment, you spawn a second container or init a container, which runs the Deployment Helper.
 The Deployment Helper sets up Shopware when it is not installed, installs the extensions and runs the one-time tasks.
 
 ### SFTP / Deployer

--- a/guides/hosting/installation-updates/deployments/deployment-helper.md
+++ b/guides/hosting/installation-updates/deployments/deployment-helper.md
@@ -137,6 +137,9 @@ When you open the extension manager, you will see that you are not logged in. Th
 
 ## Removal of extensions
 
+To find the name of the extension you want to remove, you can use the `./bin/console plugin:list` command.
+The composer or label name will not work.
+
 If you want to remove an extension you need to do it in two steps:
 
 1.) Set the extension to `remove` in the `.shopware-project.yml` file


### PR DESCRIPTION
I added a hint for the plugin list command and which name to use.
I'm not so happy with the name of the command `./bin/console` I guess it's just shopware cli? If you have a better idea, please let me know. 