### PR TITLE
fix: remove redundant function call

### DIFF
--- a/guides/plugins/plugins/administration/data-handling-processing/using-data-handling.md
+++ b/guides/plugins/plugins/administration/data-handling-processing/using-data-handling.md
@@ -118,8 +118,6 @@ Shopware.Component.register('swag-basic-example', {
         criteria.getAssociation('categories')
             .addSorting(Criteria.sort('category.name', 'ASC'));
 
-        this.productRepository.create('product');
-
         this.productRepository
             .search(criteria, Shopware.Context.api)
             .then(result => {


### PR DESCRIPTION
The edited documentation section demonstrates various functionalities of the Criteria class, when fetching entities.
 
Initially "productRepository" is instantiated via a call to the "create" function of the "RepositoryFactory" class, which returns an object of the type Repository<EntityName>.

Then, the "create" function of the said repository object is called with 'product' as an argument. This function call is totally redundant as it creates an entity with the id passed as a parameter and returns it. 

The returned Entity object is not used anywhere else and doesn't serve any purpose. Furthermore, 'product' is used as an id of the newly created object, which is generally not a good practice, as it doesn't fit the format.  

Thus, the function call to "this.productRepository.create('product')" serves no purpose, other than to confuse new developers and produce unnecessary overhead. 