### PR TITLE
remove/old-link-to-weird-site

### DIFF
--- a/resources/references/telemetry.md
+++ b/resources/references/telemetry.md
@@ -122,7 +122,7 @@ Or for a single command:
 DO_NOT_TRACK=1 shopware-cli project create
 ```
 
-This follows the `Console Do Not Track convention standard` used by many CLI tools.
+This follows the `Console Do Not Track` convention used by many CLI tools.
 
 ## Data flow summary
 

--- a/resources/references/telemetry.md
+++ b/resources/references/telemetry.md
@@ -6,7 +6,7 @@ You can [opt out of sharing telemetry data](#how-can-i-configure-telemetry) at a
 
 ## Why are we collecting telemetry data?
 
-Telemetry allows us to better identify bugs and gain visibility on usage of features across all users. It also helps us to make data-informed decisions like adding, improving or removing features. We monitor and analyze this data to ensure consistent growth, stability, usability and developer experience. For instance, if certain errors are hit more frequently, those bug fixes will be prioritized in future releases.
+Telemetry allows us to better identify bugs and gain visibility on usage of features across all users. It also helps us to make data-informed decisions like adding, improving, or removing features. We monitor and analyze this data to ensure consistent growth, stability, usability, and developer experience. For instance, if certain errors are hit more frequently, those bug fixes will be prioritized in future releases.
 
 ## Which tools collect telemetry data?
 
@@ -51,13 +51,13 @@ Data is sent via UDP to `udp.usage.shopware.io:9000`, which is operated in Frank
 
 ### Tracked events
 
-| Event | Description |
-|-------|-------------|
-| `deployment_helper.php_version` | PHP version at the time of a deployment run |
-| `deployment_helper.mysql_version` | MySQL/MariaDB version at the time of a deployment run |
-| `deployment_helper.installed` | A fresh Shopware installation completed |
-| `deployment_helper.upgrade` | A Shopware upgrade completed |
-| `deployment_helper.theme_compiled` | Theme compilation completed after an upgrade |
+| Event                              | Description                                           |
+|------------------------------------|-------------------------------------------------------|
+| `deployment_helper.php_version`    | PHP version at the time of a deployment run           |
+| `deployment_helper.mysql_version`  | MySQL/MariaDB version at the time of a deployment run |
+| `deployment_helper.installed`      | A fresh Shopware installation completed               |
+| `deployment_helper.upgrade`        | A Shopware upgrade completed                          |
+| `deployment_helper.theme_compiled` | Theme compilation completed after an upgrade          |
 
 ### How is data transmitted?
 
@@ -78,15 +78,15 @@ Data is sent via UDP to `udp.usage.shopware.io:9000`. The anonymized user identi
 
 ### Tracked events
 
-| Event | Description |
-|-------|-------------|
-| `web_installer.visit` | First visit to the installer |
-| `web_installer.install.started` | Installation process initiated |
-| `web_installer.install.completed` | Installation succeeded |
-| `web_installer.install.failed` | Installation failed |
-| `web_installer.update.started` | Update process initiated |
-| `web_installer.update.completed` | Update succeeded |
-| `web_installer.update.failed` | Update failed |
+| Event                             | Description                    |
+|-----------------------------------|--------------------------------|
+| `web_installer.visit`             | First visit to the installer   |
+| `web_installer.install.started`   | Installation process initiated |
+| `web_installer.install.completed` | Installation succeeded         |
+| `web_installer.install.failed`    | Installation failed            |
+| `web_installer.update.started`    | Update process initiated       |
+| `web_installer.update.completed`  | Update succeeded               |
+| `web_installer.update.failed`     | Update failed                  |
 
 ### How is data transmitted?
 
@@ -122,15 +122,15 @@ Or for a single command:
 DO_NOT_TRACK=1 shopware-cli project create
 ```
 
-This follows the [Console Do Not Track convention](https://consoledonottrack.com/) standard used by many CLI tools.
+This follows the `Console Do Not Track convention standard` used by many CLI tools.
 
 ## Data flow summary
 
-| Aspect | Detail |
-|--------|--------|
-| **Protocol** | UDP (fire-and-forget) |
-| **Endpoint** | `udp.usage.shopware.io:9000` |
-| **Encryption** | UDP is unencrypted by nature |
-| **Delay** | None — telemetry runs in the background |
-| **Failure handling** | Silently fails if transmission is not possible |
+| Aspect                  | Detail                                                     |
+|-------------------------|------------------------------------------------------------|
+| **Protocol**            | UDP (fire-and-forget)                                      |
+| **Endpoint**            | `udp.usage.shopware.io:9000`                               |
+| **Encryption**          | UDP is unencrypted by nature                               |
+| **Delay**               | None — telemetry runs in the background                    |
+| **Failure handling**    | Silently fails if transmission is not possible             |
 | **User identification** | Anonymized random identifiers, not linked to personal data |


### PR DESCRIPTION
## Summary

Remove link and reformats tables

<img width="1518" height="903" alt="image" src="https://github.com/user-attachments/assets/76777d2b-9214-41bd-b708-53568656bee6" />


## Related links

<!-- Link related issues, pull requests, commits, or source references. -->

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
