### PR TITLE
fix: update locks configuration documentation

### DIFF
--- a/guides/hosting/performance/lock-store.md
+++ b/guides/hosting/performance/lock-store.md
@@ -13,7 +13,15 @@ By default, Symfony will use a local lock store. This means in multi-machine (cl
 ## Using Redis as a lock store
 
 As Redis can already be used for [caching](./caches), [increment store](./increment), and [session storage](./session), you can also use that Redis host as a remote lock store.
-To use Redis, create a `config/packages/lock.yaml` file with the following content:
+To use Redis, first you need to create a named redis connection as described in the [Redis configuration guide](../infrastructure/redis#configuration).
+Then, you can configure the lock store to use that connection. Create a `config/packages/lock.yaml` file with the following content:
+
+```yaml
+framework:
+    lock: 'shopware.redis.connection.connection_name'
+```
+
+Alternatively, you can use the DSN directly in the configuration file, but this is not recommended as it does not allow connection reuse and not prefixing locks keys with the value of the `REDIS_PREFIX` environment variable.
 
 ```yaml
 framework:

--- a/guides/hosting/performance/performance-tweaks.md
+++ b/guides/hosting/performance/performance-tweaks.md
@@ -99,12 +99,7 @@ If you don't need such functionality, it is highly recommended that you disable 
 
 Shopware uses [Symfony's Lock component](https://symfony.com/doc/5.4/lock.html) to implement locking functionality.
 By default, Symfony will use a local file-based [lock store](../performance/lock-store), which breaks into multi-machine (cluster) setups. This is avoided using one of the [supported remote stores](https://symfony.com/doc/5.4/components/lock.html#available-stores).
-
-```yaml
-# config/packages/prod/framework.yaml
-framework:
-    lock: 'redis://host:port'
-```
+For more information on how to configure the lock store, refer to the [Lock storage guide](./lock-store).
 
 ## Number ranges
 


### PR DESCRIPTION
Updating locks configuration documentation with some redis configuration best practices.