### PR TITLE
fix: remove head ref

### DIFF
--- a/.github/workflows/redirect.yml
+++ b/.github/workflows/redirect.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Detect moved markdown files
         id: detect_moved_files


### PR DESCRIPTION
## Summary

This removes static head_ref so the workflow can run properly in PRs from forked repos.

## Related links

[<!-- Link related issues, pull requests, commits, or source references. -->](https://github.com/shopware/docs/actions/runs/27814679884/job/82312836387?pr=2339)

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [X] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
