### PR TITLE
docs: document multi-step deployment hooks

### DIFF
--- a/guides/hosting/installation-updates/deployments/deployment-helper.md
+++ b/guides/hosting/installation-updates/deployments/deployment-helper.md
@@ -162,7 +162,7 @@ deployment:
     post:
       - title: Warm up the cache
         script: |
-          bin/console cache:warmup
+          %php.bin% bin/console cache:warmup
       - title: Notify the team
         script: ./notify.sh
 ```

--- a/guides/hosting/installation-updates/deployments/deployment-helper.md
+++ b/guides/hosting/installation-updates/deployments/deployment-helper.md
@@ -149,6 +149,36 @@ deployment:
     enabled: false
 ```
 
+### Multi-step hooks
+
+Each hook can either be a single script (as shown above) or a list of steps that are executed individually.
+Splitting a hook into steps gives clearer output during deployment, as each step is run and reported separately.
+
+A step can be an object with a `title` and a `script`, where the `title` is shown in the deployment output:
+
+```yaml
+deployment:
+  hooks:
+    post:
+      - title: Warm up the cache
+        script: |
+          bin/console cache:warmup
+      - title: Notify the team
+        script: ./notify.sh
+```
+
+As a shorthand, a step can also be a plain script string (without a title):
+
+```yaml
+deployment:
+  hooks:
+    pre-update:
+      - echo "first step"
+      - echo "second step"
+```
+
+The single-script form remains fully supported, so existing configurations keep working unchanged.
+
 ## Local Configuration Overrides
 
 You can create a `.shopware-project.local.yml` file alongside your `.shopware-project.yml` to override configuration values for local development without modifying the base config. This file should be added to your `.gitignore`.


### PR DESCRIPTION
## What

Document the new multi-step form for Deployment Helper hooks in the Deployment Helper configuration guide.

## Why

Deployment hooks (`pre`, `post`, `pre-install`, `post-install`, `pre-update`, `post-update`) can now be defined as a list of steps that are executed individually, giving clearer per-step output during deployment. The docs only described the single-script form.

## Changes

Added a **Multi-step hooks** subsection covering:
- A list of `{ title, script }` steps, where the `title` is shown in the deployment output.
- The shorthand list-of-strings form for untitled steps.
- A note that the existing single-script form keeps working unchanged.

## Related

- Feature implementation: shopware/deployment-helper#89
- Config schema support: shopware/shopware-cli#1109
