### PR TITLE
fix: use explicit package name for PaaS composer install

### DIFF
--- a/products/paas/shopware-paas/index.md
+++ b/products/paas/shopware-paas/index.md
@@ -44,7 +44,7 @@ cd /demo
 3.) Install the PaaS composer package
 
 ```sh
-composer req paas
+composer req shopware/paas-meta
 ```
 
 4.) Initialize your local Git repository

--- a/products/paas/shopware-paas/repository.md
+++ b/products/paas/shopware-paas/repository.md
@@ -21,7 +21,7 @@ This guide explains the repository setup using **GitHub**. You can also integrat
 
 Firstly, create a new project with `composer create-project shopware/production <folder-name>` using the [Symfony Flex](../../../guides/installation/template.md) template.
 
-This will create a brand new Shopware 6 project in the given folder. Now, change it into the newly created project and require the PaaS configuration with `composer req paas`.
+This will create a brand new Shopware 6 project in the given folder. Now, change it into the newly created project and require the PaaS configuration with `composer req shopware/paas-meta`.
 
 Secondly, create a new Git repository and push it to your favourite Git hosting service.
 

--- a/products/paas/shopware-paas/setup-template.md
+++ b/products/paas/shopware-paas/setup-template.md
@@ -7,7 +7,7 @@ nav:
 
 # Setup Template
 
-The setup template is installed automatically using Symfony Flex when requiring the `paas` package as described in the [Repository](repository). It contains build and deployment logic for Shopware PaaS as well as configuration for the underlying infrastructure and services. In this chapter, we will have a look at these customizations.
+The setup template is installed automatically using Symfony Flex when requiring the `shopware/paas-meta` package as described in the [Repository](repository). It contains build and deployment logic for Shopware PaaS as well as configuration for the underlying infrastructure and services. In this chapter, we will have a look at these customizations.
 
 Below is an overview of the files and directories added by the PaaS meta-package:
 


### PR DESCRIPTION
## Summary

- Replace `composer req paas` with `composer req shopware/paas-meta` in `products/paas/shopware-paas/repository.md` and `products/paas/shopware-paas/index.md`
- Since Composer 2.8+, ambiguous short package names that match multiple packages trigger an interactive prompt instead of resolving automatically — using the fully qualified name avoids this

## Test plan

- [ ] Verify both occurrences of `composer req paas` have been replaced with `composer req shopware/paas-meta`
- [ ] Confirm the command works non-interactively with `composer req shopware/paas-meta` on a fresh Shopware install

🤖 Generated with [Claude Code](https://claude.com/claude-code)