### PR TITLE
Deployer recipe: Share theme folder for atomic themes

### DIFF
--- a/guides/hosting/installation-updates/deployments/deployment-with-deployer.md
+++ b/guides/hosting/installation-updates/deployments/deployment-with-deployer.md
@@ -329,6 +329,7 @@ set('shared_dirs', [
     'files',
     'var/log',
     'public/media',
+    'public/theme',
     'public/thumbnail',
     'public/sitemap',
 ]);


### PR DESCRIPTION
Shopware has decided to make their theme compilation atomic: https://developer.shopware.com/docs/resources/references/adr/2023-01-10-atomic-theme-compilation.html

This means, on each deployment, during the execution of `theme:compile` (when building remotely), the storefront page is broken, because the new theme files only exist in an unreleased release, until `deploy:publish` happens.