### PR TITLE
docs: update docs for 6.7 instructions for the sdk

### DIFF
--- a/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
+++ b/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
@@ -56,7 +56,7 @@ import 'regenerator-runtime/runtime';
 import { location } from '@shopware-ag/meteor-admin-sdk';
 
 // Only execute extensionSDK commands when
-// it is inside a iFrame (only needed for plugins)
+// it is inside a iFrame (only necessary for plugins when using Shopware version below 6.7)
 if (location.isIframe()) {
     if (location.is(location.MAIN_HIDDEN)) {
         // Execute the base commands
@@ -70,6 +70,7 @@ if (location.isIframe()) {
 
 This is the main file, which is executed first and functions as the entry point.
 
+[Only necessary when using Shopware version below 6.7]  
 Start with `if(location.isIframe())` to make sure only content used inside iFrames is loaded. While the SDK is used in apps and plugins, this check ensures the code is executed in the right place.
 
 Next you need `if(location.is(location.MAIN_HIDDEN))` to **load the main commands**, which are defined in the `mainCommands.ts` file. This will only be used to load logic, but not templates into the Administration.

--- a/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
+++ b/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
@@ -52,11 +52,12 @@ When our extension is finished, you will get the following file structure:
 Everything starts in the `main.ts` file:
 
 ```javascript
+// Prior to 6.7
 import 'regenerator-runtime/runtime';
 import { location } from '@shopware-ag/meteor-admin-sdk';
 
 // Only execute extensionSDK commands when
-// it is inside a iFrame (only necessary for plugins when using Shopware version below 6.7)
+// it is inside an iFrame
 if (location.isIframe()) {
     if (location.is(location.MAIN_HIDDEN)) {
         // Execute the base commands
@@ -68,14 +69,23 @@ if (location.isIframe()) {
 }
 ```
 
+```javascript
+// 6.7 and above (inside meteor-app folder)
+import 'regenerator-runtime/runtime';
+import { location } from '@shopware-ag/meteor-admin-sdk';
+
+if (location.is(location.MAIN_HIDDEN)) {
+    // Execute the base commands
+    import('./base/mainCommands');
+} else {
+    // Render different views
+    import('./viewRenderer');
+}
+```
+
 This is the main file, which is executed first and functions as the entry point.
 
-::: info
-The steps below are only necessary for Shopware versions below 6.7.
-:::
-Start with `if(location.isIframe())` to make sure only content used inside iFrames is loaded. While the SDK is used in apps and plugins, this check ensures the code is executed in the right place.
-
-Next you need `if(location.is(location.MAIN_HIDDEN))` to **load the main commands**, which are defined in the `mainCommands.ts` file. This will only be used to load logic, but not templates into the Administration.
+Use `if(location.is(location.MAIN_HIDDEN))` to **load the main commands**, which are defined in the `mainCommands.ts` file. This will only be used to load logic, but not templates into the Administration.
 
 Lastly, the `else` case will be responsible for specific loading of views via `viewRenderer.ts`. This is where the view templates will be loaded.
 

--- a/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
+++ b/guides/plugins/apps/administration/add-cms-element-via-admin-sdk.md
@@ -70,7 +70,9 @@ if (location.isIframe()) {
 
 This is the main file, which is executed first and functions as the entry point.
 
-[Only necessary when using Shopware version below 6.7]  
+::: info
+The steps below are only necessary for Shopware versions below 6.7.
+:::
 Start with `if(location.isIframe())` to make sure only content used inside iFrames is loaded. While the SDK is used in apps and plugins, this check ensures the code is executed in the right place.
 
 Next you need `if(location.is(location.MAIN_HIDDEN))` to **load the main commands**, which are defined in the `mainCommands.ts` file. This will only be used to load logic, but not templates into the Administration.


### PR DESCRIPTION
The handling for using iFrames inside plugins in the administration changes with 6.7 upwards and Vite