### PR TITLE
Update path used in asset filter example

### DIFF
--- a/guides/plugins/plugins/administration/templates-styling/using-assets.md
+++ b/guides/plugins/plugins/administration/templates-styling/using-assets.md
@@ -59,10 +59,6 @@ This way, your plugin assets are copied to the `public/bundles` folder:
 
 After adding your assets to the `public/bundles` folder, you can start using them in the Administration. Simply utilize the `asset` filter.
 
-:::warning
-Note that [Vue filters](https://vuejs.org/v2/guide/filters.html) are no longer supported in Vue3 and therefore they will not function in Shopware versions 6.6 and above.
-:::
-
 Create a computed component to make them easy to use in your template.
 
 ```javascript
@@ -74,7 +70,7 @@ computed: {
 ```
 
 ```html
-<img :src="assetFilter('/<plugin root>/static/your-image.png')">
+<img :src="assetFilter('/<plugin root>/administration/static/your-image.png')">
 ```
 
 You're able to use this line in your `twig`/`html` files as you please and that's basically it. You successfully added your own asset to the Administration.


### PR DESCRIPTION
Updated the asset path used in the code example, this has changed during 6.7 / vite changes.

Also removed the warning about Vue filters, as our `assetFilter`, which is described right above the warning is not an actual Vue filter and thus not affected by the deprecation - quite confusing. Devs should be able to learn about Vue 2 filter deprecation in their respective docs, which are linked or referred to throughout our upgrade guides anyway 💡 