### PR TITLE
Update Homebrew installation command to use --cask

### DIFF
--- a/products/cli/installation.md
+++ b/products/cli/installation.md
@@ -18,7 +18,7 @@ Shopware CLI is published in various package managers. You can install it using 
 ### Homebrew
 
 ```bash
-brew install shopware/tap/shopware-cli
+brew install --cask shopware/tap/shopware-cli
 ```
 
 ### Debian/Ubuntu — APT based Linux


### PR DESCRIPTION
Using Formula is deprecated, casks are recommended

https://goreleaser.com/deprecations/?h=deprec#brews

