### PR TITLE
[FIX] Wrong parameter order in example code

### DIFF
--- a/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
+++ b/guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route.md
@@ -96,7 +96,7 @@ class CachedExampleRoute extends AbstractExampleRoute
 
         // Fetch item from the cache pool
         $item = $this->cache->getItem(
-            $this->generateKey($criteria, $context)
+            $this->generateKey($context, $criteria)
         );
 
         try {


### PR DESCRIPTION
In the example code on the page "Add caching for Store API route" the method `generateKey` was called with parameters in wrong order.