### PR TITLE
fix: remove .shopware-extension.yml as disallowed files

### DIFF
--- a/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
@@ -526,7 +526,6 @@ Here are some examples of not allowed folders and files:
 * phpstan.neon
 * phpstan.neon.dist
 * .prettierrc
-* .shopware-extension.yml
 * .tar
 * .tar.gz
 * .zip


### PR DESCRIPTION
That file contains some information which are good to know for `shopware-cli project ci`