### PR TITLE
fix: Change nodeJS requirement and update recommendations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,3 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.md]
-trim_trailing_whitespace = false

--- a/guides/installation/requirements.md
+++ b/guides/installation/requirements.md
@@ -141,7 +141,7 @@ brew install mariadb
 
 ### JavaScript
 
-* Node.js 
+* Node.js
 
   * Recommended version: 24.0.0 or higher
   * Minimum version: 20.0.0


### PR DESCRIPTION
The minimum nodeJS version documented is wrong. 
See [6.7](https://github.com/shopware/shopware/blob/v6.7.3.1/src/Administration/Resources/app/administration/package.json#L204) and [6.6](https://github.com/shopware/shopware/blob/v6.6.10.8/src/Administration/Resources/app/administration/package.json#L245)
I also updated the recommendations to use newer versions.