### PR TITLE
chore: bump-version-and-change-comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 user := "$(shell id -u):$(shell id -g)"
 ignored = '/docs/resources/references/adr/* /docs/assets/adr/* /docs/resources/guidelines/code/core/* /docs/snippets/guide/*'
-image = ghcr.io/rojopolis/spellcheck-github-actions:0.48.0
+image = ghcr.io/rojopolis/spellcheck-github-actions:0.49.0
 
-.PHONY : help lint fix
+.PHONY : help spellcheck fix
 .DEFAULT_GOAL : help
 
 # This will output the help for each task. thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -12,7 +12,7 @@ help: ## Show this help
 	@printf "\033[33m%s:\033[0m\n" 'Available commands'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-lint: ## Runs the linting tool
+spellcheck: ## Runs the spellcheck tool
 	docker run --rm -u ${user} -v "$(shell pwd):/docs" -w /docs -e INPUT_IGNORE=${ignored} ${image} \
 	    --config /docs/markdown-style-config.yml /docs
 


### PR DESCRIPTION
**Summary**

Update spellcheck tool version and rename command

- Bump spellcheck GitHub Actions from v0.48.0 to v0.49.0
- Rename lint command to spellcheck in Makefile for better clarity

 This is a maintenance update that keeps the spellcheck tooling current and improves the naming convention to be more descriptive of the actual functionality.
