### PR TITLE
Remove image proxy setup instructions from Docker guide

### DIFF
--- a/guides/installation/setups/docker.md
+++ b/guides/installation/setups/docker.md
@@ -202,7 +202,7 @@ You can also open `https://orb.local` in your browser and see all running contai
 
 ## Proxy Production Images
 
-<PageRef page="products/cli/project-commands/image-proxy" />
+<PageRef page="../../../products/cli/project-commands/image-proxy" />
 
 ## Known issues
 


### PR DESCRIPTION
We should stick to one solution for a problem :)