### PR TITLE
chore: Update the articles where a StorefrontController is used

### DIFF
--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -37,8 +37,9 @@ This way of defining the route scope is deprecated for the 6.5 major version.
 
 Go ahead and create a new file `ExampleController.php` in the directory `<plugin root>/src/Storefront/Controller/`.
 
-```php
-// <plugin root>/src/Storefront/Controller/ExampleController.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Controller;
@@ -52,13 +53,16 @@ class ExampleController extends StorefrontController
 }
 ```
 
+:::
+
 Now we can create a new example method with a `Route` attribute which has to contain our route, in this case it will be `/example`.
 The route defines how our new method will be accessible.
 
 Below you can find an example implementation of a controller method including a route, where we render an `example.html.twig` template file with a template variable `example`.
 
-```php
-// <plugin root>/src/Storefront/Controller/ExampleController.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Controller;
@@ -82,6 +86,8 @@ class ExampleController extends StorefrontController
 }
 ```
 
+:::
+
 The name of the method does not really matter, but it should somehow fit its purpose.
 More important is the `Route` attribute, that points to the route `/example`.
 Also note its name, which is also quite important.
@@ -97,8 +103,9 @@ Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annot
 This way of defining the route-scope is deprecated for the 6.5 major version.
 :::
 
-```php
-// <plugin root>/src/Storefront/Controller/ExampleController.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Controller;
@@ -118,13 +125,15 @@ class ExampleController extends StorefrontController
 }
 ```
 
+:::
+
 ### Services.xml example
 
 Next, we need to register our controller in the DI-container and make it public.
 
 ::: code-group
 
-```xml [<plugin root>/src/Resources/config/services.xml]
+```xml [PLUGIN_ROOT/src/Resources/config/services.xml]
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services" 
@@ -153,7 +162,7 @@ Have a look at the official [Symfony documentation](https://symfony.com/doc/curr
 
 ::: code-group
 
-```xml [<plugin root>/src/Resources/config/routes.xml]
+```xml [PLUGIN_ROOT/src/Resources/config/routes.xml]
 <?xml version="1.0" encoding="UTF-8" ?>
 <routes xmlns="http://symfony.com/schema/routing"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -176,8 +185,9 @@ Thus, we have to create an `index.html.twig` in the `<plugin root>/src/Resources
 Below you can find an example, where we extend from the template `base.html.twig` and override the block `base_content`.
 In our [Customize templates](customize-templates) guide, you can learn more about customizing templates.
 
-```twig
-// <plugin root>/src/Resources/views/storefront/page/example.html.twig
+::: code-group
+
+```twig [PLUGIN_ROOT/src/Resources/views/storefront/page/example.html.twig]
 {% sw_extends '@Storefront/storefront/base.html.twig' %}
 
 {% block base_content %}
@@ -185,14 +195,17 @@ In our [Customize templates](customize-templates) guide, you can learn more abou
 {% endblock %}
 ```
 
+:::
+
 ### Request and Context
 
 If necessary, we can access the `Request` and `SalesChannelContext` instances in our controller method.
 
 Here's an example:
 
-```php
-// <plugin root>/src/Storefront/Controller/ExampleController.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Controller;
@@ -213,6 +226,8 @@ class ExampleController extends StorefrontController
     }
 }
 ```
+
+:::
 
 ## Next steps
 

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -123,6 +123,7 @@ class ExampleController extends StorefrontController
 Next, we need to register our controller in the DI-container and make it public.
 
 ::: code-group
+
 ```xml [<plugin root>/src/Resources/config/services.xml]
 <?xml version="1.0" ?>
 
@@ -139,6 +140,7 @@ Next, we need to register our controller in the DI-container and make it public.
     </services>
 </container>
 ```
+
 :::
 
 Please also note the `call` tag, which is necessary in order to set the DI container to the controller.
@@ -150,6 +152,7 @@ This is done with a `routes.xml` file at `<plugin root>/src/Resources/config/` l
 Have a look at the official [Symfony documentation](https://symfony.com/doc/current/routing.html) about routes and how they are registered.
 
 ::: code-group
+
 ```xml [<plugin root>/src/Resources/config/routes.xml]
 <?xml version="1.0" encoding="UTF-8" ?>
 <routes xmlns="http://symfony.com/schema/routing"
@@ -160,6 +163,7 @@ Have a look at the official [Symfony documentation](https://symfony.com/doc/curr
     <import resource="../../Storefront/Controller/*Controller.php" type="attribute" />
 </routes>
 ```
+
 :::
 
 ### Adding template

--- a/guides/plugins/plugins/storefront/add-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-custom-controller.md
@@ -13,20 +13,26 @@ In this guide you will learn how to create a custom Storefront controller.
 
 ## Prerequisites
 
-In order to add your own controller for your plugin, you first need a plugin as base. Therefore, you can refer to the [Plugin Base Guide](../plugin-base-guide).
+In order to add your own controller for your plugin, you first need a plugin as base.
+Therefore, you can refer to the [Plugin Base Guide](../plugin-base-guide).
 
 ::: info
-Refer to this video on **[Common Storefront controller tasks](https://www.youtube.com/watch?v=5eXXNh4cQG0)** explaining the basics about Storefront controllers. Also available on our free online training ["Shopware 6 Backend Development"](https://academy.shopware.com/courses/shopware-6-backend-development-with-jisse-reitsma).
+Refer to this video on **[Common Storefront controller tasks](https://www.youtube.com/watch?v=5eXXNh4cQG0)** explaining the basics about Storefront controllers.
+Available also on our free online training ["Shopware 6 Backend Development"](https://academy.shopware.com/courses/shopware-6-backend-development-with-jisse-reitsma).
 :::
 
 ## Adding custom Storefront controller
 
 ### Storefront Controller class example
 
-First of all we have to create a new controller which extends from the `StorefrontController` class. A controller is also just a service which can be registered via the service container. Furthermore, we have to define our `Route` with `defaults` and `_routeScope` via attributes, it is used to define which domain a route is part of and **needs to be set for every route**. In our case the scope is `storefront`.
+First of all we have to create a new controller which extends from the `StorefrontController` class.
+A controller is also just a service which can be registered via the service container.
+Furthermore, we have to define our `Route` with `defaults` and `_routeScope` via attributes, it is used to define which domain a route is part of and **needs to be set for every route**.
+In our case the scope is `storefront`.
 
 ::: info
-Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annotation: `@RouteScope`. This way of defining the route scope is deprecated for the 6.5 major version.
+Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annotation: `@RouteScope`.
+This way of defining the route scope is deprecated for the 6.5 major version.
 :::
 
 Go ahead and create a new file `ExampleController.php` in the directory `<plugin root>/src/Storefront/Controller/`.
@@ -46,7 +52,8 @@ class ExampleController extends StorefrontController
 }
 ```
 
-Now we can create a new example method with a `Route` attribute which has to contain our route, in this case it will be `/example`. The route defines how our new method will be accessible.
+Now we can create a new example method with a `Route` attribute which has to contain our route, in this case it will be `/example`.
+The route defines how our new method will be accessible.
 
 Below you can find an example implementation of a controller method including a route, where we render an `example.html.twig` template file with a template variable `example`.
 
@@ -75,12 +82,19 @@ class ExampleController extends StorefrontController
 }
 ```
 
-The name of the method does not really matter, but it should somehow fit its purpose. More important is the `Route` attribute, that points to the route `/example`. Also note its name, which is also quite important. Make sure to use prefixes `frontend`, `widgets`, `payment`, `api` or `store-api` here, depending on what your route does. Inside the method, we're using the method `renderStorefront` to render a twig template file in addition with the template variable `example`, which contains `Hello world`. This template variable will be usable in the rendered template file. The method `renderStorefront` then returns a `Response`, as every routed controller method has to.
+The name of the method does not really matter, but it should somehow fit its purpose.
+More important is the `Route` attribute, that points to the route `/example`.
+Also note its name, which is also quite important.
+Make sure to use prefixes `frontend`, `widgets`, `payment`, `api` or `store-api` here, depending on what your route does.
+Inside the method, we're using the method `renderStorefront` to render a twig template file in addition with the template variable `example`, which contains `Hello world`.
+This template variable will be usable in the rendered template file.
+The method `renderStorefront` then returns a `Response`, as every routed controller method has to.
 
 It is also possible to define the `_routeScope` per route.
 
 ::: info
-Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annotation: `@RouteScope`. This way of defining the route-scope is deprecated for the 6.5 major version.
+Prior to Shopware 6.4.11.0 the `_routeScope` was configured by a dedicated annotation: `@RouteScope`.
+This way of defining the route-scope is deprecated for the 6.5 major version.
 :::
 
 ```php
@@ -108,8 +122,8 @@ class ExampleController extends StorefrontController
 
 Next, we need to register our controller in the DI-container and make it public.
 
-```xml
-// <plugin root>/src/Resources/config/services.xml
+::: code-group
+```xml [<plugin root>/src/Resources/config/services.xml]
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services" 
@@ -121,22 +135,22 @@ Next, we need to register our controller in the DI-container and make it public.
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
-            <call method="setTwig">
-                <argument type="service" id="twig"/>
-            </call>
         </service>
     </services>
 </container>
 ```
+:::
 
 Please also note the `call` tag, which is necessary in order to set the DI container to the controller.
 
 ### Routes.xml example
 
-Once we‘ve registered our new controller, we have to tell Shopware how we want it to search for new routes in our plugin. This is done with a `routes.xml` file at `<plugin root>/src/Resources/config/` location. Have a look at the official [Symfony documentation](https://symfony.com/doc/current/routing.html) about routes and how they are registered.
+Once we've registered our new controller, we have to tell Shopware how we want it to search for new routes in our plugin.
+This is done with a `routes.xml` file at `<plugin root>/src/Resources/config/` location.
+Have a look at the official [Symfony documentation](https://symfony.com/doc/current/routing.html) about routes and how they are registered.
 
-```xml
-// <plugin root>/src/Resources/config/routes.xml
+::: code-group
+```xml [<plugin root>/src/Resources/config/routes.xml]
 <?xml version="1.0" encoding="UTF-8" ?>
 <routes xmlns="http://symfony.com/schema/routing"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -146,12 +160,17 @@ Once we‘ve registered our new controller, we have to tell Shopware how we want
     <import resource="../../Storefront/Controller/*Controller.php" type="attribute" />
 </routes>
 ```
+:::
 
 ### Adding template
 
-Now we registered our controller and Shopware indexes the route, but the template file, that is supposed to be rendered, is still missing. Let's change that now.
+Now we registered our controller and Shopware indexes the route, but the template file, that is supposed to be rendered, is still missing.
+Let's change that now.
 
-As previously mentioned, the code will try to render an `index.html.twig` file. Thus we have to create an `index.html.twig` in the `<plugin root>/src/Resources/views/storefront/page/example` directory, as defined in our controller. Below you can find an example, where we extend from the template `base.html.twig` and override the block `base_content`. In our [Customize templates](customize-templates) guide, you can learn more about customizing templates.
+As previously mentioned, the code will try to render an `index.html.twig` file.
+Thus, we have to create an `index.html.twig` in the `<plugin root>/src/Resources/views/storefront/page/example` directory, as defined in our controller.
+Below you can find an example, where we extend from the template `base.html.twig` and override the block `base_content`.
+In our [Customize templates](customize-templates) guide, you can learn more about customizing templates.
 
 ```twig
 // <plugin root>/src/Resources/views/storefront/page/example.html.twig
@@ -193,4 +212,4 @@ class ExampleController extends StorefrontController
 
 ## Next steps
 
-Since you've already created a controller now, which is also part of creating a so called "page" in Shopware, you might want to head over to our guide about [creating a page](add-custom-page).
+Since you've already created a controller now, which is also part of creating a so-called "page" in Shopware, you might want to head over to our guide about [creating a page](add-custom-page).

--- a/guides/plugins/plugins/storefront/add-custom-page.md
+++ b/guides/plugins/plugins/storefront/add-custom-page.md
@@ -9,27 +9,28 @@ nav:
 
 ## Overview
 
-In this guide you will learn how to create custom page for your Storefront.
-A page in general consists of a controller, a page loader, a "page loaded" event and a page class, which is like a struct and contains most necessary data for the page.
+In this guide, you will learn how to create a custom page for your Storefront.
+A page in general consists of a controller, a page loader, a "page loaded" event and a page class, which is like a struct and contains the most necessary data for the page.
 
 ## Prerequisites
 
-In order to add your own custom page for your plugin, you first need a plugin as base.
+To add your own custom page for your plugin, you first need a plugin as base.
 Therefore, you can refer to the [Plugin Base Guide](../plugin-base-guide). Since you need to load your page with a controller, you might want to have a look at our guide about [creating a controller](add-custom-controller) first.
 The controller created in the previously mentioned controller guide will also be used in this guide.
 
 ## Adding custom page
 
 In the following sections, we'll create each of the necessary classes one by one.
-The first one will be controller, whose creation is not going to be explained here again.
+The first one will be a controller, whose creation is not going to be explained here again.
 Have a look at the guide about [creating a controller](add-custom-controller) to see why it works.
 
 ### Creating ExampleController
 
 Let's have a look at an example controller.
 
-```php
-// <plugin root>/src/Storefront/Controller/ExampleController.php
+::: code-group
+
+```xml [PLUGIN_ROOT/src/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Controller;
@@ -48,6 +49,8 @@ class ExampleController extends StorefrontController
 }
 ```
 
+:::
+
 It has a method `examplePage`, which is accessible via the route `example-page`.
 This method will be responsible for loading your page later on, but we'll leave it like that for now.
 
@@ -55,22 +58,23 @@ Don't forget to [register your controller via the DI](add-custom-controller#serv
 
 ### Creating the pageloader
 
-In order to stick to Shopware's default location for the page loader, we'll have to create a new directory: `<plugin root>/src/Storefront/Page/Example`.
+To stick to Shopware's default location for the page loader, we'll have to create a new directory: `<plugin root>/src/Storefront/Page/Example`.
 
 In there, we will proceed to create all page related classes, such as the page loader.
 
 Go ahead and create a new file called `ExamplePageLoader.php`.
 It's a new service, which doesn't have to extend from any other class.
 You might want to implement a `ExamplePageLoaderInterface` interface, which is not explained in this guide.
-You can do that in order to have a decoratable page loader class.
+You can do that to have a decoratable page loader class.
 
 The page loader is responsible for creating your page class instance \(`ExamplePage`, will be created in the next section\), filling it with data, e.g. from store api, and firing a `PageLoaded` event, so others can react to your page being loaded.
 Do not use a repository directly in a page loader. Always get the data for your pages from a store api route instead.
 
 Let's have a look at a full example `ExamplePageLoader`:
 
-```php
-// <plugin root>/src/Storefront/Page/Example/ExamplePageLoader.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Page/Example/ExamplePageLoader.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Page\Example;
@@ -109,18 +113,20 @@ class ExamplePageLoader
 }
 ```
 
+:::
+
 So first of all, as already mentioned: This is a new class or service, which doesn't have to extend from any other class.
 The constructor is passed two arguments: The `GenericPageLoaderInterface` and the `EventDispatcherInterface`.
 
-The first one is not necessary, but useful, since it loads all kind of default page stuff like some additional helpful data.
+The first one is not necessary, but useful, since it loads all kinds of default page data.
 
-The `EventDispatcherInterface` is of course necessary in order to fire an event later on.
+The `EventDispatcherInterface` is of course necessary to fire an event later on.
 
 Every page loader should implement a `load` method, which is not mandatory, but convention.
 You want your page loader to work like all the other page loaders, right?
 It should return an instance of your example page, in this case `ExamplePage`.
 Don't worry, we haven't created that one yet, it will be created in the next sections.
-So, the first thing it does is basically creating a `Page` instance, containing basic data, like the meta information.
+So, the first thing it does is basically creating a `Page` instance, containing basic data, like the meta-information.
 
 Afterwards, you're creating your own page instance by using the method `createFrom`.
 This method is available, since your `ExamplePage` has to extend from the `Page` struct, which in return extends from the `Struct` class.
@@ -140,7 +146,7 @@ Remember to register your new page loader in the DI container:
 
 ::: code-group
 
-```xml [<plugin root>/src/Resources/config/services.xml]
+```xml [PLUGIN_ROOT/src/Resources/config/services.xml]
 <service id="Swag\BasicExample\Storefront\Page\Example\ExamplePageLoader" public="true">
     <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader" />
     <argument type="service" id="event_dispatcher"/>
@@ -154,8 +160,9 @@ Remember to register your new page loader in the DI container:
 Theoretically, this is all your page loader does - but it's not being used yet.
 Therefore, you have to inject your page loader to your custom controller and execute the `load` method.
 
-```php
-// <plugin root>/src/Storefront/Controller/ExampleController.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Controller;
@@ -184,6 +191,8 @@ class ExampleController extends StorefrontController
 }
 ```
 
+:::
+
 Note, that we've added the page to the template variables.
 
 #### Adjusting the services.xml
@@ -192,7 +201,7 @@ In addition, it is necessary to pass the argument with the ID of the `ExamplePag
 
 ::: code-group
 
-```xml [<plugin root>/src/Resources/config/services.xml]
+```xml [PLUGIN_ROOT/src/Resources/config/services.xml]
 <service id="Swag\BasicExample\Storefront\Controller\ExampleController" public="true">
     <argument type="service" id="Swag\BasicExample\Storefront\Page\Example\ExamplePageLoader" />
     <call method="setContainer">
@@ -207,12 +216,13 @@ In addition, it is necessary to pass the argument with the ID of the `ExamplePag
 
 So now we're going to create the example page class, that was already used in our page loader, `ExamplePage`.
 
-It has to extend from the `Shopware\Storefront\Page\Page` class in order to contain the meta information, as well as some helper methods.
+It has to extend from the `Shopware\Storefront\Page\Page` class to contain the meta information, as well as some helper methods.
 
 Let's have a look at an example:
 
-```php
-// <plugin root>/src/Storefront/Page/Example/ExamplePage.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Page/Example/ExamplePage.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Page\Example;
@@ -236,6 +246,8 @@ class ExamplePage extends Page
 }
 ```
 
+:::
+
 As explained in the page loader section, your page can contain all kinds of custom data.
 It has to provide a getter and a setter for the custom data, so it can be applied and read.
 In this example, the entity from our guide about [creating custom complex data](../framework/data-handling/add-custom-complex-data#entity-class) is being used.
@@ -248,13 +260,14 @@ Your page is ready to go.
 One more class is missing, the custom event class.
 It has to extend from the `Shopware\Storefront\Page\PageLoadedEvent` class.
 
-Its constructor parameter will be the `ExamplePage`, which it has to save into a property and there needs to be a getter in order to get the example page instance.
+Its constructor parameter will be the `ExamplePage`, which it has to save into a property and there needs to be a getter to get the example page instance.
 Additional constructor parameters are the `Request` and the `SalesChannelContext`, which you have to pass to the parent's constructor.
 
 Here's the example:
 
-```php
-// <plugin root>/src/Storefront/Page/Example/ExamplePageLoadedEvent.php
+::: code-group
+
+```php [PLUGIN_ROOT/src/Storefront/Page/Example/ExamplePageLoadedEvent.php]
 <?php declare(strict_types=1);
 
 namespace Swag\BasicExample\Storefront\Page\Example;
@@ -280,6 +293,8 @@ class ExamplePageLoadedEvent extends PageLoadedEvent
 }
 ```
 
+:::
+
 And that's it for your `ExamplePageLoadedEvent` class.
 
 Your example page should now be fully functioning.
@@ -289,5 +304,5 @@ Your example page should now be fully functioning.
 You've now successfully created a whole new page, including a custom controller, a custom template,
 and the necessary classes to create a new page, a loader, the page struct and the page loaded event.
 
-In your `load` method, you've used the `GenericPageLoader`, which takes care of the meta information of the page.
+In your `load` method, you've used the `GenericPageLoader`, which takes care of the meta-information of the page.
 There are also "pagelets", basically reusable fractions of a page. Learn how to [create a custom pagelet](add-custom-pagelet).

--- a/guides/plugins/plugins/storefront/add-custom-page.md
+++ b/guides/plugins/plugins/storefront/add-custom-page.md
@@ -9,15 +9,20 @@ nav:
 
 ## Overview
 
-In this guide you will learn how to create custom page for your Storefront. A page in general consists of a controller, a page loader, a "page loaded" event and a page class, which is like a struct and contains most necessary data for the page.
+In this guide you will learn how to create custom page for your Storefront.
+A page in general consists of a controller, a page loader, a "page loaded" event and a page class, which is like a struct and contains most necessary data for the page.
 
 ## Prerequisites
 
-In order to add your own custom page for your plugin, you first need a plugin as base. Therefore, you can refer to the [Plugin Base Guide](../plugin-base-guide). Since you need to load your page with a controller, you might want to have a look at our guide about [creating a controller](add-custom-controller) first. The controller created in the previously mentioned controller guide will also be used in this guide.
+In order to add your own custom page for your plugin, you first need a plugin as base.
+Therefore, you can refer to the [Plugin Base Guide](../plugin-base-guide). Since you need to load your page with a controller, you might want to have a look at our guide about [creating a controller](add-custom-controller) first.
+The controller created in the previously mentioned controller guide will also be used in this guide.
 
 ## Adding custom page
 
-In the following sections, we'll create each of the necessary classes one by one. The first one will be controller, whose creation is not going to explained here again. Have a look at the guide about [creating a controller](add-custom-controller) to see why it works.
+In the following sections, we'll create each of the necessary classes one by one.
+The first one will be controller, whose creation is not going to be explained here again.
+Have a look at the guide about [creating a controller](add-custom-controller) to see why it works.
 
 ### Creating ExampleController
 
@@ -43,7 +48,8 @@ class ExampleController extends StorefrontController
 }
 ```
 
-It has a method `examplePage`, which is accessible via the route `example-page`. This method will be responsible for loading your page later on, but we'll leave it like that for now.
+It has a method `examplePage`, which is accessible via the route `example-page`.
+This method will be responsible for loading your page later on, but we'll leave it like that for now.
 
 Don't forget to [register your controller via the DI](add-custom-controller#services-xml-example).
 
@@ -53,7 +59,10 @@ In order to stick to Shopware's default location for the page loader, we'll have
 
 In there, we will proceed to create all page related classes, such as the page loader.
 
-Go ahead and create a new file called `ExamplePageLoader.php`. It's a new service, which doesn't have to extend from any other class. You might want to implement a `ExamplePageLoaderInterface` interface, which is not explained in this guide. You can do that in order to have a decoratable page loader class.
+Go ahead and create a new file called `ExamplePageLoader.php`.
+It's a new service, which doesn't have to extend from any other class.
+You might want to implement a `ExamplePageLoaderInterface` interface, which is not explained in this guide.
+You can do that in order to have a decoratable page loader class.
 
 The page loader is responsible for creating your page class instance \(`ExamplePage`, will be created in the next section\), filling it with data, e.g. from store api, and firing a `PageLoaded` event, so others can react to your page being loaded.
 Do not use a repository directly in a page loader. Always get the data for your pages from a store api route instead.
@@ -100,35 +109,48 @@ class ExamplePageLoader
 }
 ```
 
-So first of all, as already mentioned: This is a new class or service, which doesn't have to extend from any other class. The constructor is passed two arguments: The `GenericPageLoaderInterface` and the `EventDispatcherInterface`.
+So first of all, as already mentioned: This is a new class or service, which doesn't have to extend from any other class.
+The constructor is passed two arguments: The `GenericPageLoaderInterface` and the `EventDispatcherInterface`.
 
-The first one is not necessary, but useful, since it loads all kind of default page stuff, such as a footer and a header and loads some additional helpful data. Once again, you don't have to do that, but if you want your page to have a footer etc., you should add it.
+The first one is not necessary, but useful, since it loads all kind of default page stuff like some additional helpful data.
 
 The `EventDispatcherInterface` is of course necessary in order to fire an event later on.
 
-Every page loader should implement a `load` method, which is not mandatory, but convention. You want your page loader to work like all the other page loaders, right? It should return an instance of your example page, in this case `ExamplePage`. Don't worry, we haven't created that one yet, it will be created in the next sections. So, the first thing it does is basically creating a `Page` instance, containing all necessary basic data, such as the footer etc.
+Every page loader should implement a `load` method, which is not mandatory, but convention.
+You want your page loader to work like all the other page loaders, right?
+It should return an instance of your example page, in this case `ExamplePage`.
+Don't worry, we haven't created that one yet, it will be created in the next sections.
+So, the first thing it does is basically creating a `Page` instance, containing basic data, like the meta information.
 
-Afterwards you're creating your own page instance by using the method `createFrom`. This method is available, since your `ExamplePage` has to extend from the `Page` struct, which in return extends from the `Struct` class. The latter implements the [CreateFromTrait](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Core/Framework/Struct/CreateFromTrait.php) containing this method. In short, this will create an instance of your `ExamplePage`, containing all the data from the generic `Page` object.
+Afterwards, you're creating your own page instance by using the method `createFrom`.
+This method is available, since your `ExamplePage` has to extend from the `Page` struct, which in return extends from the `Struct` class.
+The latter implements the [CreateFromTrait](https://github.com/shopware/shopware/blob/v6.3.4.1/src/Core/Framework/Struct/CreateFromTrait.php) containing this method.
+In short, this will create an instance of your `ExamplePage`, containing all the data from the generic `Page` object.
 
-Afterwards, you can add more data to your page instance by using a setter. Of course, your example page class then has to have such a setter method, as well as a getter.
+Afterwards, you can add more data to your page instance by using a setter.
+Of course, your example page class then has to have such a setter method, as well as a getter.
 
-As already mentioned, you should also fire an event once your page was loaded. For this case, you need a custom page loaded event class, which is also created in the next sections. It will be called `ExamplePageLoadedEvent`.
+As already mentioned, you should also fire an event once your page was loaded.
+For this case, you need a custom page loaded event class, which is also created in the next sections.
+It will be called `ExamplePageLoadedEvent`.
 
 The last thing to do in this method is to return your new page instance.
 
 Remember to register your new page loader in the DI container:
 
-```html
-// <plugin root>/src/Resources/config/services.xml
+::: code-group
+```xml [<plugin root>/src/Resources/config/services.xml]
 <service id="Swag\BasicExample\Storefront\Page\Example\ExamplePageLoader" public="true">
     <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader" />
     <argument type="service" id="event_dispatcher"/>
 </service>
 ```
+:::
 
 #### Adjusting the controller
 
-Theoretically, this is all your page loader does - but it's not being used yet. Therefore, you have to inject your page loader to your custom controller and execute the `load` method.
+Theoretically, this is all your page loader does - but it's not being used yet.
+Therefore, you have to inject your page loader to your custom controller and execute the `load` method.
 
 ```php
 // <plugin root>/src/Storefront/Controller/ExampleController.php
@@ -166,24 +188,22 @@ Note, that we've added the page to the template variables.
 
 In addition, it is necessary to pass the argument with the ID of the `ExamplePageLoader` class to the [configuration](add-custom-controller#services-xml-example) of the controller service in the `services.xml`.
 
-```html
-// <plugin root>/src/Resources/config/services.xml
+::: code-group
+```xml [<plugin root>/src/Resources/config/services.xml]
 <service id="Swag\BasicExample\Storefront\Controller\ExampleController" public="true">
     <argument type="service" id="Swag\BasicExample\Storefront\Page\Example\ExamplePageLoader" />
     <call method="setContainer">
         <argument type="service" id="service_container"/>
     </call>
-    <call method="setTwig">
-        <argument type="service" id="twig"/>
-    </call>
 </service>
 ```
+:::
 
 ### Creating the example page
 
 So now we're going to create the example page class, that was already used in our page loader, `ExamplePage`.
 
-It has to extend from the `Shopware\Storefront\Page\Page` class in order to contain a field for the header, the footer etc., as well as some helper methods.
+It has to extend from the `Shopware\Storefront\Page\Page` class in order to contain the meta information, as well as some helper methods.
 
 Let's have a look at an example:
 
@@ -212,15 +232,20 @@ class ExamplePage extends Page
 }
 ```
 
-As explained in the page loader section, your page can contain all kinds of custom data. It has to provide a getter and a setter for the custom data, so it can be applied and read. In this example, the entity from our guide about [creating custom complex data](../framework/data-handling/add-custom-complex-data#entity-class) is being used.
+As explained in the page loader section, your page can contain all kinds of custom data.
+It has to provide a getter and a setter for the custom data, so it can be applied and read.
+In this example, the entity from our guide about [creating custom complex data](../framework/data-handling/add-custom-complex-data#entity-class) is being used.
 
-And that's it already. Your page is ready to go.
+And that's it already.
+Your page is ready to go.
 
 ### Creating the page loaded event
 
-One more class is missing, the custom event class. It has to extend from the `Shopware\Storefront\Page\PageLoadedEvent` class.
+One more class is missing, the custom event class.
+It has to extend from the `Shopware\Storefront\Page\PageLoadedEvent` class.
 
-Its constructor parameter will be the `ExamplePage`, which it has to save into a property and there needs to be a getter in order to get the example page instance. Additional constructor parameters are the `Request` and the `SalesChannelContext`, which you have to pass to the parent's constructor.
+Its constructor parameter will be the `ExamplePage`, which it has to save into a property and there needs to be a getter in order to get the example page instance.
+Additional constructor parameters are the `Request` and the `SalesChannelContext`, which you have to pass to the parent's constructor.
 
 Here's the example:
 
@@ -257,6 +282,8 @@ Your example page should now be fully functioning.
 
 ## Next steps
 
-You've now successfully created a whole new page, including a custom controller, a custom template, and the necessary classes to create a new page, a loader, the page struct and the page loaded event.
+You've now successfully created a whole new page, including a custom controller, a custom template,
+and the necessary classes to create a new page, a loader, the page struct and the page loaded event.
 
-In your `load` method, you've used the `GenericPageLoader`, which takes care of such a thing as the footer or the header. Those two are so called "pagelets", basically reusable fractions of a page. Learn how to [create a custom pagelet](add-custom-pagelet).
+In your `load` method, you've used the `GenericPageLoader`, which takes care of the meta information of the page.
+There are also "pagelets", basically reusable fractions of a page. Learn how to [create a custom pagelet](add-custom-pagelet).

--- a/guides/plugins/plugins/storefront/add-custom-page.md
+++ b/guides/plugins/plugins/storefront/add-custom-page.md
@@ -139,12 +139,14 @@ The last thing to do in this method is to return your new page instance.
 Remember to register your new page loader in the DI container:
 
 ::: code-group
+
 ```xml [<plugin root>/src/Resources/config/services.xml]
 <service id="Swag\BasicExample\Storefront\Page\Example\ExamplePageLoader" public="true">
     <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader" />
     <argument type="service" id="event_dispatcher"/>
 </service>
 ```
+
 :::
 
 #### Adjusting the controller
@@ -189,6 +191,7 @@ Note, that we've added the page to the template variables.
 In addition, it is necessary to pass the argument with the ID of the `ExamplePageLoader` class to the [configuration](add-custom-controller#services-xml-example) of the controller service in the `services.xml`.
 
 ::: code-group
+
 ```xml [<plugin root>/src/Resources/config/services.xml]
 <service id="Swag\BasicExample\Storefront\Controller\ExampleController" public="true">
     <argument type="service" id="Swag\BasicExample\Storefront\Page\Example\ExamplePageLoader" />
@@ -197,6 +200,7 @@ In addition, it is necessary to pass the argument with the ID of the `ExamplePag
     </call>
 </service>
 ```
+
 :::
 
 ### Creating the example page

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -52,6 +52,7 @@ Using a `JsonResponse` instead of a normal `Response` causes the data structures
 The following `services.xml` and `routes.xml` are identical as in the before mentioned article, but here they are for reference anyway:
 
 ::: code-group
+
 ```xml [<plugin root>/src/Resources/config/services.xml]
 <?xml version="1.0" ?>
 
@@ -79,6 +80,7 @@ The following `services.xml` and `routes.xml` are identical as in the before men
     <import resource="../../Storefront/Controller/**/*Controller.php" type="attribute" />
 </routes>
 ```
+
 :::
 
 ## Preparing the Plugin

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -9,17 +9,20 @@ nav:
 
 ## Overview
 
-This guide will show you how to add dynamic content to your Storefront. It combines and builds upon the the guides about [adding custom Javascript](add-custom-javascript) and [adding a custom controller](add-custom-controller), so you should probably read them first.
+This guide will show you how to add dynamic content to your Storefront.
+It combines and builds upon the guides about [adding custom Javascript](add-custom-javascript) and [adding a custom controller](add-custom-controller), so you should probably read them first.
 
 ## Setting up the Controller
 
 For this guide we will use a very simple controller that returns a timestamp wrapped in the JSON format.
 
 ::: info
-Refer to this video on **[Creating a JSON controller](https://www.youtube.com/watch?v=VzREUDdpZ3E)** dealing with the creation of a controller that returns JSON data. Also available on our free online training ["Shopware 6 Backend Development"](https://academy.shopware.com/courses/shopware-6-backend-development-with-jisse-reitsma).
+Refer to this video on **[Creating a JSON controller](https://www.youtube.com/watch?v=VzREUDdpZ3E)** dealing with the creation of a controller that returns JSON data.
+Available also on our free online training ["Shopware 6 Backend Development"](https://academy.shopware.com/courses/shopware-6-backend-development-with-jisse-reitsma).
 :::
 
-As mentioned before this guide builds up upon the [adding a custom controller](add-custom-controller) guide. This means that this article will only cover the differences between returning a template and a `JSON` response and making it accessible to `XmlHttpRequests`.
+As mentioned before this guide builds up upon the [adding a custom controller](add-custom-controller) guide.
+This means that this article will only cover the differences between returning a template and a `JSON` response and making it accessible to `XmlHttpRequests`.
 
 ```php
 // <plugin base>/Storefront/Controller/ExampleController.php
@@ -42,12 +45,14 @@ class ExampleController extends StorefrontController
 }
 ```
 
-As you might have seen this controller isn't too different from the controller used in the article mentioned before. The route attribute has an added `defaults: ['XmlHttpRequest' => true]` to allow XmlHttpRequest and it returns a `JsonResponse` instead of a normal `Response`. Using a `JsonResponse` instead of a normal `Response` causes the data structures passed to it to be automatically turned into a `JSON` string.
+As you might have seen this controller isn't too different from the controller used in the article mentioned before.
+The route attribute has an added `defaults: ['XmlHttpRequest' => true]` to allow XmlHttpRequest, and it returns a `JsonResponse` instead of a normal `Response`.
+Using a `JsonResponse` instead of a normal `Response` causes the data structures passed to it to be automatically turned into a `JSON` string.
 
-The following `services.xml` and `routes.xml` are identical as in the before mentioned article, but here they are for reference anyways:
+The following `services.xml` and `routes.xml` are identical as in the before mentioned article, but here they are for reference anyway:
 
-```xml
-// <plugin root>/src/Resources/config/services.xml
+::: code-group
+```xml [<plugin root>/src/Resources/config/services.xml]
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services" 
@@ -59,16 +64,12 @@ The following `services.xml` and `routes.xml` are identical as in the before men
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
-            <call method="setTwig">
-              <argument type="service" id="twig"/>
-            </call>
         </service>
     </services>
 </container>
 ```
 
-```xml
-// <plugin root>/src/Resources/config/routes.xml
+```xml [<plugin root>/src/Resources/config/routes.xml]
 <?xml version="1.0" encoding="UTF-8" ?>
 <routes xmlns="http://symfony.com/schema/routing"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -78,6 +79,7 @@ The following `services.xml` and `routes.xml` are identical as in the before men
     <import resource="../../Storefront/Controller/**/*Controller.php" type="attribute" />
 </routes>
 ```
+:::
 
 ## Preparing the Plugin
 
@@ -140,4 +142,5 @@ The only thing that is now left, is to provide a template for the Storefront plu
 
 ## Next steps
 
-The controller we used in this example doesn't do a lot, but this pattern of providing and using data is generally the same. Even if you use it to fetch data form the database, but in that case you probably want to learn more about the [DAL](../../../../concepts/framework/data-abstraction-layer).
+The controller we used in this example doesn't do a lot, but this pattern of providing and using data is generally the same.
+Even if you use it to fetch data form the database, but in that case you probably want to learn more about the [DAL](../../../../concepts/framework/data-abstraction-layer).

--- a/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
+++ b/guides/plugins/plugins/storefront/add-dynamic-content-via-ajax-calls.md
@@ -24,8 +24,9 @@ Available also on our free online training ["Shopware 6 Backend Development"](ht
 As mentioned before this guide builds up upon the [adding a custom controller](add-custom-controller) guide.
 This means that this article will only cover the differences between returning a template and a `JSON` response and making it accessible to `XmlHttpRequests`.
 
-```php
-// <plugin base>/Storefront/Controller/ExampleController.php
+::: code-group
+
+```php [PLUGIN_ROOT/Storefront/Controller/ExampleController.php]
 <?php declare(strict_types=1);
 
 namespace SwagBasicExample\Storefront\Controller;
@@ -45,7 +46,9 @@ class ExampleController extends StorefrontController
 }
 ```
 
-As you might have seen this controller isn't too different from the controller used in the article mentioned before.
+:::
+
+As you might have seen, this controller isn't too different from the controller used in the article mentioned before.
 The route attribute has an added `defaults: ['XmlHttpRequest' => true]` to allow XmlHttpRequest, and it returns a `JsonResponse` instead of a normal `Response`.
 Using a `JsonResponse` instead of a normal `Response` causes the data structures passed to it to be automatically turned into a `JSON` string.
 
@@ -53,7 +56,7 @@ The following `services.xml` and `routes.xml` are identical as in the before men
 
 ::: code-group
 
-```xml [<plugin root>/src/Resources/config/services.xml]
+```xml [PLUGIN_ROOT/src/Resources/config/services.xml]
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services" 
@@ -70,7 +73,7 @@ The following `services.xml` and `routes.xml` are identical as in the before men
 </container>
 ```
 
-```xml [<plugin root>/src/Resources/config/routes.xml]
+```xml [PLUGIN_ROOT/src/Resources/config/routes.xml]
 <?xml version="1.0" encoding="UTF-8" ?>
 <routes xmlns="http://symfony.com/schema/routing"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -89,8 +92,9 @@ Now we have to add a `Storefront Javascript plugin` to display the timestamp we 
 
 Again this is built upon the [adding custom Javascript](add-custom-javascript) article, so if you don't already know what Storefront `plugins` are, hold on and read it first.
 
-```javascript
-// <plugin root>/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/storefront/src/example-plugin/example-plugin.plugin.js]
 const { PluginBaseClass } = window;
 
 export default class AjaxLoadPlugin extends PluginBaseClass {
@@ -114,20 +118,27 @@ export default class AjaxLoadPlugin extends PluginBaseClass {
 }
 ```
 
+:::
+
 and register it in the `main.js`
 
-```javascript
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/storefront/src/main.js]
 import AjaxLoadPlugin from './example-plugin/example-plugin.plugin';
 
 window.PluginManager.register('AjaxLoadPlugin', AjaxLoadPlugin, '[data-ajax-helper]');
 ```
 
+:::
+
 ## Adding the Template
 
-The only thing that is now left, is to provide a template for the Storefront plugin to hook into:
+The only thing that is now left is to provide a template for the Storefront plugin to hook into:
 
-```twig
-// <plugin root>/src/Resources/views/storefront/page/content/index.html.twig
+::: code-group
+
+```twig [PLUGIN_ROOT/src/Resources/views/storefront/page/content/index.html.twig]
 {% sw_extends '@Storefront/storefront/page/content/index.html.twig' %}
 
 {% block cms_content %}
@@ -142,7 +153,9 @@ The only thing that is now left, is to provide a template for the Storefront plu
 {% endblock %}
 ```
 
+:::
+
 ## Next steps
 
 The controller we used in this example doesn't do a lot, but this pattern of providing and using data is generally the same.
-Even if you use it to fetch data form the database, but in that case you probably want to learn more about the [DAL](../../../../concepts/framework/data-abstraction-layer).
+Even if you use it to fetch data from the database, but in that case, you probably want to learn more about the [DAL](../../../../concepts/framework/data-abstraction-layer).

--- a/resources/references/adr/2021-08-10-storefront-coding-standards.md
+++ b/resources/references/adr/2021-08-10-storefront-coding-standards.md
@@ -51,7 +51,7 @@ example:
 * Each storefront functionality has to be available inside the store-api too
 * A storefront controller should never contain business logic
 * The controller class requires the annotation: #[Route(defaults: ['_routeScope' => ['storefront']])]
-* Depending services has to be injected over the class constructor. The only exception is the container, which can be injected with the methods `setContainer`.
+* Depending services has to be injected over the class constructor. The only exceptions are the container and twig, which can be injected with the methods `setContainer` and `setTwig`
 * Depending services has to be defined in the DI-Container service definition
 * Depending services has to be assigned to a private class property
 * Each storefront controller needs to be declared as a public service. (otherwise the routes can be removed from the container)

--- a/resources/references/adr/2021-08-10-storefront-coding-standards.md
+++ b/resources/references/adr/2021-08-10-storefront-coding-standards.md
@@ -51,7 +51,7 @@ example:
 * Each storefront functionality has to be available inside the store-api too
 * A storefront controller should never contain business logic
 * The controller class requires the annotation: #[Route(defaults: ['_routeScope' => ['storefront']])]
-* Depending services has to be injected over the class constructor. The only exceptions are the container and twig, which can be injected with the methods `setContainer` and `setTwig`
+* Depending services has to be injected over the class constructor. The only exception is the container, which can be injected with the methods `setContainer`.
 * Depending services has to be defined in the DI-Container service definition
 * Depending services has to be assigned to a private class property
 * Each storefront controller needs to be declared as a public service. (otherwise the routes can be removed from the container)


### PR DESCRIPTION
Using `setTwig` is no longer necessary.
References about header and footer in custom page objects are also removed. As they are no longer part of the generic page.