### PR TITLE
fix: Improve article about adding data to the storefront

### DIFF
--- a/guides/plugins/plugins/storefront/add-data-to-storefront-page.md
+++ b/guides/plugins/plugins/storefront/add-data-to-storefront-page.md
@@ -82,9 +82,12 @@ The next thing we need to do is register our subscriber in the DI-Container and 
 
 Now that we have registered our Subscriber to the right event, we first need to fetch the additional data we need and then add it as an extension to the pagelet.
 
-Because we are in an event of a Pagelet we should not directly call the DAL to fetch the data. Instead we should check if there is a proper store-api route to fetch our data.
-If we just wanted to add specific products data we could use the ProductListRoute. But we want to fetch data that is currently not returned in a performant way with the store-api.
-The ProductListRoute could return the data but it would return way to much data for our purpose. Because of that we will add a new store-api route for our data.
+Because we are in an event of a Pagelet we should not directly call the DAL to fetch the data.
+Instead, we should check if there is a proper store-api route to fetch our data.
+If we just wanted to add specific products data we could use the ProductListRoute.
+But we want to fetch data that is currently not returned in a performant way with the store-api.
+The ProductListRoute could return the data, but it would return way too much data for our purpose.
+Because of that we will add a new store-api route for our data.
 
 First you should read our guide for [adding store-api routes](../framework/store-api/add-store-api-route).
 
@@ -137,7 +140,12 @@ class ProductCountRoute extends AbstractProductCountRoute
         throw new DecorationPatternException(self::class);
     }
 
-     #[Route(path: '/store-api/get-active-product-count', name: 'store-api.product-count.get', methods: ['GET', 'POST'], defaults: ['_entity' => 'product'])]
+    #[Route(
+        path: '/store-api/get-active-product-count',
+        name: 'store-api.product-count.get',
+        methods: ['GET', 'POST'],
+        defaults: ['_entity' => 'product']
+    )]
     public function load(Criteria $criteria, SalesChannelContext $context): ProductCountRouteResponse
     {
         $criteria = new Criteria();
@@ -196,8 +204,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 
 /**
- * Class CountResult
- * @property CountResult $object
+ * @extends StoreApiResponse<CountResult>
  */
 class ProductCountRouteResponse extends StoreApiResponse
 {
@@ -294,14 +301,12 @@ For our case we extend the footer template and add a new column to the navigatio
 {% block layout_footer_navigation_columns %}
     {{ parent() }}
 
-    {% if page.footer.extensions.product_count %}
+    {% if footer.extensions.product_count %}
         <div class="col-md-4 footer-column">
-            <p>This shop offers you {{ page.footer.extensions.product_count.count }} products</p>
+            <p>This shop offers you {{ footer.extensions.product_count.count }} products</p>
         </div>
     {% endif %}
 {% endblock %}
 ```
 
 Note the usage of the variable here. You're accessing the footer object, in which you can now find the path `extensions.product_count.count`.
-
-That's it for this guide, you've successfully added data to a Storefront page\(let\).

--- a/guides/plugins/plugins/storefront/add-data-to-storefront-page.md
+++ b/guides/plugins/plugins/storefront/add-data-to-storefront-page.md
@@ -82,9 +82,12 @@ The next thing we need to do is register our subscriber in the DI-Container and 
 
 Now that we have registered our Subscriber to the right event, we first need to fetch the additional data we need and then add it as an extension to the pagelet.
 
-Since we are in a `Pagelet`-event, the DAL should not be called directly to fetch data. Instead, we should check whether a suitable `store-api` route exists.
+Since we are in a `Pagelet`-event, the DAL should not be called directly to fetch data.
+Instead, we should check whether a suitable `store-api` route exists.
 
-If we only needed specific product data, we could use the `ProductListRoute`. However, this does not satisfy our use case. While the `ProductListRoute` could provide this data, it would return far more information than necessary.
+If we only needed specific product data, we could use the `ProductListRoute`.
+However, this does not satisfy our use case.
+While the `ProductListRoute` could provide this data, it would return far more information than necessary.
 
 Therefore, we will create a new `store-api` route tailored to our needs.
 

--- a/guides/plugins/plugins/storefront/add-data-to-storefront-page.md
+++ b/guides/plugins/plugins/storefront/add-data-to-storefront-page.md
@@ -82,12 +82,11 @@ The next thing we need to do is register our subscriber in the DI-Container and 
 
 Now that we have registered our Subscriber to the right event, we first need to fetch the additional data we need and then add it as an extension to the pagelet.
 
-Because we are in an event of a Pagelet we should not directly call the DAL to fetch the data.
-Instead, we should check if there is a proper store-api route to fetch our data.
-If we just wanted to add specific products data we could use the ProductListRoute.
-But we want to fetch data that is currently not returned in a performant way with the store-api.
-The ProductListRoute could return the data, but it would return way too much data for our purpose.
-Because of that we will add a new store-api route for our data.
+Since we are in a `Pagelet`-event, the DAL should not be called directly to fetch data. Instead, we should check whether a suitable `store-api` route exists.
+
+If we only needed specific product data, we could use the `ProductListRoute`. However, this does not satisfy our use case. While the `ProductListRoute` could provide this data, it would return far more information than necessary.
+
+Therefore, we will create a new `store-api` route tailored to our needs.
 
 First you should read our guide for [adding store-api routes](../framework/store-api/add-store-api-route).
 


### PR DESCRIPTION
With SW 6.7 the page template variable is no longer available in footer and header template files. 