### PR TITLE
Add version notice for clientside-to-app-backend JWT feature

### DIFF
--- a/guides/plugins/apps/clientside-to-app-backend.md
+++ b/guides/plugins/apps/clientside-to-app-backend.md
@@ -42,6 +42,10 @@ The JWT is signed with `SHA256-HMAC` and the secret is the `appSecret` from the 
 
 ## Generate JSON Web Token
 
+::: info
+This feature has been introduced with Shopware version 6.5.5.0
+:::
+
 The JWT is generated with a POST request against `/store-api/app-system/{name}/generate-token` or `/app-system/{name}/generate-token`.
 
 <Tabs>


### PR DESCRIPTION
### Summary

This PR updates the `Client-side communication to the app backend` guide to clarify that the JWT-based communication feature was introduced in **Shopware version 6.5.5.0**.
