### PR TITLE
Remove package.json from Unauthorized file

### DIFF
--- a/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
@@ -531,8 +531,6 @@ Here are some examples of not allowed folders and files:
 * .zipignore
 * composer.lock
 * phpdoc.dist.xml
-* package.json
-* package-lock.json
 * phpunit.sh
 * phpunitx.xml
 * shell.nix


### PR DESCRIPTION
When adding NPM Dependencies in the administration or storefront,` a package.json` and `package-lock.json` is required. 

The Quality Guidelines state that `package.json` isn’t allowed, but I assume or at least hope that this might be a mistake.