### PR TITLE
docs: show compatibility to php 8.4

### DIFF
--- a/guides/installation/requirements.md
+++ b/guides/installation/requirements.md
@@ -27,7 +27,7 @@ You can use these commands to check your actual environment:
 
 ### PHP
 
-* Compatible version: 8.2 and 8.3
+* Compatible version: 8.2, 8.3 and 8.4
 * `memory_limit` : 512M minimum
 * `max_execution_time` : 30 seconds minimum
 * Extensions:


### PR DESCRIPTION
According to https://github.com/shopware/shopware/blob/3a3ce91b0434d32e38d654a38670cd7f13ed4299/composer.json#L63 (`composer.json` on the `6.6.10.4` tag) Shopware is compatible with PHP 8.4.

This is now also present in the docs.