### PR TITLE
fix/link

### DIFF
--- a/guides/installation/setups/symfony-cli.md
+++ b/guides/installation/setups/symfony-cli.md
@@ -43,7 +43,7 @@ composer create-project shopware/production:6.6.10.0 <project-name>
 
 During project creation, Symfony Flex asks whether you want to use Docker. Choose **Yes** if you want to run the database in a container, or **No** to use a local MySQL/MariaDB server.
 
-For more details, see the [Shopware Production template documentation](https://developer.shopware.com/docs/guides/installation/production.html).
+For more details, see the [Shopware Production template documentation](../template).
 
 ## Configure database connection
 

--- a/guides/installation/template.md
+++ b/guides/installation/template.md
@@ -7,7 +7,7 @@ nav:
 
 # Project Template
 
-The Shopware project template is a Composer project that can be used as starting point for new Shopware Projects, or if you want to develop extensions or themes for Shopware.
+The Shopware project template is a Composer project that can be used as a starting point for new Shopware Projects, or if you want to develop extensions or themes for Shopware.
 
 Each official setup option—[Docker](./setups/docker.md), [Symfony CLI](./setups/symfony-cli.md), and [Devenv](./setups/devenv.md)—builds upon this project template, either directly or via a pre-configured environment. See [Installation Overview](./index.md) for a comparison of setup options.
 
@@ -109,7 +109,7 @@ There are two ways to update Shopware:
 
 * To force-update all config files, run `composer recipes:update`.
 
-## Migrate from old zip installation to new project template
+## Migrate from the old zip installation to a new project template
 
 Before Shopware 6.5, we provided a zip file for installation. The zip file contained all dependencies required to run Shopware. This method has been deprecated and replaced with a Composer project template. The Composer project template is way more flexible and allows you to manage extensions together with Shopware itself using Composer.
 
@@ -117,7 +117,7 @@ To migrate from the old zip installation to the new Composer project template, y
 
 ### 1. Backup
 
-Start with a clean git state, stash everything or make a backup of your files.
+Start with a clean git state, stash everything, or make a backup of your files.
 
 ### 2. Adjust root composer.json
 


### PR DESCRIPTION
## Pull Request Overview

This PR fixes grammar issues and updates an absolute URL to a relative path in the installation documentation.

- Grammar improvements in `guides/installation/template.md` (adding articles and a comma)
- Link fix in `guides/installation/setups/symfony-cli.md` (converting absolute URL to relative path)

### Reviewed Changes

Copilot reviewed 2 out of 2 changed files in this pull request and generated no comments.

| File | Description |
| ---- | ----------- |
| guides/installation/template.md | Fixed grammar by adding articles ("a", "the") and improved punctuation with comma placement |
| guides/installation/setups/symfony-cli.md | Converted absolute URL to relative path for internal documentation link |





---

💡 <a href="/shopware/docs/new/main/.github/instructions?filename=*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.