### PR TITLE
docs(product): Add description teaser performance info

### DIFF
--- a/guides/development/integrations-api/partial-data-loading.md
+++ b/guides/development/integrations-api/partial-data-loading.md
@@ -9,6 +9,8 @@ nav:
 
 `Partial data loading` allows you to select specific fields of an entity to be returned by the API. This can be useful if you only need a few fields of an entity and don't want to load the whole entity. This can reduce response size and improve your application's performance.
 
+Shopware itself uses this mechanism for storefront product listings when the `core.listing.partialDataLoading` setting is enabled. See [Reduced product data in listings](../../hosting/performance/performance-tweaks.md#reduced-product-data-in-listings).
+
 ## Partial data loading vs Includes
 
 `Partial data loading` is different from the [includes](./search-criteria.md#includes-apialias) feature. The `includes` works as post-output processing, so the complete entity or data is loaded on the backend and then filtered, while `partial data loading` works already at the database level. This means the database only loads the requested fields, not the entire entity.

--- a/guides/hosting/performance/performance-tweaks.md
+++ b/guides/hosting/performance/performance-tweaks.md
@@ -110,15 +110,15 @@ Read more on [Elasticsearch setup](../infrastructure/elasticsearch/elasticsearch
 ## Reduced product data in listings
 
 Product listings can load a reduced, curated field set instead of full product entities.
-This includes the `descriptionTeaser`, a shortened, HTML-free excerpt that replaces the full description in listings.
-It lowers database load, memory usage and transfer size — especially for catalogs with large product descriptions.
+This includes the `descriptionTeaser`, a shortened (max. 512 characters), HTML-free excerpt that replaces the full description in listings.
+It lowers database load, memory usage, and transfer size — especially for catalogs with large product descriptions.
 
 Enable the setting per sales channel under `Settings > Products > Load reduced product data in listings` (`core.listing.partialDataLoading`).
 With the setting enabled, listing products are partial entities — only enable it if your theme and extensions do not require additional product data in listings.
 The underlying mechanism is described in [Partial data loading](../../development/integrations-api/partial-data-loading.md).
 
 ::: info
-Supported since Shopware `6.7.12.0`. Fresh installations start with this setting enabled; existing shops keep the full listing loading until they opt in.
+Supported since Shopware `6.7.12.0`. New installations have this setting enabled by default; existing shops continue loading full product data in listings until they opt in.
 :::
 
 ## Prevent mail data updates

--- a/guides/hosting/performance/performance-tweaks.md
+++ b/guides/hosting/performance/performance-tweaks.md
@@ -113,7 +113,7 @@ Product listings can load a reduced, curated field set instead of full product e
 This includes the `descriptionTeaser`, a shortened, HTML-free excerpt that replaces the full description in listings.
 It lowers database load, memory usage and transfer size — especially for catalogs with large product descriptions.
 
-Enable the setting per sales channel under *Settings > Products > "Load reduced product data in listings"* (`core.listing.partialDataLoading`).
+Enable the setting per sales channel under `Settings > Products > Load reduced product data in listings` (`core.listing.partialDataLoading`).
 With the setting enabled, listing products are partial entities — only enable it if your theme and extensions do not require additional product data in listings.
 The underlying mechanism is described in [Partial data loading](../../development/integrations-api/partial-data-loading.md).
 

--- a/guides/hosting/performance/performance-tweaks.md
+++ b/guides/hosting/performance/performance-tweaks.md
@@ -107,6 +107,20 @@ Supported since Shopware `6.7.9.0`. This is an experimental feature. For impleme
 
 Read more on [Elasticsearch setup](../infrastructure/elasticsearch/elasticsearch-setup)
 
+## Reduced product data in listings
+
+Product listings can load a reduced, curated field set instead of full product entities.
+This includes the `descriptionTeaser`, a shortened, HTML-free excerpt that replaces the full description in listings.
+It lowers database load, memory usage and transfer size — especially for catalogs with large product descriptions.
+
+Enable the setting per sales channel under *Settings > Products > "Load reduced product data in listings"* (`core.listing.partialDataLoading`).
+With the setting enabled, listing products are partial entities — only enable it if your theme and extensions do not require additional product data in listings.
+The underlying mechanism is described in [Partial data loading](../../development/integrations-api/partial-data-loading.md).
+
+::: info
+Supported since Shopware `6.7.12.0`. Fresh installations start with this setting enabled; existing shops keep the full listing loading until they opt in.
+:::
+
 ## Prevent mail data updates
 
 To provide auto-completion for different mail templates in the Administration UI, Shopware has a mechanism that writes an example mail into the database when sending the mail.


### PR DESCRIPTION
fixes: shopware/shopware#6310

## Summary

Added info über descriptionTeaser, which reduces the load of the description to a maximum of 512 characters

## Related links

https://github.com/shopware/shopware/issues/6310

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
