### PR TITLE
Deletion of cluster reference plugins

### DIFF
--- a/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
@@ -47,13 +47,6 @@ Please pay attention to every point in this guide. We'll review it before you re
 
 * We check the complete functionality of the app (separately sales channel configurations in the config.xml, the uninstallation and reinstallation procedure) and check for styling errors on every viewport.
 
-* We want to improve the quality of the Shopware Community Store and offer as many different apps as possible.
-Hence, we check for a functional comparison with other apps already in the Shopware Community store, in the Rise edition or above.
-If an extension with the same function exists and it does not fit into one of our differentiator clusters, it can be rejected as it doesn't provide any added value.
-If you would like more information, please write an email to [qa@shopware.com](mailto:qa@shopware.com).
-
-Link: [Differentiator cluster for Shopware extensions](../../../../../resources/guidelines/testing/Differentiator-Clusters.md)
-
 Link: [Documentation for Extension Partner](https://docs.shopware.com/en/account-en/extension-partner/extensions?category=account-en/extension-partner#how-can-i-request-a-preview)
 
 ::: info


### PR DESCRIPTION
We will no longer be working with clusters as of 1 October 2025.


This change may only be implemented on 1 October.