### PR TITLE
fix: mock builder handles traits and enums

### DIFF
--- a/guides/development/testing/unit/php-unit.md
+++ b/guides/development/testing/unit/php-unit.md
@@ -102,7 +102,7 @@ class UsedClassesAvailableTest extends TestCase
 
             /** @var class-string $className */
             $className = $namespace . '\\' . $classRelativePath;
-            if (trait_exists($className) || enum_exists($className)) {
+            if (trait_exists($className, false) || enum_exists($className, false)) {
                 continue;
             }
 

--- a/guides/development/testing/unit/php-unit.md
+++ b/guides/development/testing/unit/php-unit.md
@@ -100,7 +100,13 @@ class UsedClassesAvailableTest extends TestCase
         foreach ($this->getPluginClasses() as $class) {
             $classRelativePath = str_replace(['.php', '/'], ['', '\\'], $class->getRelativePathname());
 
-            $this->getMockBuilder($namespace . '\\' . $classRelativePath)
+            /** @var class-string $className */
+            $className = $namespace . '\\' . $classRelativePath;
+            if (trait_exists($className) || enum_exists($className)) {
+                continue;
+            }
+
+            $this->getMockBuilder($className)
  ->disableOriginalConstructor()
  ->getMock();
  }


### PR DESCRIPTION
## Summary

Test will fail as soon as Enums or Traits are introduced. This PR skips the instancing of them.

## Related links



## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
