### PR TITLE
fix: port of imageproxy was wrong

### DIFF
--- a/guides/installation/advanced-options.md
+++ b/guides/installation/advanced-options.md
@@ -186,7 +186,7 @@ services:
     imageproxy:
         image: ghcr.io/shopwarelabs/devcontainer/image-proxy
         ports:
- - "8050:80"
+ - "8050:8000"
         environment:
           # Your production URL.
           REMOTE_SERVER_HOST: shopware.com


### PR DESCRIPTION
## Summary

the imageproxy starts at port 8000

## Related links


## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
