### PR TITLE
change order of sections to have the most general first

### DIFF
--- a/guides/plugins/apps/app-scripts/custom-endpoints.md
+++ b/guides/plugins/apps/app-scripts/custom-endpoints.md
@@ -9,42 +9,6 @@ nav:
 
 If you want to execute some logic in Shopware and trigger the execution over an HTTP request or need some special data from Shopware over the API, you can create custom API endpoints in your app that allow you to execute a script when a request to that endpoint is made.
 
-## Manipulate HTTP-headers to API responses
-
-::: info
-Note that the `response` hook was added in v6.6.10.4 and is not available in earlier versions.
-:::
-
-There is a specific `response` script hook, that allows you to manipulate the HTTP-headers of the response via app scripts.
-This is especially useful to adjust the security headers to your needs.
-
-To add a custom header to every response, you can do the following:
-
-```twig
-// Resources/scripts/response/response.twig
-{% do hook.setHeader('X-Frame-Options', 'SAMEORIGIN') %}
-```
-
-Additionally, you can check the current value of a given header and adjust it accordingly:
-
-```twig
-// Resources/scripts/response/response.twig
-{% if hook.getHeader('X-Frame-Options') == 'DENY' %}
-    {% do hook.setHeader('X-Frame-Options', 'SAMEORIGIN') %}
-{% endif %}
-```
-
-You also have access to the route name of the current request and to the route scopes to control the headers for specific routes:
-
-```twig
-// Resources/scripts/response/response.twig
-{% if hook.routeName == 'frontend.detail.page' and hook.isInRouteScope('store-api') %}
-    {% do hook.setHeader('X-Frame-Options', 'SAMEORIGIN') %}
-{% endif %}
-```
-
-The possible route scopes are `storefront`, `store-api`, `api` and `administration`.
-
 ## Custom Endpoints
 
 There are specialized script-execution endpoints for the `api`, `store-api` and `storefront` scopes.
@@ -162,6 +126,42 @@ Additionally, it is also possible to redirect to an existing route:
 ```
 
 For a complete overview of the available data and services, refer to the [reference documentation](../../../../resources/references/app-reference/script-reference/script-hooks-reference#storefront-hook).
+
+## Manipulate HTTP-headers to API responses
+
+::: info
+Note that the `response` hook was added in v6.6.10.4 and is not available in earlier versions.
+:::
+
+There is a specific `response` script hook, that allows you to manipulate the HTTP-headers of the response via app scripts.
+This is especially useful to adjust the security headers to your needs.
+
+To add a custom header to every response, you can do the following:
+
+```twig
+// Resources/scripts/response/response.twig
+{% do hook.setHeader('X-Frame-Options', 'SAMEORIGIN') %}
+```
+
+Additionally, you can check the current value of a given header and adjust it accordingly:
+
+```twig
+// Resources/scripts/response/response.twig
+{% if hook.getHeader('X-Frame-Options') == 'DENY' %}
+    {% do hook.setHeader('X-Frame-Options', 'SAMEORIGIN') %}
+{% endif %}
+```
+
+You also have access to the route name of the current request and to the route scopes to control the headers for specific routes:
+
+```twig
+// Resources/scripts/response/response.twig
+{% if hook.routeName == 'frontend.detail.page' and hook.isInRouteScope('store-api') %}
+    {% do hook.setHeader('X-Frame-Options', 'SAMEORIGIN') %}
+{% endif %}
+```
+
+The possible route scopes are `storefront`, `store-api`, `api` and `administration`.
 
 ## Caching
 


### PR DESCRIPTION
## Summary

Currently, the order of the sections seems to be a little off, starting with a quite special topic like manipulating headers before even discussing how to set up custom endpoints in the first place. This change is for fixing that.

## Related links

<!-- Link related issues, pull requests, commits, or source references. -->

## Checklist

- [  ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [  ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [  ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [  ] Any required dependent changes in downstream modules have already been merged and published.
- [  ] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
