### PR TITLE
fix: remove wrong parameter

### DIFF
--- a/products/paas/shopware/fundamentals/account.md
+++ b/products/paas/shopware/fundamentals/account.md
@@ -119,7 +119,7 @@ Service account tokens do not inherit the full permissions of the user who creat
 Generate a new access token:
 
 ```sh
-sw-paas account token create --name "ci-token"
+sw-paas account token create
 ```
 
 ### Using a Token


### PR DESCRIPTION
In the latest release we have removed this parameter, this is a left over. Should be a quick win