### PR TITLE
Update CLI auth docs to use client credentials

### DIFF
--- a/products/cli/shopware-account-commands/authentication.md
+++ b/products/cli/shopware-account-commands/authentication.md
@@ -17,8 +17,4 @@ shopware-cli account login
 
 and it will open a browser window for you to log in.
 
-For CI/CD pipelines, you should pass `SHOPWARE_CLI_ACCOUNT_EMAIL` and `SHOPWARE_CLI_ACCOUNT_PASSWORD` as environment variables and call directly the command you want to use.
-
-::: info
-For CI/CD tasks you should create a dedicated Shopware Account with limited access to the Shopware Store.
-:::
+For CI/CD pipelines, you should pass `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` and `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET` as environment variables and call directly the command you want to use. The client ID and client secret can be generated in the **Extension Partner** section under the [Development](https://account.shopware.com/producer/development) navigation point in the [Shopware Account](https://account.shopware.com).


### PR DESCRIPTION
> [!CAUTION]
> Merge this on 1 April 2026, as than the feature will be available in the Shopware Account

## Summary
- Replace legacy `SHOPWARE_CLI_ACCOUNT_EMAIL` / `SHOPWARE_CLI_ACCOUNT_PASSWORD` env vars with the new `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` / `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET` for CI/CD authentication
- Add guidance on where to generate client credentials (Extension Partner > Development in the Shopware Account)

Related: https://github.com/shopware/shopware-cli/pull/918

## Test plan
- [ ] Verify the rendered docs page displays correctly