### PR TITLE
docs: document cache-relevant config fields

### DIFF
--- a/guides/plugins/apps/lifecycle/configuration.md
+++ b/guides/plugins/apps/lifecycle/configuration.md
@@ -27,6 +27,8 @@ To offer configuration possibilities to your users you can provide a `config.xml
 The configuration page will be displayed in the Administration under `Extensions > My extensions`.
 For development purposes you can use the Administration component to configure plugins to provide configuration for your app, therefore use the URL `{APP_URL}/admin#/sw/extension/config/{appName}`.
 
+If an app configuration value changes cached Storefront output, mark the corresponding `<input-field>` or `<component>` with `cache-relevant="true"` in the `config.xml`. See [Cache relevant fields](../../plugins/plugin-fundamentals/add-plugin-configuration.md#cache-relevant-fields) for details.
+
 ## Reading the configuration values
 
 The configuration values are saved as part of the `SystemConfig` and you can use the key `{appName}.config.{fieldName}` to identify the values. There are two possibilities to access the configuration values from your app. If you need those values on your app-backend server, you can read them over the API. If you need the configuration values in your Storefront twig templates you can use the `systemConfig()`-twig function.

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -136,7 +136,7 @@ Use the `cache-relevant="true"` attribute when a configuration value changes cac
 
 When a shop operator changes a cache-relevant field in the Administration, Shopware invalidates the affected Storefront HTTP cache entries for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
 
-The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into HTTP cache invalidations, which increases cache misses and page generation work after saving.
+The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into HTTP cache invalidations, which increases cache misses and negatively impacts performance and scalability.
 
 You can set the attribute on `<input-field>` and advanced `<component>` fields:
 

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -130,6 +130,26 @@ Beside these settings, they have the following in common:
 [disabled](add-plugin-configuration.md#disabled),
 and [required](add-plugin-configuration.md#required).
 
+#### Cache relevant fields
+
+Use the `cache-relevant="true"` attribute when a configuration value changes cached Storefront output. This applies to fields that are read in Storefront templates, controllers, page loaders, or other code paths that influence an HTTP-cached response.
+
+When a shop operator changes a cache-relevant field in the Administration, Shopware invalidates the affected Storefront HTTP cache entries for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
+
+You can set the attribute on `<input-field>` and advanced `<component>` fields:
+
+```html
+<input-field type="bool" cache-relevant="true">
+    <name>showBadge</name>
+    <label>Show badge in the Storefront</label>
+</input-field>
+
+<component name="sw-media-field" cache-relevant="true">
+    <name>heroImage</name>
+    <label>Hero image</label>
+</component>
+```
+
 #### Label, placeholder and help text
 
 The settings `<label>`, `<placeholder>` and `<helpText>` are used to label and explain your `<input-field>` and are translatable.
@@ -398,6 +418,13 @@ Full multi-card `config.xml` example (collapse to focus on smaller snippets abov
             <defaultValue>smtp</defaultValue>
             <label>Mail method</label>
             <label lang="de-DE">Versand-Protokoll</label>
+        </input-field>
+
+        <input-field type="bool" cache-relevant="true">
+            <name>showBadge</name>
+            <defaultValue>true</defaultValue>
+            <label>Show badge in the Storefront</label>
+            <label lang="de-DE">Badge im Storefront anzeigen</label>
         </input-field>
     </card>
 

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -140,7 +140,7 @@ The `cache-relevant` attribute is available starting with Shopware 6.7.12.0. Sta
 
 When a shop operator changes a cache-relevant field in the Administration, Shopware treats the write as cache-relevant and triggers the broader system config cache invalidation path for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
 
-The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into broad cache invalidations, which increases cache misses and negatively impacts performance and scalability.
+The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache-relevant turns routine configuration saves into broad cache invalidations, which increases cache misses and negatively impacts performance and scalability.
 
 You can set the attribute on `<input-field>` and advanced `<component>` fields:
 

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -134,6 +134,10 @@ and [required](add-plugin-configuration.md#required).
 
 Use the `cache-relevant="true"` attribute when a configuration value changes cached Storefront output. This applies to fields that are read in Storefront templates, controllers, page loaders, or other code paths that influence an HTTP-cached response.
 
+::: info
+The `cache-relevant` attribute is available starting with Shopware 6.7.12.0. Starting with Shopware 6.8.0.0, system config writes no longer invalidate caches by default, so fields that affect cached Storefront output need to provide this attribute.
+:::
+
 When a shop operator changes a cache-relevant field in the Administration, Shopware treats the write as cache-relevant and triggers the broader system config cache invalidation path for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
 
 The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into broad cache invalidations, which increases cache misses and negatively impacts performance and scalability.

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -134,9 +134,9 @@ and [required](add-plugin-configuration.md#required).
 
 Use the `cache-relevant="true"` attribute when a configuration value changes cached Storefront output. This applies to fields that are read in Storefront templates, controllers, page loaders, or other code paths that influence an HTTP-cached response.
 
-When a shop operator changes a cache-relevant field in the Administration, Shopware invalidates the affected Storefront HTTP cache entries for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
+When a shop operator changes a cache-relevant field in the Administration, Shopware treats the write as cache-relevant and triggers the broader system config cache invalidation path for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
 
-The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into HTTP cache invalidations, which increases cache misses and negatively impacts performance and scalability.
+The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into broad cache invalidations, which increases cache misses and negatively impacts performance and scalability.
 
 You can set the attribute on `<input-field>` and advanced `<component>` fields:
 

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -136,6 +136,8 @@ Use the `cache-relevant="true"` attribute when a configuration value changes cac
 
 When a shop operator changes a cache-relevant field in the Administration, Shopware invalidates the affected Storefront HTTP cache entries for the current sales channel. Leave the attribute unset for internal settings, credentials, timestamps, or other values that do not change cached Storefront output.
 
+The default is off because most configuration values do not change cached Storefront output. Marking too many fields as cache relevant turns routine configuration saves into HTTP cache invalidations, which increases cache misses and page generation work after saving.
+
 You can set the attribute on `<input-field>` and advanced `<component>` fields:
 
 ```html

--- a/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-plugin-configuration.md
@@ -130,7 +130,7 @@ Beside these settings, they have the following in common:
 [disabled](add-plugin-configuration.md#disabled),
 and [required](add-plugin-configuration.md#required).
 
-#### Cache relevant fields
+#### Cache-relevant fields
 
 Use the `cache-relevant="true"` attribute when a configuration value changes cached Storefront output. This applies to fields that are read in Storefront templates, controllers, page loaders, or other code paths that influence an HTTP-cached response.
 


### PR DESCRIPTION
## Summary

- Documents the `cache-relevant="true"` attribute for plugin `config.xml` fields.
- Shows that the attribute can be used on `<input-field>` and `<component>` elements.
- Adds an app configuration cross-reference because apps use the same `config.xml` schema.

## Related links

- Core PR: https://github.com/shopware/shopware/pull/17413
- Issue: https://github.com/shopware/shopware/issues/17367

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

Validation run locally:

- `git diff --check`
- `make spellcheck`
- targeted `markdown-lint` for the two changed files

No redirects were needed because no pages were moved, renamed, or deleted. `.wordlist.txt` was not changed because spellcheck passed without new terms.
