### PR TITLE
Update build admin command

### DIFF
--- a/guides/installation/setups/docker.md
+++ b/guides/installation/setups/docker.md
@@ -85,7 +85,7 @@ To build the Administration or Storefront, you can run the following commands:
 
 ```bash
 # Build the administration
-make build-admin
+make build-administration
 
 # Build the storefront
 make build-storefront


### PR DESCRIPTION
Command `build-admin` does not exist, use `build-administration`. 

https://github.com/shopware/recipes/blob/main/shopware/docker-dev/0.1/manifest.json#L26-L44