### PR TITLE
Update add-custom-commands.md

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-custom-commands.md
@@ -69,6 +69,7 @@ namespace Swag\BasicExample\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 // Command name
 #[AsCommand(name: 'swag-commands:example')]


### PR DESCRIPTION
There was one class missing in the "use Symfony\Component\Console\Attribute\AsCommand" class, which is generating an error like the following:

The command defined in "NameSpace\Of\MyClassCommand" cannot have an empty name.