### PR TITLE
docs: add app requirements feature

### DIFF
--- a/guides/plugins/apps/lifecycle/app-registration-setup.md
+++ b/guides/plugins/apps/lifecycle/app-registration-setup.md
@@ -13,7 +13,7 @@ This page documents app setup (registration), permissions, validation, and chang
 
 ::: info
 Registration is necessary only when your app backend and Shopware need to communicate. It is performed during the installation of your app.
-This process is called setup. Apps can also declare [requirements](../../../resources/references/app-reference/manifest-reference.md#requirements) that are validated before registration begins.
+This process is called setup.
 :::
 
 ::: warning
@@ -297,9 +297,10 @@ The requirement feature is extensible. We encourage you to contribute new requir
 Validation is skipped in `dev` and `test` environments so that local development and CI are not blocked by infrastructure checks.
 :::
 
+
 ## Permissions
 
-Shopware allows creating fine-grained [Access Control Lists](../administration/../../plugins/administration/permissions-error-handling/add-acl-rules.md) \(ACLs\).
+Shopware comes with the possibility to create fine-grained [Access Control Lists](../administration/../../plugins/administration/permissions-error-handling/add-acl-rules.md) \(ACLs\).
 This means you need to request permissions if your app needs to read or write data via the API or receive webhooks.
 The permissions your app needs are defined in the manifest file and combine a privilege (`read`, `create`, `update`, or `delete`) with an entity.
 Since version 6.4.12.0, your app can also request additional non-CRUD privileges with the `<permission>` element.

--- a/guides/plugins/apps/lifecycle/app-registration-setup.md
+++ b/guides/plugins/apps/lifecycle/app-registration-setup.md
@@ -289,7 +289,7 @@ Add a `<requirements>` element to your `manifest.xml`. Each requirement is an em
 :::
 
 ::: info
-Requirements are available since Shopware 6.7.10.0. For the full list of available requirements, see the [manifest reference](../../../resources/references/app-reference/manifest-reference.md#requirements).
+Requirements are available since Shopware 6.7.10.0. For the full list of available requirements, see the [manifest reference](../../../../resources/references/app-reference/manifest-reference.md#requirements).
 The requirement feature is extensible. We encourage you to contribute new requirements to the Shopware core to allow all app developers to use them.
 :::
 

--- a/guides/plugins/apps/lifecycle/app-registration-setup.md
+++ b/guides/plugins/apps/lifecycle/app-registration-setup.md
@@ -297,7 +297,6 @@ The requirement feature is extensible. We encourage you to contribute new requir
 Validation is skipped in `dev` and `test` environments so that local development and CI are not blocked by infrastructure checks.
 :::
 
-
 ## Permissions
 
 Shopware comes with the possibility to create fine-grained [Access Control Lists](../administration/../../plugins/administration/permissions-error-handling/add-acl-rules.md) \(ACLs\).

--- a/guides/plugins/apps/lifecycle/app-registration-setup.md
+++ b/guides/plugins/apps/lifecycle/app-registration-setup.md
@@ -13,7 +13,7 @@ This page documents app setup (registration), permissions, validation, and chang
 
 ::: info
 Registration is necessary only when your app backend and Shopware need to communicate. It is performed during the installation of your app.
-This process is called setup.
+This process is called setup. Apps can also declare [requirements](../../../resources/references/app-reference/manifest-reference.md#requirements) that are validated before registration begins.
 :::
 
 ::: warning
@@ -264,6 +264,36 @@ As this process is also used for secret rotation, your app **must generate a new
 
 ::: warning
 To prevent failure of in-flight requests during the secret rotation, your app **should accept the old secret in parallel** with the new secret for a short period (e.g., 1 minute). After that grace period, the signatures based on the old secret **must be** considered invalid.
+:::
+
+## Requirements
+
+Apps can declare requirements in their manifest that must be met for the app to function properly. Shopware validates these during installation and updates in `prod` environments. If a requirement is not met, the installation is rejected with a descriptive error before the app attempts registration.
+
+Add a `<requirements>` element to your `manifest.xml`. Each requirement is an empty child element — its presence enables it:
+
+::: code-group
+
+```xml [manifest.xml]
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+ ...
+    </meta>
+    <requirements>
+        <public-access/>
+    </requirements>
+</manifest>
+```
+
+:::
+
+::: info
+Requirements are available since Shopware 6.7.10.0. For the full list of available requirements, see the [manifest reference](../../../resources/references/app-reference/manifest-reference.md#requirements).
+:::
+
+::: warning
+Validation is skipped in `dev` and `test` environments so that local development and CI are not blocked by infrastructure checks.
 :::
 
 ## Permissions

--- a/guides/plugins/apps/lifecycle/app-registration-setup.md
+++ b/guides/plugins/apps/lifecycle/app-registration-setup.md
@@ -268,7 +268,7 @@ To prevent failure of in-flight requests during the secret rotation, your app **
 
 ## Requirements
 
-Apps can declare requirements in their manifest that must be met for the app to function properly. Shopware validates these during installation and updates in `prod` environments. If a requirement is not met, the installation is rejected with a descriptive error before the app attempts registration.
+Apps can declare requirements in their manifest that must be met for the app to function properly. For example, an app that communicates with the shop via the Admin API will fail if the shop is not publicly accessible — declaring that upfront avoids a registration attempt that is guaranteed to fail. Shopware validates requirements during installation and updates in `prod` environments. If a requirement is not met, the installation is rejected with a descriptive error before the app attempts registration.
 
 Add a `<requirements>` element to your `manifest.xml`. Each requirement is an empty child element — its presence enables it:
 
@@ -290,6 +290,7 @@ Add a `<requirements>` element to your `manifest.xml`. Each requirement is an em
 
 ::: info
 Requirements are available since Shopware 6.7.10.0. For the full list of available requirements, see the [manifest reference](../../../resources/references/app-reference/manifest-reference.md#requirements).
+The requirement feature is extensible, we encourage you to contribute new requirements to the Shopware core to allow all app developers to use them.
 :::
 
 ::: warning

--- a/guides/plugins/apps/lifecycle/app-registration-setup.md
+++ b/guides/plugins/apps/lifecycle/app-registration-setup.md
@@ -290,7 +290,7 @@ Add a `<requirements>` element to your `manifest.xml`. Each requirement is an em
 
 ::: info
 Requirements are available since Shopware 6.7.10.0. For the full list of available requirements, see the [manifest reference](../../../resources/references/app-reference/manifest-reference.md#requirements).
-The requirement feature is extensible, we encourage you to contribute new requirements to the Shopware core to allow all app developers to use them.
+The requirement feature is extensible. We encourage you to contribute new requirements to the Shopware core to allow all app developers to use them.
 :::
 
 ::: warning
@@ -299,7 +299,7 @@ Validation is skipped in `dev` and `test` environments so that local development
 
 ## Permissions
 
-Shopware comes with the possibility to create fine-grained [Access Control Lists](../administration/../../plugins/administration/permissions-error-handling/add-acl-rules.md) \(ACLs\).
+Shopware allows creating fine-grained [Access Control Lists](../administration/../../plugins/administration/permissions-error-handling/add-acl-rules.md) \(ACLs\).
 This means you need to request permissions if your app needs to read or write data via the API or receive webhooks.
 The permissions your app needs are defined in the manifest file and combine a privilege (`read`, `create`, `update`, or `delete`) with an entity.
 Since version 6.4.12.0, your app can also request additional non-CRUD privileges with the `<permission>` element.

--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -33,7 +33,7 @@ _Optional_, declare requirements that must be met for your app to function prope
 
 #### `public-access` (since 6.7.10.0)
 
-Validates that the Shopware instance is publicly reachable, which is necessary for apps that rely on webhooks or server-to-server communication. The validator checks that:
+Validates that the Shopware instance is publicly reachable, which is necessary for apps that rely on webhooks or server-to-server communication. This is a best-effort check — a temporary network issue could cause it to fail, and a passing check does not guarantee the condition will hold indefinitely. The validator checks that:
 
 - `APP_URL` is configured and uses HTTPS
 - The host is not `localhost`, an IP address, or a reserved domain (`.local`, `.test`, `.example`, etc.)

--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -25,7 +25,7 @@ Can be omitted if no communication between Shopware and your app is needed. For 
 
 ## Requirements
 
-Declare requirements that must be met for your app to function properly (since `6.7.10.0`). This section can be omitted if your app does not need environment preconditions for setup or installation. For more details, see the [requirements section](../../../guides/plugins/apps/app-registration-setup.md#requirements).
+Declare requirements that must be met for your app to function properly (since `6.7.10.0`). This section can be omitted if your app does not need environment preconditions for setup or installation. For more details, see the [requirements section](../../../guides/plugins/apps/lifecycle/app-registration-setup.md#requirements).
 
 <<< @/docs/snippets/config/app/requirements.xml
 

--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -23,6 +23,23 @@ Can be omitted if no communication between Shopware and your app is needed. For 
 
 <<< @/docs/snippets/config/app/setup.xml
 
+## Requirements
+
+_Optional_, declare requirements that must be met for your app to function properly (since `6.7.10.0`). For more details, see the [requirements section](../../../guides/plugins/apps/app-registration-setup.md#requirements).
+
+<<< @/docs/snippets/config/app/requirements.xml
+
+### Available requirements
+
+#### `public-access` (since 6.7.10.0)
+
+Validates that the Shopware instance is publicly reachable, which is necessary for apps that rely on webhooks or server-to-server communication. The validator checks that:
+
+- `APP_URL` is configured and uses HTTPS
+- The host is not `localhost`, an IP address, or a reserved domain (`.local`, `.test`, `.example`, etc.)
+- The host resolves via DNS to a public IP address
+- The health check endpoint (`/api/_info/health-check`) returns HTTP 200
+
 ## Storefront
 
 Can be omitted if your app template needs higher load priority than other plugins/apps. For more details, follow the [storefront guide](../../../guides/plugins/apps/storefront/index.md).

--- a/resources/references/app-reference/manifest-reference.md
+++ b/resources/references/app-reference/manifest-reference.md
@@ -25,7 +25,7 @@ Can be omitted if no communication between Shopware and your app is needed. For 
 
 ## Requirements
 
-_Optional_, declare requirements that must be met for your app to function properly (since `6.7.10.0`). For more details, see the [requirements section](../../../guides/plugins/apps/app-registration-setup.md#requirements).
+Declare requirements that must be met for your app to function properly (since `6.7.10.0`). This section can be omitted if your app does not need environment preconditions for setup or installation. For more details, see the [requirements section](../../../guides/plugins/apps/app-registration-setup.md#requirements).
 
 <<< @/docs/snippets/config/app/requirements.xml
 

--- a/snippets/config/app/requirements.xml
+++ b/snippets/config/app/requirements.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        ...
+    </meta>
+    <requirements>
+        <public-access/>
+    </requirements>
+</manifest>


### PR DESCRIPTION
This pull request updates the app registration and manifest documentation to introduce and explain the new "requirements" feature for Shopware apps. It describes how apps can declare requirements in their `manifest.xml`, how Shopware validates these during installation and updates, and provides details on the available requirements, including the new `public-access` requirement.

**Clarifications and environment-specific behavior:**

- Noted that requirements validation is available since Shopware 6.7.10.0, and that validation is skipped in `dev` and `test` environments to avoid blocking development and CI.

These changes help app developers understand how to use requirements for more robust app installation and validation.