### PR TITLE
fix: caching-links

### DIFF
--- a/concepts/framework/http_cache.md
+++ b/concepts/framework/http_cache.md
@@ -69,6 +69,6 @@ An example of usage for this feature is to save the cache for logged-in customer
 
 As soon as a response has been defined as cacheable and the response is written to the cache, it is tagged accordingly. For this purpose, the core uses all cache tags generated during the request or loaded from existing cache entries. The cache invalidation of a Storefront controller route is controlled by the cache invalidation of the Store API routes.
 
-For more information about Store API cache invalidation, you can refer to the [Add Cache for Store API Route Guide](../../guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route).
+For more information about Store API cache invalidation, you can refer to the [Caching Guide](../../guides/plugins/plugins/framework/caching/index.md).
 
 This is because all data loaded in a Storefront controller, is loaded in the core via the corresponding Store API routes and provided with corresponding cache tags. So the tags of the HTTP cache entries we have in the core consist of the sum of all Store API tags generated or loaded during the request. Therefore, the invalidation of a controller route is controlled over the Store API cache invalidation.

--- a/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
+++ b/guides/plugins/plugins/storefront/add-caching-to-custom-controller.md
@@ -55,6 +55,6 @@ class ExampleController extends StorefrontController
 
 As soon as a controller route has been defined as cacheable, and the corresponding response is written to the cache, it is tagged accordingly. For this purpose, the core uses all cache tags generated during the request or loaded from existing cache entries. The cache invalidation of the Storefront controller routes is controlled by the cache invalidation of the store API routes.
 
-For more information about Store API cache invalidation, you can refer to the [Add Cache for Store Api Route Guide](../framework/store-api/add-caching-for-store-api-route).
+For more information about Store API cache invalidation, you can refer to the [Caching Guide](../framework/caching/index.md).
 
 This is because all data loaded in a controller route, is loaded in the core via the corresponding Store API routes and provided with corresponding cache tags. So the tags of the HTTP cache entries we have in the core consists of the sum of all store api tags generated or loaded during the request. Therefore the invalidation of a controller route that loads all data via the store API, no additional invalidation needs to be written.


### PR DESCRIPTION
## Fix broken links to removed Store API caching guide

### Problem
Two documentation files contained broken links to `add-caching-for-store-api-route.md`, which was removed in commit 21393f1c (June 18, 2025) as part of PR #1743 that consolidated caching documentation into a unified guide.

### Changes
- **Fixed broken link in `guides/plugins/plugins/storefront/add-caching-to-custom-controller.md`**
  - Updated reference from deleted `../framework/store-api/add-caching-for-store-api-route` 
  - Now points to `../framework/caching/index.md`

- **Fixed broken link in `concepts/framework/http_cache.md`**
  - Updated reference from deleted `../../guides/plugins/plugins/framework/store-api/add-caching-for-store-api-route`
  - Now points to `../../guides/plugins/plugins/framework/caching/index.md`
