### PR TITLE
fix(nginx): Remove old paths to install/update Shopware

### DIFF
--- a/resources/references/config-reference/server/nginx.md
+++ b/resources/references/config-reference/server/nginx.md
@@ -34,19 +34,6 @@ server {
         deny all;
     }
     
-    location /recovery/install {
-        index index.php;
-        try_files $uri /recovery/install/index.php$is_args$args;
-    }
-
-    location /recovery/update/ {
-        location /recovery/update/assets {
-        }
-        if (!-e $request_filename){
-            rewrite . /recovery/update/index.php last;
-        }
-    }
-    
     location ~ ^/(theme|media|thumbnail|bundles|css|fonts|js|recovery|sitemap)/ {
         expires 1y;
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";


### PR DESCRIPTION
Afaik these paths `/recovery/install` were only needed for Shopware 5 (or maybe some very old Shopware 6 setups, I am not sure). But now, for Shopware 6.7 they should not be needed anymore.