### PR TITLE
Align documentation with SnippetFinder code

### DIFF
--- a/guides/plugins/plugins/administration/templates-styling/adding-snippets.md
+++ b/guides/plugins/plugins/administration/templates-styling/adding-snippets.md
@@ -38,7 +38,7 @@ In this example you would have access the two translations by the following path
 By default, Shopware 6 will collect those files automatically when your plugin is activated.
 
 ::: info
-When you do not build a module and therefore do not fit into the suggested directory structure, you can still place the translation files anywhere in `<plugin root>/src/Resources/app/administration/`.
+When you do not build a module and therefore do not fit into the suggested directory structure, you can still place the translation files anywhere in `<plugin root>/src/Resources/app/administration/src/`.
 :::
 
 ## Using the snippets in JavaScript


### PR DESCRIPTION
The SnippetFinder changed in commit https://github.com/shopware/shopware/commit/41ed930d26751f17338a48f43136d64421da3e68 but the documentation still contained the old path.

AFAICT this applies to version 6.6.3.0 and newer.