### PR TITLE
Fix outdated JS paths in theme.json for 6.6

### DIFF
--- a/guides/plugins/themes/add-css-js-to-theme.md
+++ b/guides/plugins/themes/add-css-js-to-theme.md
@@ -91,7 +91,7 @@ Add some test code in order to see if it works out:
 console.log('SwagBasicExampleTheme JS loaded');
 ```
 
-In the end, by running the command `bin/build-storefront.sh` your custom JS plugin is loaded. By default, the compiled JavaScript file is saved as `<plugin root>/src/resources/app/storefront/dist/storefront/js/swag-basic-example-theme.js`. It is detected by Shopware automatically and included in the Storefront. So you do not need to embed the JavaScript file yourself.
+In the end, by running the command `bin/build-storefront.sh` your custom JS plugin is loaded. By default, the compiled JavaScript file is saved as `<plugin root>/src/resources/app/storefront/dist/storefront/js/swag-basic-example-theme/swag-basic-example-theme.js`. It is detected by Shopware automatically and included in the Storefront. So you do not need to embed the JavaScript file yourself.
 
 ## Using the hot-proxy \(live reload\)
 

--- a/guides/plugins/themes/create-a-theme.md
+++ b/guides/plugins/themes/create-a-theme.md
@@ -122,7 +122,8 @@ Now your theme is fully installed, and you can start your customization.
     │   │       ├── dist
     │   │       │   └── storefront
     │   │       │       └── js
-    │   │       │           └── swag-basic-example-theme.js
+    |   |       |           └── swag-basic-example-theme  
+    │   │       │               └── swag-basic-example-theme.js
     │   │       └── src
     │   │           ├── assets
     │   │           ├── main.js

--- a/guides/plugins/themes/override-bootstrap-variables-in-a-theme.md
+++ b/guides/plugins/themes/override-bootstrap-variables-in-a-theme.md
@@ -45,7 +45,7 @@ This entry point is called `overrides.scss`:
   ],
   "script": [
     "@Storefront",
-    "app/storefront/dist/storefront/js/just-another-theme.js"
+    "app/storefront/dist/storefront/js/just-another-theme/just-another-theme.js"
   ],
   "asset": [
     "@Storefront",

--- a/guides/plugins/themes/theme-configuration.md
+++ b/guides/plugins/themes/theme-configuration.md
@@ -47,7 +47,7 @@ The theme configuration for a theme is located in the `theme.json` file `<plugin
   ],
   "script": [
     "@Storefront",
-    "app/storefront/dist/storefront/js/swag-basic-example-theme.js"
+    "app/storefront/dist/storefront/js/swag-basic-example-theme/swag-basic-example-theme.js"
   ],
   "asset": [
     "@Storefront",
@@ -318,7 +318,7 @@ A custom single-select field example
   ],
   "script": [
     "@Storefront",
-    "app/storefront/dist/storefront/js/select-example.js"
+    "app/storefront/dist/storefront/js/select-example/select-example.js"
   ],
   "asset": [
     "@Storefront",
@@ -409,7 +409,7 @@ A custom multi-select field example
   ],
   "script": [
     "@Storefront",
-    "app/storefront/dist/storefront/js/select-example.js"
+    "app/storefront/dist/storefront/js/select-example/select-example.js"
   ],
   "asset": [
     "@Storefront",


### PR DESCRIPTION
Some paths in the Theme documentation are outdated and using 6.5 structure