### PR TITLE
Fix/lychee retries for flaky tests

### DIFF
--- a/.github/workflows/validate-external-links.yml
+++ b/.github/workflows/validate-external-links.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.1.0
+        uses: lycheeverse/lychee-action@v2
         with:
           fail: false
           args: --retry-wait-time 10 --max-retries 3 --timeout 30 --accept=200,403,429 -s "https"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude-mail

--- a/.github/workflows/validate-external-links.yml
+++ b/.github/workflows/validate-external-links.yml
@@ -18,7 +18,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.1.0
         with:
           fail: false
-          args: --accept=200,403,429 -s "https"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude-mail
+          args: --retry-wait-time 10 --max-retries 3 --timeout 30s --accept=200,403,429 -s "https"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude-mail
 
       - name: Find Link Checker Issue
         uses: micalevisk/last-issue-action@v2

--- a/.github/workflows/validate-external-links.yml
+++ b/.github/workflows/validate-external-links.yml
@@ -18,7 +18,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.1.0
         with:
           fail: false
-          args: --retry-wait-time 10 --max-retries 3 --timeout 30s --accept=200,403,429 -s "https"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude-mail
+          args: --retry-wait-time 10 --max-retries 3 --timeout 30 --accept=200,403,429 -s "https"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude-mail
 
       - name: Find Link Checker Issue
         uses: micalevisk/last-issue-action@v2


### PR DESCRIPTION
The changes in this branch update the Lychee link checker workflow in .github/workflows/validate-external-links.yml:


**Added** 
--retry-wait-time 10 to wait 10 seconds between retries.
--max-retries 3 to retry failed URLs up to 3 times.
 --timeout 30 for a 30-second timeout per request.

This makes the link check more reliable for unstable or temporarily unreachable URLs.

Also the version was changed to fix v2 - no minor