### PR TITLE
FIX: wrong key level in object-storage config in filesystem.md

### DIFF
--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -92,11 +92,10 @@ shopware:
         bucket: "{{AWS_BUCKET}}"
         region: "{{AWS_REGION}}"
         endpoint: "{{AWS_ENDPOINT}}"
-        options:
-          visibility: "public"
-          credentials:
-            key: "{{AWS_ACCESS_KEY_ID}}"
-            secret: "{{AWS_SECRET_ACCESS_KEY}}"
+        visibility: "public"
+        credentials:
+          key: "{{AWS_ACCESS_KEY_ID}}"
+          secret: "{{AWS_SECRET_ACCESS_KEY}}"
     theme:
       type: "local"
       url: "https://your.domain/public"


### PR DESCRIPTION
"options:" does not exist anymore in config and was not removed here but later in the docs. This will result in an "access denied" error as soon as file system calls are made, despite valid credentials.
It seems "visibility:" was also moved one level higher as mentioned later in the docs.