### PR TITLE
Fixed compose.override.yaml for using orbstack with https

### DIFF
--- a/guides/installation/setups/docker.md
+++ b/guides/installation/setups/docker.md
@@ -150,6 +150,8 @@ services:
       environment:
           APP_URL: https://web.sw.orb.local
           SYMFONY_TRUSTED_PROXIES: REMOTE_ADDR
+          HTTPS: on
+          SERVER_PORT: 443
 
 ###> symfony/mailer ###
   mailer:


### PR DESCRIPTION
When using the provided compose.override.yaml to use orbstack in the documentation. The resources (css, js) are still loaded over http instead of https. You have to add the following lines to fix this:
          HTTPS: on
          SERVER_PORT: 443