### PR TITLE
Clarify that store api should not directly be used in twig storefront

### DIFF
--- a/concepts/api/store-api.md
+++ b/concepts/api/store-api.md
@@ -19,7 +19,6 @@ Using plugins, you can add custom routes to the Store API \(as well as any other
 
 <PageRef page="../../guides/plugins/plugins/framework/store-api/" />
 
-
 ## Store API and the traditional TWIG storefront
 
 When using the server-side rendered TWIG storefront, the Store API is not used.


### PR DESCRIPTION
the store api should not be used directly from within the storefront,