### PR TITLE
docs: document DynamicallyScheduledTaskHandler for custom rescheduling

### DIFF
--- a/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
@@ -116,7 +116,7 @@ Every five minutes, Shopware will dispatch the task to the message bus and the h
 Available since Shopware version 6.7.13.0
 :::
 
-By default, a scheduled task is rescheduled to run again after its `getDefaultInterval()` (i.e. `now + runInterval`). If you want to control *when* the task runs next based on your own domain data — for example, scheduling the next run to the timestamp of the next pending record instead of a fixed interval — let your handler implement the `Shopware\Core\Framework\MessageQueue\ScheduledTask\DynamicallyScheduledTaskHandler` interface.
+By default, a scheduled task is rescheduled to run again after its configured `runInterval` (initially taken from `getDefaultInterval()`), i.e. `nextExecutionTime + runInterval` (capped to `now` if it would lie in the past). If you want to control *when* the task runs next based on your own domain data — for example, scheduling the next run to the timestamp of the next pending record instead of a fixed interval — let your handler implement the `Shopware\Core\Framework\MessageQueue\ScheduledTask\DynamicallyScheduledTaskHandler` interface.
 
 Shopware asks the handler for the next execution time and persists it for you, so the handler only answers the "when", not the "how":
 

--- a/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
@@ -110,6 +110,47 @@ The task handler, `ExampleTaskHandler` as defined previously in your `services.p
 
 Every five minutes, Shopware will dispatch the task to the message bus and the handler's `run()` method will be executed.
 
+## Dynamic rescheduling
+
+::: info
+Available since Shopware version 6.7.13.0
+:::
+
+By default, a scheduled task is rescheduled to run again after its `getDefaultInterval()` (i.e. `now + runInterval`). If you want to control *when* the task runs next based on your own domain data — for example, scheduling the next run to the timestamp of the next pending record instead of a fixed interval — let your handler implement the `Shopware\Core\Framework\MessageQueue\ScheduledTask\DynamicallyScheduledTaskHandler` interface.
+
+Shopware asks the handler for the next execution time and persists it for you, so the handler only answers the "when", not the "how":
+
+```php
+// <plugin root>/src/Service/ScheduledTask/ExampleTaskHandler.php
+<?php declare(strict_types=1);
+
+namespace Swag\BasicExample\Service\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\DynamicallyScheduledTaskHandler;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler(handles: ExampleTask::class)]
+class ExampleTaskHandler extends ScheduledTaskHandler implements DynamicallyScheduledTaskHandler
+{
+    public function run(): void
+    {
+        // ...
+    }
+
+    public function getNextExecutionTime(ScheduledTask $task, ScheduledTaskEntity $taskEntity): ?\DateTimeInterface
+    {
+        // return the time the task should next run at,
+        // or null to fall back to the default `now + runInterval` schedule
+        return $this->resolveNextPendingTimestamp();
+    }
+}
+```
+
+`getNextExecutionTime()` is called after `run()` finishes. Returning `null` falls back to the default interval-based schedule. If the returned time lies in the past, Shopware runs the task again as soon as possible.
+
 ## Executing the scheduled task
 
 Usually scheduled tasks are registered when installing or updating your plugin. If you don't want to reinstall your plugin in order to register your scheduled task, you can also use the following command to achieve this:

--- a/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
+++ b/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task.md
@@ -14,10 +14,10 @@ Quite often one might want to run any type of code on a regular basis, e.g. to c
 This guide builds on the [Plugin Base Guide](../plugin-base-guide.md). Familiarity with `services.php` is helpful — see [Dependency Injection](../services/dependency-injection.md) and [Creating a service](../services/add-custom-service.md).
 
 ::: info
-Refer to this video on **[Adding scheduled tasks](https://www.youtube.com/watch?v=88S9P3x6wYE)**. Also available on our free online training ["Shopware 6 Backend Development"](https://academy.shopware.com/courses/shopware-6-backend-development-with-jisse-reitsma).
+Refer to this video on **[Adding scheduled tasks](https://www.youtube.com/watch?v=88S9P3x6wYE)**. Also, available on our free online training ["Shopware 6 Backend Development"](https://academy.shopware.com/courses/shopware-6-backend-development-with-jisse-reitsma).
 :::
 
-## Registering scheduled task in the DI container
+## Registering a scheduled task in the DI container
 
 A `ScheduledTask` and its respective `ScheduledTaskHandler` are registered in a plugin's `services.php`. For it to be found by Shopware 6 automatically, you need to place the `services.php` file in a `Resources/config/` directory, relative to the location of your plugin's base class. The path could look like this: `<plugin root>/src/Resources/config/services.php`.
 
@@ -80,7 +80,7 @@ class ExampleTask extends ScheduledTask
 
 Your `ExampleTask` class has to extend from the `Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask` class, which will force you to implement two methods:
 
-* `getTaskName`: The technical name of your task. Make sure to add a vendor prefix to your custom task, to prevent collisions with other plugins' scheduled tasks. In this example this is `swag`.
+* `getTaskName`: The technical name of your task. Make sure to add a vendor prefix to your custom task to prevent collisions with other plugins' scheduled tasks. In this example this is `swag`.
 * `getDefaultInterval`: The interval in seconds at which your scheduled task should be executed.
 
 The respective task handler:


### PR DESCRIPTION
## Summary

Documents the new `DynamicallyScheduledTaskHandler` interface in the "Add Scheduled Task" guide. A handler implementing it can compute its own next execution time (e.g. the timestamp of the next pending record) instead of the default `now + runInterval` schedule, while the executor still persists the schedule.

Adds a new "Dynamic rescheduling" section with an `Available since Shopware version 6.7.13.0` note and a full handler example.

## Related links

- Platform PR: shopware/shopware#17293

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

New terms are all wrapped in code fences/backticks, so no `.wordlist.txt` changes were needed — `make spellcheck` and the markdown style check both pass locally. The "available since" version (6.7.13.0) matches the upcoming release the platform PR targets; adjust if the platform PR lands in a different version.
