### PR TITLE
fix: legacy setups position

### DIFF
--- a/guides/installation/legacy-setups/index.md
+++ b/guides/installation/legacy-setups/index.md
@@ -1,7 +1,7 @@
 ---
 nav:
   title: Legacy Setups
-  position: 15
+  position: 10000
 
 ---
 


### PR DESCRIPTION
... and a reference to the nicely hidden sidebar items sorter. :)

https://github.com/shopware/developer-documentation-vitepress/blob/main/src/shopware/composables/Sidebar.ts#L176