### PR TITLE
Update documentation for Composer plugin loader

### DIFF
--- a/products/paas/shopware-paas/build-deploy.md
+++ b/products/paas/shopware-paas/build-deploy.md
@@ -61,7 +61,7 @@ Make sure to replace `%place your key here%` with your actual token. You can fin
 
 ## Extending Shopware - plugins and apps
 
-The PaaS recipe uses the [Composer plugin loader](../../../guides/hosting/installation-updates/cluster-setup#composer-plugin-loader).
+The PaaS recipe uses the Composer plugin loader, which expects all extension being installed via Composer.
 
 ## Manually trigger rebuilds
 


### PR DESCRIPTION
Clarify the usage of the Composer plugin loader in the PaaS recipe as the previous link is dead