### PR TITLE
Use latest shopware version in setup instructions as previous was running in errors

### DIFF
--- a/guides/installation/template.md
+++ b/guides/installation/template.md
@@ -17,7 +17,7 @@ To create a new Shopware project, run the following command:
 composer create-project shopware/production <project-name>
 
 # or install a specific version
-composer create-project shopware/production:6.6.10.0 <project-name>
+composer create-project shopware/production:6.6.10.5 <project-name>
 ```
 
 ::: info


### PR DESCRIPTION
Related errors:

```
$ composer create-project shopware/production:6.6.10.0 .
Creating a "shopware/production:6.6.10.0" project at "./"
Installing shopware/production (v6.6.10.0)
  - Installing shopware/production (v6.6.10.0): Extracting archive
Created project in /private/var/folders/7j/lfxr9fd12tn1lcfj3bl9f_7r0000gn/T/tmp.fcvyTU83hD/.
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires shopware/core v6.6.10.0 -> satisfiable by shopware/core[v6.6.10.0].
    - Root composer.json requires shopware/storefront * -> satisfiable by shopware/storefront[v6.0.0+ea2, ..., v6.6.10.5].
    - shopware/conflicts[0.2.0, ..., 0.3.0] conflict with twig/twig v3.21.1.
    - shopware/conflicts[0.2.0, ..., 0.3.0] conflict with twig/twig v3.20.0.
    - shopware/conflicts[0.2.0, ..., 0.3.0] conflict with twig/twig v3.19.0.
    - shopware/conflicts 0.4.0 requires shopware/core ~6.6.10.1 -> found shopware/core[v6.6.10.1, ..., v6.6.10.5] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/conflicts 0.5.0 requires shopware/core >=6.6.10.2 -> found shopware/core[v6.6.10.2, v6.6.10.3, v6.6.10.4, v6.6.10.5] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/conflicts 0.5.1 requires shopware/core >=6.7.1.0 -> found shopware/core[dev-trunk, 6.7.x-dev (alias of dev-trunk)] but it does not match your minimum-stability.
    - shopware/core v6.6.10.0 requires shopware/conflicts >=0.2.0 -> satisfiable by shopware/conflicts[0.2.0, ..., 0.5.1].
    - shopware/storefront v6.0.0+ea2 requires symfony/service-contracts 1.1.6 -> satisfiable by symfony/service-contracts[v1.1.6], symfony/contracts[v1.1.6].
    - shopware/storefront[v6.1.0, ..., v6.1.6] require symfony/config 4.4.1 -> satisfiable by symfony/config[v4.4.1].
    - shopware/storefront[v6.2.0, ..., 6.3.1.0] require symfony/config 4.4.4 -> satisfiable by symfony/config[v4.4.4].
    - shopware/storefront[6.3.1.1, ..., 6.3.5.4] require symfony/service-contracts 1.1.8 -> satisfiable by symfony/service-contracts[v1.1.8], symfony/contracts[v1.1.8].
    - shopware/storefront 6.4.0.0 requires shopware/core v6.4.0.0 -> found shopware/core[6.4.0.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.1.0 requires shopware/core v6.4.1.0 -> found shopware/core[6.4.1.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.1.1 requires shopware/core v6.4.1.1 -> found shopware/core[6.4.1.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.1.2 requires shopware/core v6.4.1.2 -> found shopware/core[6.4.1.2] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.10.0 requires shopware/core v6.4.10.0 -> found shopware/core[6.4.10.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.10.1 requires shopware/core v6.4.10.1 -> found shopware/core[6.4.10.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.11.0 requires shopware/core v6.4.11.0 -> found shopware/core[6.4.11.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.11.1 requires shopware/core v6.4.11.1 -> found shopware/core[6.4.11.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.12.0 requires shopware/core v6.4.12.0 -> found shopware/core[6.4.12.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.13.0 requires shopware/core v6.4.13.0 -> found shopware/core[6.4.13.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.14.0 requires shopware/core v6.4.14.0 -> found shopware/core[6.4.14.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.15.0 requires shopware/core v6.4.15.0 -> found shopware/core[6.4.15.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.15.1 requires shopware/core v6.4.15.1 -> found shopware/core[6.4.15.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.15.2 requires shopware/core v6.4.15.2 -> found shopware/core[6.4.15.2] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.16.0 requires shopware/core v6.4.16.0 -> found shopware/core[6.4.16.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.16.1 requires shopware/core v6.4.16.1 -> found shopware/core[6.4.16.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.17.0 requires shopware/core v6.4.17.0 -> found shopware/core[6.4.17.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.17.1 requires shopware/core v6.4.17.1 -> found shopware/core[6.4.17.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.17.2 requires shopware/core v6.4.17.2 -> found shopware/core[6.4.17.2] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.18.0 requires shopware/core v6.4.18.0 -> found shopware/core[6.4.18.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.18.1 requires shopware/core v6.4.18.1 -> found shopware/core[6.4.18.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.19.0 requires shopware/core v6.4.19.0 -> found shopware/core[6.4.19.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.2.0 requires shopware/core v6.4.2.0 -> found shopware/core[6.4.2.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.2.1 requires shopware/core v6.4.2.1 -> found shopware/core[6.4.2.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.20.0 requires shopware/core v6.4.20.0 -> found shopware/core[6.4.20.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.20.1 requires shopware/core v6.4.20.1 -> found shopware/core[6.4.20.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.20.2 requires shopware/core v6.4.20.2 -> found shopware/core[6.4.20.2] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.3.0 requires shopware/core v6.4.3.0 -> found shopware/core[6.4.3.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.3.1 requires shopware/core v6.4.3.1 -> found shopware/core[6.4.3.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.4.0 requires shopware/core v6.4.4.0 -> found shopware/core[6.4.4.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.4.1 requires shopware/core v6.4.4.1 -> found shopware/core[6.4.4.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.5.0 requires shopware/core v6.4.5.0 -> found shopware/core[6.4.5.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.5.1 requires shopware/core v6.4.5.1 -> found shopware/core[6.4.5.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.6.0 requires shopware/core v6.4.6.0 -> found shopware/core[6.4.6.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.6.1 requires shopware/core v6.4.6.1 -> found shopware/core[6.4.6.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.7.0 requires shopware/core v6.4.7.0 -> found shopware/core[6.4.7.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.8.0 requires shopware/core v6.4.8.0 -> found shopware/core[6.4.8.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.8.1 requires shopware/core 6.4.8.1 -> found shopware/core[6.4.8.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.8.2 requires shopware/core v6.4.8.2 -> found shopware/core[6.4.8.2] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront 6.4.9.0 requires shopware/core v6.4.9.0 -> found shopware/core[6.4.9.0] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront[6.5.0.0, ..., v6.5.7.4] require php ~8.1.0 || ~8.2.0 -> your php version (8.4.7) does not satisfy that requirement.
    - shopware/storefront[v6.5.8.0, ..., v6.5.8.18] require php ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (8.4.7) does not satisfy that requirement.
    - shopware/storefront[v6.6.0.0, ..., v6.6.9.0] require php ~8.2.0 || ~8.3.0 -> your php version (8.4.7) does not satisfy that requirement.
    - shopware/storefront v6.6.10.0 requires twig/twig ^3.19.0 -> satisfiable by twig/twig[v3.19.0, v3.20.0, v3.21.0, v3.21.1].
    - shopware/storefront v6.6.10.1 requires shopware/core v6.6.10.1 -> found shopware/core[v6.6.10.1] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront v6.6.10.2 requires shopware/core v6.6.10.2 -> found shopware/core[v6.6.10.2] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront v6.6.10.3 requires shopware/core v6.6.10.3 -> found shopware/core[v6.6.10.3] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront v6.6.10.4 requires shopware/core v6.6.10.4 -> found shopware/core[v6.6.10.4] but it conflicts with your root composer.json require (v6.6.10.0).
    - shopware/storefront v6.6.10.5 requires shopware/core v6.6.10.5 -> found shopware/core[v6.6.10.5] but it conflicts with your root composer.json require (v6.6.10.0).
    - symfony/config[v4.4.0, ..., v4.4.8] require php ^7.1.3 -> your php version (8.4.7) does not satisfy that requirement.
    - symfony/contracts[v1.1.6, ..., v1.1.8] require php ^7.1.3 -> your php version (8.4.7) does not satisfy that requirement.
    - symfony/service-contracts[v1.1.4, ..., v1.1.8] require php ^7.1.3 -> your php version (8.4.7) does not satisfy that requirement.
```

When I use the latest version in the version constraint it just works fine.