### PR TITLE
chore: fix-links

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1631,6 +1631,7 @@ qa@shopware.com
 qty's
 quantityBefore
 quantityDelta
+quickstart
 rabbitmq
 randomHex
 reCAPTCHA

--- a/guides/hosting/infrastructure/elasticsearch/elasticsearch-debugging.md
+++ b/guides/hosting/infrastructure/elasticsearch/elasticsearch-debugging.md
@@ -254,4 +254,4 @@ bin/console es:create:alias
 ## Logfiles and tipps
 
 You can usually find the Elasticsearch logfiles at [`/var/log/elasticsearch`](https://www.elastic.co/guide/en/elasticsearch/reference/master/settings.html#_config_file_format) to check for any issues when indexing.
-Also, tools like [Kibana](https://www.elastic.co/kibana) or [Cerebro](https://wissen.profihost.com/wissen/artikel/cerebro/) can help you better understand what is happening in your Elasticsearch.
+Also, tools like [Kibana](https://www.elastic.co/kibana) or [Cerebro](https://help.profihost.com/hc/de/articles/18918050563729-Cerebro) can help you better understand what is happening in your Elasticsearch.

--- a/guides/installation/setups/docker.md
+++ b/guides/installation/setups/docker.md
@@ -18,7 +18,7 @@ In this guide, we will run PHP, Node and all required services in Docker contain
 ## Prerequisites
 
 ::: info
-On macOS we recommend OrbStack, instead of Docker Desktop. OrbStack is a lightweight and fast alternative to Docker Desktop, and it is free for personal use. You can follow the official [OrbStack installation guide](https://orbstack.dev/docs/getting-started/installation) to install OrbStack.
+On macOS we recommend OrbStack, instead of Docker Desktop. OrbStack is a lightweight and fast alternative to Docker Desktop, and it is free for personal use. You can follow the official [OrbStack quickstart guide](https://docs.orbstack.dev/quick-start) to install OrbStack.
 :::
 
 - Docker installed on your machine. You can follow the official [Docker installation guide](https://docs.docker.com/get-docker/) to install Docker.

--- a/guides/plugins/apps/app-base-guide.md
+++ b/guides/plugins/apps/app-base-guide.md
@@ -310,7 +310,7 @@ You can use the `apiKey` and the `secretKey` as `client_id` and `client_secret`,
 
 You can find out more about how to use these credentials in our Admin API authentication guide:
 
-<PageRef page="https://shopware.stoplight.io/docs/admin-api/ZG9jOjEwODA3NjQx-authentication-and-authorisation#integration-client-credentials-grant-type" title="Admin API Authentication & Authorisation" target="_blank" />
+<PageRef page="https://shopware.stoplight.io/docs/admin-api/authentication#integration-client-credentials-grant-type" title="Admin API Authentication & Authorisation" target="_blank" />
 
 ::: info
 Starting from Shopware version 6.4.1.0, the current Shopware version will be sent as a `sw-version` header.

--- a/guides/plugins/plugins/api/customer-specific-pricing.md
+++ b/guides/plugins/plugins/api/customer-specific-pricing.md
@@ -18,7 +18,7 @@ Customer-specific pricing is part of the Commercial plugin, requiring an existin
 ## Working with the API route
 
 To create, alter and/or delete customer-specific prices, you can use the API endpoint `/api/_action/custom-price`. Like with any other admin request in Shopware, you must first authenticate yourself. Therefore, please head over to the
-[authentication guide](https://shopware.stoplight.io/docs/admin-api/ZG9jOjEwODA3NjQx-authentication) for details.
+[authentication guide](https://shopware.stoplight.io/docs/admin-api/authentication) for details.
 
 Otherwise, the Customer-specific Pricing API interface models itself upon the interface of the [sync API](https://shopware.stoplight.io/docs/admin-api/twpxvnspkg3yu-quick-start-guide), so you will be able to package your requests similarly.
 

--- a/guides/plugins/plugins/api/multi-inventory.md
+++ b/guides/plugins/plugins/api/multi-inventory.md
@@ -27,7 +27,7 @@ To create, modify or delete Warehouses, WarehouseGroups etc., related to Multi-I
 
 Meanwhile, refer to the following links regarding the general use of the Admin API:
 
-* [Authentication & Authorization](https://shopware.stoplight.io/docs/admin-api/ZG9jOjEwODA3NjQx-authentication)
+* [Authentication & Authorization](https://shopware.stoplight.io/docs/admin-api/authentication)
 * [Request, Response and Endpoint Structure](https://shopware.stoplight.io/docs/admin-api/request-and-response-structure)
 
 ## Data structure

--- a/products/extensions/b2b-components/shopping-lists/guides/api-and-pricing.md
+++ b/products/extensions/b2b-components/shopping-lists/guides/api-and-pricing.md
@@ -7,7 +7,7 @@ nav:
 
 ## Store API
 
-Here are some the actions you can perform on *Shopping lists* with Store API.
+Here are some of the actions you can perform on *Shopping lists* with Store API.
 
 ### Create new shopping list
 
@@ -53,15 +53,15 @@ The shopping list price will be included in the API for getting the shopping lis
 GET {url}/store-api/shopping-list/{id}/summary
 ```
 
-For more details, refer to [B2B Shopping Lists](https://shopware.stoplight.io/docs/store-api/0789edb2e95b6-create-new-shopping-list) from Store API docs.
+For more details, refer to [B2B Shopping Lists](https://shopware.stoplight.io/docs/store-api/c9849725606fd-create-new-shopping-list) from Store API docs.
 
 ## Admin API
 
-Shopping lists does not provide any special APIs. The Admin API offers CRUD operations for every entity within Shopware, and you can use it to work with shopping lists.
+Shopping lists do not provide any special APIs. The Admin API offers CRUD operations for every entity within Shopware, and you can use it to work with shopping lists.
 
 ### Shopping lists price
 
-A shopping lists shows a list of products. The prices of these products may change depending on the time, customers, and sales channels. Therefore, the price of each product and the total price of the shopping list will not be saved in the database but will be calculated when loading the shopping list.
+A shopping list shows a list of products. The prices of these products may change depending on the time, customers, and sales channels. Therefore, the price of each product and the total price of the shopping list will not be saved in the database but will be calculated when loading the shopping list.
 
 The `Shopware\Commercial\B2B\ShoppingList\Subscriber\ShoppingListSubscriber` listens to any loading of a shopping list.
 


### PR DESCRIPTION
- Fixed broken Cerebro documentation link in Elasticsearch debugging guide
- Updated OrbStack installation link to use their new quickstart guide
- Corrected Stoplight API documentation URLs that were outdated
- Fixed minor grammar issues in B2B Shopping Lists guide