### PR TITLE
fix: add-data-to-mails.md by adding content about registering event subscriber

### DIFF
--- a/guides/plugins/plugins/content/mail/add-data-to-mails.md
+++ b/guides/plugins/plugins/content/mail/add-data-to-mails.md
@@ -137,3 +137,27 @@ class MyMailSubscriber implements EventSubscriberInterface
 ```
 
 :::
+
+### Register your event subscriber
+
+You have to register the subscriber to the service container as well.
+
+Here's the respective example `services.xml`:
+
+::: code-group
+
+```xml [PLUGIN_ROOT/src/Resources/config/services.xml]
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Swag\BasicExample\Subscriber\MyMailSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+    </services>
+</container>
+```
+
+:::


### PR DESCRIPTION
See docs page:
https://developer.shopware.com/docs/guides/plugins/plugins/content/mail/add-data-to-mails.html#adding-data-via-subscriber

It mentions to add a class `MyMailSubscriber`, which implements the `EventSubscriberInterface` but doesn't explain that it needs to be registered to the service container with the `<tag name="kernel.event_subscriber"/>` tag.

This PR adds a section with that extra needed information.