### PR TITLE
Document info-level logging for cache invalidation

### DIFF
--- a/concepts/framework/http_cache.md
+++ b/concepts/framework/http_cache.md
@@ -96,7 +96,16 @@ This is because all data loaded in a Storefront controller is loaded in the core
 
 List-type routes are not tagged with all entities returned in the response. This applies to Store API endpoints such as product listings or search results, category listings, or SEO URL listings. These routes instead rely on their TTL as defined by the active HTTP Caching Policy. If the default TTLs are not appropriate for your use case, configure a [custom caching policy](../../guides/hosting/performance/caches.md#fine-tuning-per-route-or-app-hook) for those routes. The reason is that, while it would be technically possible to try to invalidate all affected listings when a single entity changes, doing this at scale is very costly in terms of performance and resources. One entity can appear in many different listings (with different filters, sorting, pagination, etc.). It is also not possible to catch all cases where a change would cause an entity to newly appear in or disappear from a cached listing. Because of this, listing pages cannot guarantee strict, immediate consistency under caching; instead, we accept a small amount of staleness in exchange for predictable performance and stability.
 
-Since v6.7.7.0, cache invalidations are logged at the info level and can be enabled or disabled via the `tag_invalidation_log_enabled` configuration option.
+Since v6.7.7.0, cache invalidations logging at info level can be enabled or disabled via the `tag_invalidation_log_enabled` configuration option.
+It is disabled by default. 
+
+```yaml
+# <shopware-root>/config/packages/shopware.yaml
+shopware:
+  cache:
+    invalidation:
+      tag_invalidation_log_enabled: false
+```
 
 ## HTTP Cache workflow
 


### PR DESCRIPTION
Documents that cache invalidation events are logged at the info level to improve observability.

companion PR in platform https://github.com/shopware/shopware/pull/14253