### PR TITLE
docs: Correct language codes in testing documentation

### DIFF
--- a/guides/plugins/plugins/testing/playwright/language-agnostic-testing.md
+++ b/guides/plugins/plugins/testing/playwright/language-agnostic-testing.md
@@ -1,7 +1,7 @@
 ---
 nav:
     title: Language Agnostic Testing
-    position: 20
+    position: 19
 ---
 
 # Language Agnostic Testing
@@ -46,8 +46,8 @@ test('Category creation', async ({ AdminPage, Translate }) => {
 Switch test language using environment variables:
 
 ```bash
-LANG=de npm run test  # German
-LANG=en npm run test  # English (default)
+LANG=de-DE npm run test  # German
+LANG=en-GB npm run test  # English (default)
 ```
 
 ## Translation Keys
@@ -365,11 +365,8 @@ export default defineConfig({
 
 ```bash
 # German
-lang=de npx playwright test
+LANG=de-DE npx playwright test
 
 # English (default)
 npx playwright test
-
-# Using system environment
-LANG=de npx playwright test
 ```


### PR DESCRIPTION
This pull request makes minor documentation updates to the Playwright language-agnostic testing guide. The main changes clarify the usage of the `LANG` environment variable by specifying locale codes and adjust the navigation position in the documentation.

- Documentation improvements:
  * Updated examples to use full locale codes (e.g., `de-DE`, `en-GB`) for the `LANG` environment variable in test commands, ensuring clarity and consistency. [[1]](diffhunk://#diff-d07b2e093a0f7470c3afd0bb9b11d87e9f84023f5871115a46ec5756ccfcd428L49-R50) [[2]](diffhunk://#diff-d07b2e093a0f7470c3afd0bb9b11d87e9f84023f5871115a46ec5756ccfcd428L368-L374)

- Documentation organization:
  * Changed the navigation position of the "Language Agnostic Testing" guide from 20 to 19 for better ordering in the docs.Updated language codes in testing instructions for clarity.