### PR TITLE
fix: update PaaS CLI installation URL in quickstart guide

### DIFF
--- a/products/paas/shopware/get-started/quickstart.md
+++ b/products/paas/shopware/get-started/quickstart.md
@@ -21,7 +21,7 @@ Before you begin, ensure you have:
 First, install the Shopware PaaS Native CLI tool:
 
 ```sh
-curl -L https://install.cli.shopware.systems | sh
+curl -L https://install.sw-paas-cli.shopware.systems | sh
 ```
 
 Verify the installation:


### PR DESCRIPTION
This pull request updates the installation instructions for the Shopware PaaS Native CLI tool in the `quickstart.md` file. The change updates the URL to reflect the new domain for downloading the CLI binary.