### PR TITLE
chore/fix-links

### DIFF
--- a/resources/guidelines/testing/store/quality-guidelines-apps/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-apps/index.md
@@ -392,7 +392,7 @@ For example, "Swag\\MyPlugin\\SwagMyPluginSW6" instead of "Swag\\MyPlugin\\SwagM
 
 ### Ensure cross-domain messages are sent to the intended domain
 
-When using `postMessage()` or similar cross-window messaging APIs, verify the message origin (e.g. `event.origin`) and restrict target domains to trusted URLs instead of `'*'`. This prevents malicious sites from sending or receiving messages inappropriately.
+When using `postMessage()` or similar cross-window messaging APIs, verify the message origin (e.g. `event.origin`) and restrict target domains to trusted URLs instead of `'*'`. This prevents malicious sites from sending or receiving unauthorized messages.
 
 ### Class Shopware\Storefront\* not found
 

--- a/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
+++ b/resources/guidelines/testing/store/quality-guidelines-plugins/index.md
@@ -433,7 +433,7 @@ Link: [Example of a valid composer.json](https://github.com/FriendsOfShopware/Fr
 
 ### Ensure cross-domain messages are sent to the intended domain
 
-When using `postMessage()` or similar cross-window messaging APIs, verify the message origin (e.g. `event.origin`) and restrict target domains to trusted URLs instead of `'*'`. This prevents malicious sites from sending or receiving messages inappropriately.
+When using `postMessage()` or similar cross-window messaging APIs, verify the message origin (e.g. `event.origin`) and restrict target domains to trusted URLs instead of `'*'`. This prevents malicious sites from sending or receiving unauthorized messages.
 
 ### No bootstrapping file found. Expecting bootstrapping in
 


### PR DESCRIPTION
There are no active links anymore on that, so I searched the webarchive and added context here:

https://web.archive.org/web/20230927143646/https://rules.sonarsource.com/typescript/type/Vulnerability/RSPEC-2819/

Not sure if still needed, but better then a 404 - Sonarcube support does not answer. Rules seem to be removed.