### PR TITLE
chore: update app custom flow actions guide to focus on current state

### DIFF
--- a/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md
+++ b/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md
@@ -201,7 +201,7 @@ Define the `parameter` for the URL body based on your URL webhook services.
 | type                                       | Type of parameter, only support `string` type.                                                                                                                         |
 | name                                       | The body key for your URL.                                                                                                                                             |
 | value                                      | The content message for your URL; free to design your content message here.                                                                                            |
-| <code v-pre>{{ message }}</code>           | The variable from your `<input-field>` defined in `flow.xml`.                                                                                                   |
+| <code v-pre>{{ message }}</code>           | The variable from your `<input-field>` defined in `flow.xml`.                                                                                                          |
 | <code v-pre>{{ order.orderNumber }}</code> | For each trigger event, the action will have the variables suitable. [Read more variables here](../../../../resources/references/app-reference/flow-action-reference). |
 
 With the parameters configured as described above, an exemplary call of your Webhook Action could look like this:


### PR DESCRIPTION
Before this change /docs/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app-system.md describes structure that is working for older shopware versions and briefly mentions changes to make it work for the current one. 

The pr changes it to describe current state and removes mentions of legacy state, as documentation is versioned.