### PR TITLE
DX-693 add/missing-commands-esp-make-plugin

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -317,6 +317,7 @@ Dockerfile
 Dockware
 DomainException
 DomainExceptions
+Dotenv
 DynamoDB
 ECDSA
 ENUM
@@ -1284,6 +1285,7 @@ dom
 don'ts
 dont
 dont's
+dotenv
 dr
 dragTo
 dropdown

--- a/resources/references/core-reference/commands-reference.md
+++ b/resources/references/core-reference/commands-reference.md
@@ -228,7 +228,6 @@ $ bin/console [command] [parameters]
 
 Generating the skeletons and essential files needed to create and structure a Shopware plugin.
 
-
  | Command                             | Description                                    |
  |:------------------------------------|:-----------------------------------------------|
  | `make:plugin:admin-module`          | Generate an administration module skeleton     |


### PR DESCRIPTION
**Summary**
This PR updates the commands reference to reflect the current CLI command set. It adds missing commands, creates new sections where appropriate, and standardizes table formatting.

**Scope**
Affects only: resources/references/core-reference/commands-reference.md

**Changes**

- Added missing commands to existing sections:
- Administration, App, Cache, Dal, Debug, Es, Lint, Media, Plugin, System, User
- Created new sections with tables:
- Dotenv, Error, Integration, Server, Services, Translation
- Added “Make plugin” section documenting all make:plugin:* generators
- Harmonized table headers and descriptions to match CLI phrasing

**Why**
Keep the reference in sync with actual bin/console output