### PR TITLE
docs: replace deprecated bin/build-*/watch-* scripts with shopware-cli commands

### DIFF
--- a/guides/development/start-developing.md
+++ b/guides/development/start-developing.md
@@ -78,15 +78,15 @@ make watch-admin
 make watch-storefront
 ```
 
-### Alternative: run build and watch scripts directly
+### Alternative: use Shopware CLI
 
-If you prefer not to use `make`, your project also provides bash scripts in the `bin/` directory to build and watch the Administration and Storefront. Run the following commands:
+If you prefer not to use `make`, you can use the [Shopware CLI](https://developer.shopware.com/docs/products/cli/) to build and watch the Administration and Storefront. Run the following commands:
 
 ```bash
-./bin/build-administration.sh
-./bin/build-storefront.sh
-./bin/watch-administration.sh
-./bin/watch-storefront.sh
+shopware-cli project admin-build
+shopware-cli project storefront-build
+shopware-cli project admin-watch
+shopware-cli project storefront-watch
 ```
 
 The `watch` commands monitor changes to the Administration and Storefront and automatically rebuild them.

--- a/guides/development/tooling/using-watchers.md
+++ b/guides/development/tooling/using-watchers.md
@@ -23,7 +23,7 @@ composer run build:js:admin
 <Tab title="Build administration (Production template)">
 
 ```bash
-./bin/build-administration.sh
+shopware-cli project admin-build
 ```
 
 </Tab>
@@ -39,7 +39,7 @@ composer run build:js:storefront
 <Tab title="Build storefront (Production template)">
 
 ```bash
-./bin/build-storefront.sh
+shopware-cli project storefront-build
 ```
 
 </Tab>
@@ -87,7 +87,7 @@ To enable Hot Module Reloading, use the following shell scripts in the Shopware 
 <Tab title="Admin watcher">
 
 ```bash
-./bin/watch-administration.sh
+shopware-cli project admin-watch
 ```
 
 </Tab>
@@ -95,7 +95,7 @@ To enable Hot Module Reloading, use the following shell scripts in the Shopware 
 <Tab title="Storefront watcher">
 
 ```bash
-./bin/watch-storefront.sh
+shopware-cli project storefront-watch
 ```
 
 </Tab>

--- a/guides/hosting/installation-updates/deployments/build-w-o-db.md
+++ b/guides/hosting/installation-updates/deployments/build-w-o-db.md
@@ -1375,7 +1375,7 @@ index.json
 
 ### Partially compiling the Storefront
 
-You can also build just the JavaScript bundle using `CI=1 SHOPWARE_SKIP_THEME_COMPILE=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true bin/build-storefront.sh` (without the need for the above loader) in your CI. After that, run `bin/console theme:dump` on your production system when the database is available. This will happen automatically if theme variables are changed via the admin panel.
+You can also build just the JavaScript bundle using `CI=1 SHOPWARE_SKIP_THEME_COMPILE=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true shopware-cli project storefront-build` (without the need for the above loader) in your CI. After that, run `bin/console theme:dump` on your production system when the database is available. This will happen automatically if theme variables are changed via the admin panel.
 
 ## Cache directory and hash implications
 

--- a/guides/plugins/plugins/administration/module-component-management/add-custom-field.md
+++ b/guides/plugins/plugins/administration/module-component-management/add-custom-field.md
@@ -73,7 +73,7 @@ As mentioned above, Shopware 6 is looking for a `main.js` file in your plugin. I
 <Tab title="Template">
 
 ```bash
-./bin/build-administration.sh
+shopware-cli project admin-build
 ```
 
 </Tab>

--- a/guides/plugins/plugins/administration/module-component-management/add-custom-module.md
+++ b/guides/plugins/plugins/administration/module-component-management/add-custom-module.md
@@ -183,7 +183,7 @@ Given this plugin would be named "AdministrationNewModule", the bundled and mini
 <Tab title="Template">
 
 ```bash
-./bin/build-administration.sh
+shopware-cli project admin-build
 ```
 
 </Tab>

--- a/guides/plugins/plugins/administration/routing-navigation/add-new-tab.md
+++ b/guides/plugins/plugins/administration/routing-navigation/add-new-tab.md
@@ -144,7 +144,7 @@ Don't forget to rebuild the Administration after applying changes to your `main.
 <Tab title="Template">
 
 ```bash
-./bin/build-administration.sh
+shopware-cli project admin-build
 ```
 
 </Tab>

--- a/guides/plugins/plugins/dependencies/using-npm-dependencies.md
+++ b/guides/plugins/plugins/dependencies/using-npm-dependencies.md
@@ -123,7 +123,7 @@ PluginManager.register(
 Build the Storefront using:
 
 ```bash
-./bin/build-storefront.sh
+shopware-cli project storefront-build
 ```
 
 ## Next steps

--- a/guides/plugins/plugins/storefront/howto/using-a-modal-window.md
+++ b/guides/plugins/plugins/storefront/howto/using-a-modal-window.md
@@ -152,7 +152,7 @@ To see your changes you have to build the storefront. Use the following command 
 <Tab title="Template">
 
 ```bash
-./bin/build-storefront.sh
+shopware-cli project storefront-build
 ```
 
 </Tab>

--- a/guides/plugins/plugins/storefront/javascript/add-custom-javascript.md
+++ b/guides/plugins/plugins/storefront/javascript/add-custom-javascript.md
@@ -251,7 +251,7 @@ To see your changes you have to build the Storefront. Use the following command 
 <Tab title="Template">
 
 ```bash
-./bin/build-storefront.sh
+shopware-cli project storefront-build
 ```
 
 </Tab>

--- a/guides/plugins/plugins/storefront/javascript/override-existing-javascript.md
+++ b/guides/plugins/plugins/storefront/javascript/override-existing-javascript.md
@@ -131,7 +131,7 @@ To see your changes you have to build the Storefront. Use the following command 
 <Tab title="Template">
 
 ```bash
-./bin/build-storefront.sh
+shopware-cli project storefront-build
 ```
 
 </Tab>

--- a/guides/plugins/plugins/storefront/styling/add-custom-styling.md
+++ b/guides/plugins/plugins/storefront/styling/add-custom-styling.md
@@ -69,7 +69,7 @@ Now you want to test if your custom styles actually apply to the Storefront. For
 <Tab title="Template">
 
 ```bash
-./bin/build-storefront.sh
+shopware-cli project storefront-build
 ```
 
 </Tab>
@@ -88,7 +88,7 @@ If you want to see all style changes made by you live, you can also use our Stor
 <Tab title="Template">
 
 ```bash
-./bin/watch-storefront.sh
+shopware-cli project storefront-watch
 ```
 
 </Tab>

--- a/guides/plugins/themes/styling/add-css-js-to-theme.md
+++ b/guides/plugins/themes/styling/add-css-js-to-theme.md
@@ -91,7 +91,7 @@ Add some test code in order to see if it works out:
 console.log('SwagBasicExampleTheme JS loaded');
 ```
 
-In the end, by running the command `bin/build-storefront.sh` your custom JS plugin is loaded. By default, the compiled JavaScript file is saved as `<plugin root>/src/resources/app/storefront/dist/storefront/js/swag-basic-example-theme/swag-basic-example-theme.js`. It is detected by Shopware automatically and included in the Storefront. So you do not need to embed the JavaScript file yourself.
+In the end, by running the command `shopware-cli project storefront-build` your custom JS plugin is loaded. By default, the compiled JavaScript file is saved as `<plugin root>/src/resources/app/storefront/dist/storefront/js/swag-basic-example-theme/swag-basic-example-theme.js`. It is detected by Shopware automatically and included in the Storefront. So you do not need to embed the JavaScript file yourself.
 
 ## Using the live reload
 
@@ -104,7 +104,7 @@ To activate the dev-server, run the following command in your terminal.
 <Tab title="Template">
 
 ```bash
-./bin/watch-storefront.sh
+shopware-cli project storefront-watch
 ```
 
 </Tab>

--- a/guides/plugins/themes/styling/override-bootstrap-variables-in-a-theme.md
+++ b/guides/plugins/themes/styling/override-bootstrap-variables-in-a-theme.md
@@ -84,7 +84,7 @@ Please only add variable overrides in this file. You should not write CSS code l
 :::
 
 ::: info
-When running `composer run watch:storefront` in platform only setups or `./bin/watch-storefront.sh` in the production template, SCSS variables will be injected dynamically by webpack. When writing selectors and properties in the `overrides.scss` the code can appear multiple times in your built CSS.
+When running `composer run watch:storefront` in platform only setups or `shopware-cli project storefront-watch` in the production template, SCSS variables will be injected dynamically by webpack. When writing selectors and properties in the `overrides.scss` the code can appear multiple times in your built CSS.
 :::
 
 ## Next steps

--- a/products/tools/cli/project-commands/helper-commands.md
+++ b/products/tools/cli/project-commands/helper-commands.md
@@ -17,7 +17,7 @@ To create a new project, you can use the following command:
 shopware-cli project create <folder-name>
 ```
 
-It will ask you for the Shopware version. You can pass the version as second parameter:
+It will ask you for the Shopware version. You can pass the version as the second parameter:
 
 ```bash
 shopware-cli project create <folder-name> <version>
@@ -36,15 +36,15 @@ Shopware CLI contains replacements for `bin/build-administration.sh` and `bin/bu
 | bin/watch-storefront.sh     | `shopware-cli project storefront-watch` |
 | bin/watch-administration.sh | `shopware-cli project admin-watch`      |
 
-Additionally to the replacement, Shopware CLI allows only watching a specific set of extensions or exclude few.
+Additionally to the replacement, Shopware CLI allows only watching a specific set of extensions or excluding a few.
 
-To only watch specific:
+To only watch specific extensions:
 
 ```bash
 shopware-cli project admin-watch --only-extensions <name>,<second>....
 ```
 
-To exclude specific:
+To exclude specific extensions:
 
 ```bash
 shopware-cli project admin-watch --skip-extensions <name>,<second>....
@@ -53,7 +53,7 @@ shopware-cli project admin-watch --skip-extensions <name>,<second>....
 ### Building only custom extensions
 
 When working with a lot of 3rd party extensions, `project storefront-build` and `project admin-build` would become slow, when all extensions are built.
-This is unnecessary, because store extensions are shipped together with their assets.
+This is unnecessary because store extensions are shipped together with their assets.
 
 Use
 


### PR DESCRIPTION
## Summary

see also https://github.com/shopware/recipes/commit/690adcf974fa46704348bc777baf48dd5140c1c8

The `./bin/build-administration.sh`, `./bin/build-storefront.sh`, `./bin/watch-administration.sh`, and `./bin/watch-storefront.sh` scripts have been deprecated in favor of the Shopware CLI equivalents:

| Old Script | Replacement |
|---|---|
| `./bin/build-administration.sh` | `shopware-cli project admin-build` |
| `./bin/build-storefront.sh` | `shopware-cli project storefront-build` |
| `./bin/watch-administration.sh` | `shopware-cli project admin-watch` |
| `./bin/watch-storefront.sh` | `shopware-cli project storefront-watch` |

## Changes

Updated all documentation references across **13 files** to point to `shopware-cli` commands instead of the deprecated `./bin/*.sh` scripts.