### PR TITLE
docs: clarify extension-management conflicts with Store-installed plugins

### DIFF
--- a/guides/hosting/installation-updates/deployments/deployment-helper.md
+++ b/guides/hosting/installation-updates/deployments/deployment-helper.md
@@ -225,7 +225,7 @@ Additionally, you can configure the Shopware installation using the following en
 When `extension-management` is enabled (default), the Deployment Helper automatically manages **all** extensions it finds in `custom/plugins`, `custom/apps`, and via Composer. This means it will install, update, activate, or deactivate extensions based on what is present in your codebase.
 
 :::warning
-If you install plugins later via the Shopware Store (Admin UI) while `extension-management` is enabled, this can cause conflicts during deployment. The Deployment Helper does not know about extensions that were installed at runtime through the Store and may interfere with their state. For example, a Store-installed plugin might be deactivated or behave unexpectedly after the next deployment.
+If you install plugins later via the Shopware Store (Admin UI) while `extension-management` is enabled, this can cause conflicts during deployment. The Deployment Helper does not know about extensions installed at runtime through the Store and may interfere with their state. For example, a Store-installed plugin might be deactivated or behave unexpectedly after the next deployment.
 :::
 
 You have two options to handle this:


### PR DESCRIPTION
## Summary
- Add warning that runtime-installed extensions (via Store/Admin UI) conflict with Deployment Helper's `extension-management` when enabled
- Add dedicated section "Extension Management and Store-installed Plugins" with two clear options: manage all via Composer (recommended) or disable extension-management
- Add inline comment in the YAML config example pointing to the new section

Based on customer feedback that the interaction between `extension-management` and Store-installed plugins was not well documented.

## Test plan
- [ ] Verify the new section renders correctly (warning box, code blocks, link to extension-management page)
- [ ] Verify the inline YAML comment in the config block is clear