### PR TITLE
docs: fix app signature verification php header name and secret name

### DIFF
--- a/guides/plugins/apps/app-signature-verification.md
+++ b/guides/plugins/apps/app-signature-verification.md
@@ -134,10 +134,10 @@ $body = $response->getBody()->getContents();
 $response->getBody()->rewind();
 
 // calculate the signature
-$signature = hash_hmac('sha256', $body, $appSecret);
+$signature = hash_hmac('sha256', $body, $shopSecret);
 
 // add the signature to the response
-$response = $response->withHeader('shopware-shop-signature', $signature);
+$response = $response->withHeader('shopware-app-signature', $signature);
 ```
 
 </Tab>


### PR DESCRIPTION
### 1. Why is this change necessary?
The current documenatation for https://developer.shopware.com/docs/guides/plugins/apps/app-signature-verification.html#signing-responses are wrong.

### 2. What does this change do, exactly?
In reality the header is named "shopware-app-signature" and it is not the app secret that is used but the, in the handshake generated, shop secret