### PR TITLE
docs: xdebug docker setup for linux

### DIFF
--- a/guides/installation/setups/docker-options.md
+++ b/guides/installation/setups/docker-options.md
@@ -50,7 +50,7 @@ To enable Xdebug connectivity on Linux, you must manually map the host.docker.in
 services:
     web:
         extra_hosts:
-        - "host.docker.internal:host-gateway"
+            - "host.docker.internal:host-gateway"
 ```
 
 Shopware’s Docker setup also supports other profilers, like [Blackfire](https://www.blackfire.io/), [Tideways](https://tideways.com/), and [PCOV](https://github.com/krakjoe/pcov). For Tideways and Blackfire, you'll need to run an additional container. For example:


### PR DESCRIPTION
## Description
I had problems with xdebug working with the official docker setup on my dev machine (Fedora 43). So I started searching and found out that Linux does not map the internal Docker hostname to the Docker host gateway. I added the correct mapping and that worked for me. It would be great to have this in official docs.

## Changes
Added a note about using ```extra_hosts: - "host.docker.internal:host-gateway"``` in ```compose.override.yaml```.

## Testing
Verified on Fedora 43 with PHPStorm/vscode, official shopware docker image ```ghcr.io/shopware/docker-dev:php8.4-node22-caddy``` (PHP 8.4.17 and Xdebug 3.5.0) and Docker 29.2.1.