### PR TITLE
docs(cli): document fix command ignores validation rules as known issue

### DIFF
--- a/products/tools/cli/validation.md
+++ b/products/tools/cli/validation.md
@@ -208,7 +208,7 @@ validation:
 ```
 
 ::: info
-Validation ignores are only applied to the `validate` command. The `fix` command does not respect these ignore rules and will still apply fixes for the matching identifiers. This is a known limitation.
+Validation ignores are only applied to the `validate` command. The `fix` command does not respect the `validation.ignore` rules and will still apply fixes even when an ignore would match (by identifier or message). This is a known limitation.
 :::
 
 ## Scanning a project

--- a/products/tools/cli/validation.md
+++ b/products/tools/cli/validation.md
@@ -207,6 +207,10 @@ validation:
     - message: 'Some error message'
 ```
 
+::: info
+Validation ignores are only applied to the `validate` command. The `fix` command does not respect these ignore rules and will still apply fixes for the matching identifiers. This is a known limitation.
+:::
+
 ## Scanning a project
 
 It's possible to scan an entire project instead of just a single extension. This is useful if you want to check all extensions in your project at once. You can do this by passing the path to the project root instead of the extension path.


### PR DESCRIPTION
## Summary

- Documents that the Shopware CLI `fix` command does not respect the `validation.ignore` rules defined in `.shopware-project.yml` / `.shopware-extension.yaml` — those ignores only apply to the `validate` command.
- Added as an info note in the "Validation ignores" section of the CLI validation docs.

## Related links

- Closes shopware/shopware-cli#751

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

This documents a known limitation rather than fixing the behavior, as the issue cannot be reliably fixed.