### PR TITLE
fix: getRequest is not part of HttpCacheKeyEvent

### DIFF
--- a/guides/plugins/plugins/framework/caching/index.md
+++ b/guides/plugins/plugins/framework/caching/index.md
@@ -43,7 +43,7 @@ class CacheKeySubscriber implements EventSubscriberInterface
     
     public function addKeyPart(HttpCacheKeyEvent $event): void
     {
-        $request = $event->getRequest();
+        $request = $event->request;
         // Perform checks to determine the key
         $key = $this->determineKey($request);
         $event->add('myCustomKey', $key);


### PR DESCRIPTION
https://github.com/shopware/shopware/blob/37135663de520a3f5b585570e52b985b05173fda/src/Core/Framework/Adapter/Cache/Event/HttpCacheKeyEvent.php#L20

there is no method  `getRequest`.