### PR TITLE
chore: Update tools from the plugin qualitiy guidelines

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -367,7 +367,6 @@ FooterPagelet
 FrameworkBundle
 FriendsOfShopware
 FroshDevelopmentHelper
-FroshPluginUploader
 Fullstack
 GDPR
 GIFs

--- a/resources/guidelines/testing/store/quality-guidelines-apps/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-apps/index.md
@@ -383,10 +383,9 @@ The following statements will be blocked as of 1st Oct. 2022:
 
 [Refer to the list of the already existing blockers](https://s3.eu-central-1.amazonaws.com/wiki-assets.shopware.com/1657519735/blocker.txt).
 
-### Helpful tools for app developers
+### Useful tool for app development and extension management
 
-* [FroshPluginUploader](https://github.com/FriendsOfShopware/FroshPluginUploader): Tool for validating and uploading new SW6 app releases to the Community Store (GitHub Project from "Friends of Shopware")]
-* [Shopware CLI tools](https://github.com/shopwareLabs/sw-cli-tools): When you think about performance, these are various useful console helpers for generating data.
+The [`shopware-cli`](https://github.com/shopware/shopware-cli) is a useful tool for building, validating and uploading new Shopware 6 app releases to the Community Store. It also allows you to manage the store description and images of your apps efficiently.
 
 ## Automatic code review - Errors
 

--- a/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
@@ -422,10 +422,9 @@ The project is driven by the *Friends of Shopware* group. You can contribute at 
 * Link: [Developer Documentation Cypress Tests for Shopware 6](../../../../../guides/plugins/plugins/testing/end-to-end-testing)
 * Link: [Cypress Tests for Shopware 6](https://github.com/shopware/shopware/tree/trunk/src/Administration/Resources)
 
-### Helpful tools for app developers
+### Useful tool for plugin development and extension management
 
-* Link: [FroshPluginUploader](https://github.com/FriendsOfShopware/FroshPluginUploader) Tool for validating and uploading new SW6 app releases to the Community Store (GitHub Project from "Friends of Shopware").
-* Link: [Shopware CLI tools / console helpers](https://github.com/shopwareLabs/sw-cli-tools)
+The [`shopware-cli`](https://github.com/shopware/shopware-cli) is a useful tool for building, validating and uploading new Shopware 6 plugin releases to the Community Store. It also allows you to manage the store description and images of your plugins efficiently.
 
 ## Automatic code review - Errors
 


### PR DESCRIPTION
The `FroshPluginUploader` is deprecated: https://github.com/FriendsOfShopware/FroshPluginUploader?tab=readme-ov-file#this-tool-is-abandoned-and-will-only-receive-bug-fixes-please-move-to-httpsgithubcomfriendsofshopwareshopware-cli

For the `sw-cli-tools` I am not sure, what the status there is, but I changed the naming a bit, to be not to confusing.