### PR TITLE
docs: add agentic files guide

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -47,6 +47,7 @@ Adminer
 AdministrationNewField
 AdministrationNewModule
 Afile
+Agentic
 AfterLineItemAddedEvent
 AfterLineItemQuantityChangedEvent
 AfterLineItemRemovedEvent
@@ -1049,6 +1050,7 @@ TypeError
 TypeError's
 TypeScript
 TypeScript's
+UCP
 UDP
 UI
 UID
@@ -1164,6 +1166,7 @@ activateShopwareTheme
 adr
 afterSort
 ag
+agentic
 ai
 ajax
 allowlist
@@ -1445,6 +1448,7 @@ extendability
 extensibility
 externalReference
 failover
+fallback
 fallbacks
 fastly
 favicon
@@ -1635,6 +1639,7 @@ logfiles
 logics
 loginRequired
 loginViaApi
+llms
 longtext
 lookups
 lowerCamelCase
@@ -1906,6 +1911,7 @@ selectbox
 sellable
 sendmail
 seo
+seoUrl
 seperate
 seperated
 serializable
@@ -1986,6 +1992,7 @@ substring
 supervisord
 svg
 sw
+sw_extends
 swSelect
 swoole
 symfony

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -5,6 +5,7 @@ ACLs
 ADDR
 ADR
 ADRs
+ARD
 AES
 AI
 AOF

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -5,7 +5,6 @@ ACLs
 ADDR
 ADR
 ADRs
-ARD
 AES
 AI
 AOF
@@ -13,6 +12,7 @@ API's
 APIRequestContext
 APIs
 APM
+ARD
 AUR
 AbstractCaptcha
 AbstractDocumentRenderer

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -47,10 +47,10 @@ Adminer
 AdministrationNewField
 AdministrationNewModule
 Afile
-Agentic
 AfterLineItemAddedEvent
 AfterLineItemQuantityChangedEvent
 AfterLineItemRemovedEvent
+Agentic
 AggregationResultCollection
 AjaxModalPlugin
 Aktions
@@ -1630,6 +1630,7 @@ lineItemId
 linter
 linters
 linux
+llms
 localVue
 localhost
 localhost's
@@ -1639,7 +1640,6 @@ logfiles
 logics
 loginRequired
 loginViaApi
-llms
 longtext
 lookups
 lowerCamelCase
@@ -1992,8 +1992,8 @@ substring
 supervisord
 svg
 sw
-sw_extends
 swSelect
+sw_extends
 swoole
 symfony
 symfony's

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -121,7 +121,7 @@ requiring merchants to replace the whole template.
 
 ## Template variables
 
-Agentic file templates receive these variables:
+The following table lists the variables that agentic file templates receive.
 
 | Variable | Description |
 | --- | --- |

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -12,8 +12,13 @@ how they should interact with a shop.
 
 Shopware ships the `agentic` file family with these default files:
 
-* `/llms.txt`: A concise entry point to public sales-channel resources.
-* `/agents.md`: Guidance for AI agents interacting with the shop.
+* [`/llms.txt`](https://llmstxt.org/): A concise entry point to public
+  sales-channel resources.
+* [`/agents.md`](https://agents.md/): Guidance for AI agents interacting with
+  the shop.
+* [`/.well-known/ai-catalog.json`](https://agenticresourcediscovery.org/spec/):
+  An Agentic Resource Discovery catalog for machine-readable resources, such as
+  available MCP servers.
 
 The files are generated from Twig templates and can be enabled per sales
 channel in the Administration. Merchants can also add custom notes or override
@@ -21,8 +26,9 @@ individual content sources from the sales-channel detail page.
 
 ::: info
 The core agentic files feature is available since Shopware 6.7.12.0. Older
-Shopware versions can serve compatible `/llms.txt` and `/agents.md` files
-through the Agentic Commerce plugin fallback. See
+Shopware versions can serve compatible `/llms.txt`, `/agents.md`, and
+`/.well-known/ai-catalog.json` files through the Agentic Commerce plugin
+fallback. See
 [Agentic Commerce plugin compatibility](#agentic-commerce-plugin-compatibility)
 for details.
 :::
@@ -37,7 +43,7 @@ The following table shows example mappings from template paths to public paths.
 |-----------------------------------------------|-----------------------------|
 | `files/agentic/llms.txt.twig`                 | `/llms.txt`                 |
 | `files/agentic/agents.md.twig`                | `/agents.md`                |
-| `files/agentic/.well-known/example.json.twig` | `/.well-known/example.json` |
+| `files/agentic/.well-known/ai-catalog.json.twig` | `/.well-known/ai-catalog.json` |
 
 Files are served only for sales channels where the file is enabled. Disabled
 files and unknown files behave like regular 404 responses.
@@ -83,12 +89,30 @@ several extensions contribute content to the same file.
 {% endblock %}
 ```
 
+```twig [PLUGIN_ROOT/src/Resources/views/files/agentic/.well-known/ai-catalog.json.twig]
+{% sw_extends 'files/agentic/.well-known/ai-catalog.json.twig' %}
+
+{% block agentic_ai_catalog_entries %}
+    {% set entries = entries|merge([{
+        identifier: 'urn:ai:example.com:resource:my-integration',
+        displayName: 'My integration',
+        type: 'application/json',
+        url: '/.well-known/my-integration',
+        description: 'Machine-readable capabilities for this sales channel.',
+        tags: ['integration'],
+    }]) %}
+
+    {{ parent() }}
+{% endblock %}
+```
+
 :::
 
 Prefer the dedicated extension blocks for additive content:
 
 * `agentic_llms_extensions`
 * `agentic_agents_extensions`
+* `agentic_ai_catalog_entries`
 
 ## Add custom files
 
@@ -128,8 +152,44 @@ The following table lists the variables that agentic file templates receive.
 | `context`          | The current sales-channel context                                                                                                    |
 | `salesChannel`     | The sales channel, including languages and currencies needed by the default templates                                                |
 | `salesChannelFile` | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources |
+| `salesChannelFileContext` | Additional array context for file-specific data, such as base URL and publisher for `/.well-known/ai-catalog.json` |
 
 Use normal Twig functions such as `path()` and `seoUrl()` to build links.
+
+To add file-specific template context, subscribe to
+`SalesChannelFileRenderParametersExtension::onPost()`:
+
+```php
+use Shopware\Core\System\SalesChannel\File\Discovery\SalesChannelFile;
+use Shopware\Core\System\SalesChannel\File\Rendering\Extension\SalesChannelFileRenderParametersExtension;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class MyAgenticFileSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SalesChannelFileRenderParametersExtension::onPost() => 'addContext',
+        ];
+    }
+
+    public function addContext(SalesChannelFileRenderParametersExtension $extension): void
+    {
+        if ($extension->file->fileFamily !== SalesChannelFile::DEFAULT_FILE_FAMILY
+            || $extension->file->fileName !== '.well-known/ai-catalog.json'
+            || !\is_array($extension->result)
+        ) {
+            return;
+        }
+
+        $context = $extension->result['salesChannelFileContext'] ?? [];
+        $context = \is_array($context) ? $context : [];
+        $context['myIntegrationUrl'] = '/.well-known/my-integration';
+
+        $extension->result['salesChannelFileContext'] = $context;
+    }
+}
+```
 
 ## Add Administration descriptions
 
@@ -164,15 +224,18 @@ When the core feature is available:
 * Core handles discovery, Administration enablement, rendering, cache
   invalidation, and public serving.
 * The plugin only contributes UCP sections through the templates
-  `files/agentic/llms.txt.twig` and `files/agentic/agents.md.twig`.
+  `files/agentic/llms.txt.twig`, `files/agentic/agents.md.twig`, and
+  `files/agentic/.well-known/ai-catalog.json.twig`.
 * When UCP is activated for a sales channel, the plugin automatically enables
-  `/llms.txt` and `/agents.md` for that sales channel.
+  `/llms.txt`, `/agents.md`, and `/.well-known/ai-catalog.json` for that sales
+  channel.
 * After a shop is upgraded to a Shopware version with the core feature, the
   plugin enables the files for sales channels that already have UCP configured.
 
 When the core feature is not available:
 
-* The plugin provides fallback routes for `GET /llms.txt` and `GET /agents.md`.
+* The plugin provides fallback routes for `GET /llms.txt`, `GET /agents.md`,
+  and `GET /.well-known/ai-catalog.json`.
 * Fallback files are served only for sales channels where UCP is active.
 * The fallback mode does not backport the core Administration file-management UI,
   merchant template overrides, discovery API, or cache tagging.

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -125,9 +125,9 @@ The following table lists the variables that agentic file templates receive.
 
 | Variable | Description |
 | --- | --- |
-| `context` | The current sales-channel context. |
-| `salesChannel` | The sales channel, including languages and currencies needed by the default templates. |
-| `salesChannelFile` | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources. |
+| `context` | The current sales-channel context |
+| `salesChannel` | The sales channel, including languages and currencies needed by the default templates |
+| `salesChannelFile` | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources |
 
 Use normal Twig functions such as `path()` and `seoUrl()` to build links.
 

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -19,6 +19,14 @@ The files are generated from Twig templates and can be enabled per sales
 channel in the Administration. Merchants can also add custom notes or override
 individual content sources from the sales-channel detail page.
 
+::: info
+The core agentic files feature is available since Shopware 6.7.12.0. Older
+Shopware versions can serve compatible `/llms.txt` and `/agents.md` files
+through the Agentic Commerce plugin fallback. See
+[Agentic Commerce plugin compatibility](#agentic-commerce-plugin-compatibility)
+for details.
+:::
+
 ## Public paths
 
 Templates are registered below `Resources/views/files/<file-family>/`.

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -30,8 +30,8 @@ for details.
 ## Public paths
 
 Templates are registered below `Resources/views/files/<file-family>/`.
-Shopware derives the public path by removing the `files/<file-family>/` prefix
-and the `.twig` suffix.
+Shopware derives the public path by removing the `files/<file-family>/` prefix and the `.twig` suffix.
+The following table shows example mappings from template paths to public paths.
 
 | Template path | Public path |
 | --- | --- |

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -156,7 +156,7 @@ If no snippet exists, the description stays empty.
 
 ## Agentic Commerce plugin compatibility
 
-The Agentic Commerce plugin is compatible with shops that already provide the
+The [Agentic Commerce plugin](https://store.shopware.com/de/swag705756117823f/agentic-commerce-beta.html) is compatible with shops that already provide the
 core agentic files feature and with older Shopware versions that do not.
 
 When the core feature is available:

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -39,10 +39,10 @@ Templates are registered below `Resources/views/files/<file-family>/`.
 Shopware derives the public path by removing the `files/<file-family>/` prefix and the `.twig` suffix.
 The following table shows example mappings from template paths to public paths.
 
-| Template path                                 | Public path                 |
-|-----------------------------------------------|-----------------------------|
-| `files/agentic/llms.txt.twig`                 | `/llms.txt`                 |
-| `files/agentic/agents.md.twig`                | `/agents.md`                |
+| Template path                                    | Public path                    |
+|--------------------------------------------------|--------------------------------|
+| `files/agentic/llms.txt.twig`                    | `/llms.txt`                    |
+| `files/agentic/agents.md.twig`                   | `/agents.md`                   |
 | `files/agentic/.well-known/ai-catalog.json.twig` | `/.well-known/ai-catalog.json` |
 
 Files are served only for sales channels where the file is enabled. Disabled
@@ -147,12 +147,12 @@ requiring merchants to replace the whole template.
 
 The following table lists the variables that agentic file templates receive.
 
-| Variable           | Description                                                                                                                          |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `context`          | The current sales-channel context                                                                                                    |
-| `salesChannel`     | The sales channel, including languages and currencies needed by the default templates                                                |
-| `salesChannelFile` | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources |
-| `salesChannelFileContext` | Additional array context for file-specific data, such as base URL and publisher for `/.well-known/ai-catalog.json` |
+| Variable                  | Description                                                                                                                          |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `context`                 | The current sales-channel context                                                                                                    |
+| `salesChannel`            | The sales channel, including languages and currencies needed by the default templates                                                |
+| `salesChannelFile`        | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources |
+| `salesChannelFileContext` | Additional array context for file-specific data, such as base URL and publisher for `/.well-known/ai-catalog.json`                   |
 
 Use normal Twig functions such as `path()` and `seoUrl()` to build links.
 

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -18,7 +18,7 @@ Shopware ships the `agentic` file family with these default files:
   the shop.
 * [`/.well-known/ai-catalog.json`](https://agenticresourcediscovery.org/spec/):
   An Agentic Resource Discovery catalog for machine-readable resources, such as
-  available MCP servers.
+  the Store API MCP server for headless/API sales channels when MCP is enabled.
 
 The files are generated from Twig templates and can be enabled per sales
 channel in the Administration. Merchants can also add custom notes or override
@@ -94,12 +94,16 @@ several extensions contribute content to the same file.
 
 {% block agentic_ai_catalog_entries %}
     {% set entries = entries|merge([{
-        identifier: 'urn:ai:example.com:resource:my-integration',
-        displayName: 'My integration',
-        type: 'application/json',
-        url: '/.well-known/my-integration',
-        description: 'Machine-readable capabilities for this sales channel.',
-        tags: ['integration'],
+        identifier: 'urn:air:example.com:server:my-integration',
+        displayName: 'My integration MCP server',
+        type: 'application/mcp-server-card+json',
+        url: salesChannelFileContext.myIntegrationMcpServerUrl,
+        description: 'MCP server for my integration.',
+        tags: ['integration', 'mcp'],
+        capabilities: ['my-integration-capability'],
+        representativeQueries: [
+            'inspect available integration capabilities',
+        ],
     }]) %}
 
     {{ parent() }}
@@ -124,6 +128,13 @@ For example, a plugin can add `/my-integration.md` with this template path:
 ```text
 PLUGIN_ROOT/src/Resources/views/files/agentic/my-integration.md.twig
 ```
+
+::: warning
+Every Twig file below `Resources/views/files/<file-family>/` is discovered as a
+public sales-channel file. Put private partials or include templates outside
+`Resources/views/files/**` and include them with an explicit Twig namespace,
+for example `@MyPlugin/agentic/includes/content.md.twig`.
+:::
 
 Use the `agentic` file family when your file belongs to the public AI and agent
 guidance surface. Use another file family only when the feature owns a separate
@@ -152,7 +163,7 @@ The following table lists the variables that agentic file templates receive.
 | `context`                 | The current sales-channel context                                                                                                    |
 | `salesChannel`            | The sales channel, including languages and currencies needed by the default templates                                                |
 | `salesChannelFile`        | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources |
-| `salesChannelFileContext` | Additional array context for file-specific data, such as base URL and publisher for `/.well-known/ai-catalog.json`                   |
+| `salesChannelFileContext` | Optional array context for file-specific data. For `/.well-known/ai-catalog.json`, core adds `baseUrl` and `publisher` when a sales-channel domain is available. When `MCP_SERVER` is active for headless/API sales channels, core also adds `storeApiMcpServerUrl`. |
 
 Use normal Twig functions such as `path()` and `seoUrl()` to build links.
 
@@ -184,12 +195,15 @@ final class MyAgenticFileSubscriber implements EventSubscriberInterface
 
         $context = $extension->result['salesChannelFileContext'] ?? [];
         $context = \is_array($context) ? $context : [];
-        $context['myIntegrationUrl'] = '/.well-known/my-integration';
+        $context['myIntegrationMcpServerUrl'] = '/.well-known/my-integration';
 
         $extension->result['salesChannelFileContext'] = $context;
     }
 }
 ```
+
+The extension result is the full Twig parameter array. Preserve existing keys
+and add only the data needed for the concrete file you handle.
 
 ## Add Administration descriptions
 

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -1,0 +1,177 @@
+---
+nav:
+  title: Agentic Files
+  position: 15
+
+---
+
+# Agentic Files
+
+Agentic files are public sales-channel files that help AI assistants understand
+how they should interact with a shop.
+
+Shopware ships the `agentic` file family with these default files:
+
+* `/llms.txt`: A concise entry point to public sales-channel resources.
+* `/agents.md`: Guidance for AI agents interacting with the shop.
+
+The files are generated from Twig templates and can be enabled per sales
+channel in the Administration. Merchants can also add custom notes or override
+individual content sources from the sales-channel detail page.
+
+## Public paths
+
+Templates are registered below `Resources/views/files/<file-family>/`.
+Shopware derives the public path by removing the `files/<file-family>/` prefix
+and the `.twig` suffix.
+
+| Template path | Public path |
+| --- | --- |
+| `files/agentic/llms.txt.twig` | `/llms.txt` |
+| `files/agentic/agents.md.twig` | `/agents.md` |
+| `files/agentic/.well-known/example.json.twig` | `/.well-known/example.json` |
+
+Files are served only for sales channels where the file is enabled. Disabled
+files and unknown files behave like regular 404 responses.
+
+## Extend default files
+
+Plugins, apps, and themes can contribute to existing agentic files by shipping
+templates at the same path. Use `sw_extends` with the unqualified template path
+so the normal Shopware Twig inheritance chain can resolve the next template in
+both core and compatibility modes.
+
+When you use one of the dedicated extension blocks, always render
+<code v-pre>{{ parent() }}</code>. This keeps multi inheritance intact when
+several extensions contribute content to the same file.
+
+::: code-group
+
+```twig [PLUGIN_ROOT/src/Resources/views/files/agentic/llms.txt.twig]
+{% sw_extends 'files/agentic/llms.txt.twig' %}
+
+{% block agentic_llms_extensions %}
+    {{ parent() }}
+
+    ## My integration
+
+    - [Integration profile](/.well-known/my-integration): Machine-readable
+      capabilities for this sales channel.
+{% endblock %}
+```
+
+```twig [PLUGIN_ROOT/src/Resources/views/files/agentic/agents.md.twig]
+{% sw_extends 'files/agentic/agents.md.twig' %}
+
+{% block agentic_agents_extensions %}
+    {{ parent() }}
+
+    ## My integration
+
+    - Only use this integration when it is explicitly available for this sales
+      channel.
+    - Follow the user's explicit intent before performing state-changing
+      actions.
+{% endblock %}
+```
+
+:::
+
+Prefer the dedicated extension blocks for additive content:
+
+* `agentic_llms_extensions`
+* `agentic_agents_extensions`
+
+## Add custom files
+
+Extensions can also add new files by shipping new templates below
+`Resources/views/files/<file-family>/`.
+
+For example, a plugin can add `/my-integration.md` with this template path:
+
+```text
+PLUGIN_ROOT/src/Resources/views/files/agentic/my-integration.md.twig
+```
+
+Use the `agentic` file family when your file belongs to the public AI and agent
+guidance surface. Use another file family only when the feature owns a separate
+file group and matching Administration support.
+
+Custom files should expose a `user_provided_content` block near the end of the
+template. This allows the Administration to offer merchant custom notes without
+requiring merchants to replace the whole template.
+
+```twig
+{% block my_integration_md %}
+    # My integration
+
+    This file explains how AI agents can use the custom public resource.
+
+    {% block user_provided_content %}{% endblock %}
+{% endblock %}
+```
+
+## Template variables
+
+Agentic file templates receive these variables:
+
+| Variable | Description |
+| --- | --- |
+| `context` | The current sales-channel context. |
+| `salesChannel` | The sales channel, including languages and currencies needed by the default templates. |
+| `salesChannelFile` | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources. |
+
+Use normal Twig functions such as `path()` and `seoUrl()` to build links.
+
+## Add Administration descriptions
+
+The Administration can show a description for discovered files. Add snippets
+with the predefined key pattern:
+
+```json [PLUGIN_ROOT/src/Resources/app/administration/src/module/my-module/snippet/en-GB.json]
+{
+  "sw-sales-channel": {
+    "detail": {
+      "agenticFiles": {
+        "descriptions": {
+          "agentic": {
+            "my-file.txt": "Explains how AI agents should use the custom public resource."
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+If no snippet exists, the description stays empty.
+
+## Agentic Commerce plugin compatibility
+
+The Agentic Commerce plugin is compatible with shops that already provide the
+core agentic files feature and with older Shopware versions that do not.
+
+When the core feature is available:
+
+* Core handles discovery, Administration enablement, rendering, cache
+  invalidation, and public serving.
+* The plugin only contributes UCP sections through the templates
+  `files/agentic/llms.txt.twig` and `files/agentic/agents.md.twig`.
+* When UCP is activated for a sales channel, the plugin automatically enables
+  `/llms.txt` and `/agents.md` for that sales channel.
+* After a shop is upgraded to a Shopware version with the core feature, the
+  plugin enables the files for sales channels that already have UCP configured.
+
+When the core feature is not available:
+
+* The plugin provides fallback routes for `GET /llms.txt` and `GET /agents.md`.
+* Fallback files are served only for sales channels where UCP is active.
+* The fallback mode does not backport the core Administration file-management UI,
+  merchant template overrides, discovery API, or cache tagging.
+* Third-party templates should still use unqualified `sw_extends`, for example
+  `{% sw_extends 'files/agentic/llms.txt.twig' %}`. The same template then works
+  when the shop later switches from plugin fallback mode to the core feature.
+
+After an upgrade, clear the cache and rebuild the storefront or Administration
+assets as usual. The plugin then switches from fallback serving to
+template-extension-only mode.

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -33,10 +33,10 @@ Templates are registered below `Resources/views/files/<file-family>/`.
 Shopware derives the public path by removing the `files/<file-family>/` prefix and the `.twig` suffix.
 The following table shows example mappings from template paths to public paths.
 
-| Template path | Public path |
-| --- | --- |
-| `files/agentic/llms.txt.twig` | `/llms.txt` |
-| `files/agentic/agents.md.twig` | `/agents.md` |
+| Template path                                 | Public path                 |
+|-----------------------------------------------|-----------------------------|
+| `files/agentic/llms.txt.twig`                 | `/llms.txt`                 |
+| `files/agentic/agents.md.twig`                | `/agents.md`                |
 | `files/agentic/.well-known/example.json.twig` | `/.well-known/example.json` |
 
 Files are served only for sales channels where the file is enabled. Disabled
@@ -123,10 +123,10 @@ requiring merchants to replace the whole template.
 
 The following table lists the variables that agentic file templates receive.
 
-| Variable | Description |
-| --- | --- |
-| `context` | The current sales-channel context |
-| `salesChannel` | The sales channel, including languages and currencies needed by the default templates |
+| Variable           | Description                                                                                                                          |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `context`          | The current sales-channel context                                                                                                    |
+| `salesChannel`     | The sales channel, including languages and currencies needed by the default templates                                                |
 | `salesChannelFile` | Read-only metadata for the rendered file, such as file family, file name, template path, content type, and resolved template sources |
 
 Use normal Twig functions such as `path()` and `seoUrl()` to build links.
@@ -180,6 +180,6 @@ When the core feature is not available:
   `{% sw_extends 'files/agentic/llms.txt.twig' %}`. The same template then works
   when the shop later switches from plugin fallback mode to the core feature.
 
-After an upgrade, clear the cache and rebuild the storefront or Administration
+After an upgrade, clear the cache and rebuild the Storefront or Administration
 assets as usual. The plugin then switches from fallback serving to
 template-extension-only mode.

--- a/guides/plugins/plugins/storefront/templates/index.md
+++ b/guides/plugins/plugins/storefront/templates/index.md
@@ -9,6 +9,7 @@ nav:
 This section explains how to customize and extend Storefront templates in plugins.
 
 * [Customize Templates](./customize-templates.md)
+* [Agentic Files](./agentic-files.md)
 * [Customize Header/Footer](./customize-header-footer.md)
 * [Add Custom Twig Functions](./add-custom-twig-function.md)
 


### PR DESCRIPTION
## Summary

- Add a Storefront template guide for the new agentic files feature.
- Document default files, public path derivation, template extension patterns, custom file templates, and Administration description snippets.
- Explain Agentic Commerce plugin compatibility, including core-feature mode, fallback serving on older Shopware versions, and automatic enablement for UCP-enabled sales channels.

## Related links

- Related platform feature: shopware/shopware#17143

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

No redirects are required because this PR only adds a new page. Local validation: `git diff --check`.