### PR TITLE
Remove @Storefront

### DIFF
--- a/guides/plugins/themes/add-theme-inheritance.md
+++ b/guides/plugins/themes/add-theme-inheritance.md
@@ -72,7 +72,6 @@ Here is an example:
   ],
   "style": [
     "app/storefront/src/scss/overrides.scss",
-    "@Storefront",
     "@SwagBasicExampleTheme",
     "app/storefront/src/scss/base.scss"
   ],


### PR DESCRIPTION
Reference: https://shopwarecommunity.slack.com/archives/C01JH7CGT7V/p1736331528674989

Tested and approved. Border radius only is 10px if @Storefront is removed.

![2025-01-23_17-09_1](https://github.com/user-attachments/assets/af9464ec-7335-4388-8da5-1f8edc91a70d)
![2025-01-23_17-09](https://github.com/user-attachments/assets/2a1bfc68-770a-41a6-be08-ba3f08972677)
![2025-01-23_17-08](https://github.com/user-attachments/assets/78ed8825-afca-4c78-a31e-4e535d6fccdf)
