### PR TITLE
Fix the link for contribution changelog guideline

### DIFF
--- a/resources/guidelines/code/contribution.md
+++ b/resources/guidelines/code/contribution.md
@@ -25,7 +25,7 @@ Here is a checklist of requirements you should always consider when committing n
 * A pull request to the Shopware core always has to be made to the [main shopware](https://github.com/shopware/shopware) repository.
 * Fill out the [pull request info template](https://github.com/shopware/shopware/blob/trunk/.github/PULL_REQUEST_TEMPLATE.md) as detailed as possible.
 * Create a changelog file with documentation of your changes.
-  Refer to [Changelog](https://github.com/shopware/shopware/blob/master/adr/2020-08-03-implement-new-changelog.md) section for more detailed information about writing changelog.
+  Refer to [Changelog](https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md) section for more detailed information about writing changelog.
 * Check if your pull request addresses the correct Shopware branch.
   It should always target the `trunk` branch.
   If you would like to have your changes in the previous major version, we have the possibility to do a backport quite easily.


### PR DESCRIPTION
The contribution guidelines still has the link to the old changelog information.
Since the file was moved into `_superseded`, the link in the documentation is a 404.

This PR swaps it with the new guideline.

Old: https://github.com/shopware/shopware/blob/master/adr/2020-08-03-implement-new-changelog.md
New: https://github.com/shopware/shopware/blob/trunk/adr/2025-10-28-changelog-release-info-process.md