### PR TITLE
docs: declarative custom-fields.xml for plugins and apps

### DIFF
--- a/guides/plugins/apps/custom-data/custom-fields.md
+++ b/guides/plugins/apps/custom-data/custom-fields.md
@@ -17,6 +17,22 @@ To make use of the custom fields, register your custom field sets in your manife
 
 For a complete reference of the structure of the manifest file, take a look at the [Manifest reference](../../../../resources/references/app-reference/manifest-reference.md).
 
+::: warning
+Defining custom fields inline in `manifest.xml` via the `<custom-fields>` element is deprecated since Shopware 6.7.13.0 and will be removed in Shopware 6.8.0.0. Define your custom fields in a separate `Resources/config/custom-fields.xml` file instead (see below).
+:::
+
+## Defining custom fields in `Resources/config/custom-fields.xml`
+
+::: info
+Available starting with Shopware 6.7.13.0.
+:::
+
+Instead of the inline `<custom-fields>` section in `manifest.xml`, you can define your custom field sets in a dedicated `Resources/config/custom-fields.xml` file at the root of your app. The format inside `<custom-fields>` is identical to the inline manifest definition:
+
+<<< @/docs/snippets/config/custom-fields-standalone.xml
+
+When both a `Resources/config/custom-fields.xml` file and an inline `<custom-fields>` section in `manifest.xml` are present, the separate file takes priority. If only the inline definition exists, a deprecation warning is triggered. The same file format is also available for [plugins](../../plugins/framework/custom-field/add-custom-field.md#declarative-custom-fields-via-resources-config-custom-fields-xml).
+
 For the data needed, please refer to the custom fields in general: At first, you need a custom field set, as [custom fields](../../plugins/framework/custom-field/index.md) in Shopware are organised in sets. Here you need to consider some important fields:
 
 * `name`: A technical name for your set

--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -214,7 +214,7 @@ $this->swagExampleRepository->upsert([[
 Available starting with Shopware 6.7.13.0.
 :::
 
-Instead of registering custom field sets imperatively through plugin lifecycle hooks (see [Add a custom field to the Administration](#add-a-custom-field-to-the-administration) below), you can define them declaratively in a `Resources/config/custom-fields.xml` file at the root of your plugin. Shopware then handles creation, updates, and removal automatically during the plugin lifecycle (install, update, uninstall) — no `CustomFieldsInstaller` service or lifecycle hooks required.
+Instead of registering custom field sets imperatively through plugin lifecycle hooks (see [Add a custom field to the Administration](#add-a-custom-field-to-the-administration) below), you can define them declaratively in a `Resources/config/custom-fields.xml` file shipped with your plugin (under `src`). Shopware then handles creation, updates, and removal automatically during the plugin lifecycle (install, update, uninstall) — no `CustomFieldsInstaller` service or lifecycle hooks required.
 
 Place the file at `<plugin root>/src/Resources/config/custom-fields.xml`:
 
@@ -227,7 +227,7 @@ On every install or update, Shopware syncs the defined sets:
 * On uninstall (without keeping user data), the plugin's custom field sets are removed.
 
 ::: warning
-The names of the custom fields are global and should always contain a vendor prefix, like "swag" for "shopware ag", to keep them unique. This applies to the name of the custom field set as well as to each field name.
+The names of the custom fields are global and should always contain a vendor prefix, like "swag" for "Shopware AG", to keep them unique. This applies to the name of the custom field set as well as to each field name.
 :::
 
 The XML format is identical to the one [apps use in their manifest](../../../apps/custom-data/custom-fields.md). For a full list of available field types and their configuration options, refer to the [custom field section of the Manifest reference](../../../../../resources/references/app-reference/manifest-reference.md).

--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -208,6 +208,32 @@ $this->swagExampleRepository->upsert([[
 ]], $context);
 ```
 
+### Declarative custom fields via `Resources/config/custom-fields.xml`
+
+::: info
+Available starting with Shopware 6.7.13.0.
+:::
+
+Instead of registering custom field sets imperatively through plugin lifecycle hooks (see [Add a custom field to the Administration](#add-a-custom-field-to-the-administration) below), you can define them declaratively in a `Resources/config/custom-fields.xml` file at the root of your plugin. Shopware then handles creation, updates, and removal automatically during the plugin lifecycle (install, update, uninstall) — no `CustomFieldsInstaller` service or lifecycle hooks required.
+
+Place the file at `<plugin root>/src/Resources/config/custom-fields.xml`:
+
+<<< @/docs/snippets/config/custom-fields-standalone.xml
+
+On every install or update, Shopware syncs the defined sets:
+
+* Sets and fields present in the XML are created or updated.
+* Sets and fields that were previously defined by your plugin but are no longer in the XML are removed.
+* On uninstall (without keeping user data), the plugin's custom field sets are removed.
+
+::: warning
+The names of the custom fields are global and should always contain a vendor prefix, like "swag" for "shopware ag", to keep them unique. This applies to the name of the custom field set as well as to each field name.
+:::
+
+The XML format is identical to the one [apps use in their manifest](../../../apps/custom-data/custom-fields.md). For a full list of available field types and their configuration options, refer to the [custom field section of the Manifest reference](../../../../../resources/references/app-reference/manifest-reference.md).
+
+If you only need your custom fields to be available declaratively, you can stop here. The remaining sections describe the imperative alternative using the `custom_field_set.repository`, which you only need when creating sets dynamically at runtime.
+
 ### Add a custom field to the Administration
 
 You can skip this section if you don't want your new custom field to be editable in the Administration.
@@ -215,6 +241,10 @@ You can skip this section if you don't want your new custom field to be editable
 So now you've already filled the custom fields of one of your entity instances via code. But what if you want your user to do that, which is the more common case?
 
 Only if you want your custom field to show up in the Administration and to be editable in there, you have to define the custom fields first in a custom field set. For this you have to use the custom fieldset repository, which can be retrieved from the dependency injection container via the `custom_field_set.repository` key and is used like any other repository.
+
+::: info
+For most plugins, the [declarative `Resources/config/custom-fields.xml`](#declarative-custom-fields-via-resources-config-custom-fields-xml) approach is the simpler choice. Use the imperative approach below only when you need to create custom field sets dynamically at runtime.
+:::
 
 ```php
 // <plugin root>/src/Resources/config/services.php

--- a/guides/plugins/plugins/framework/custom-field/add-custom-field.md
+++ b/guides/plugins/plugins/framework/custom-field/add-custom-field.md
@@ -214,17 +214,17 @@ $this->swagExampleRepository->upsert([[
 Available starting with Shopware 6.7.13.0.
 :::
 
-Instead of registering custom field sets imperatively through plugin lifecycle hooks (see [Add a custom field to the Administration](#add-a-custom-field-to-the-administration) below), you can define them declaratively in a `Resources/config/custom-fields.xml` file shipped with your plugin (under `src`). Shopware then handles creation, updates, and removal automatically during the plugin lifecycle (install, update, uninstall) — no `CustomFieldsInstaller` service or lifecycle hooks required.
+Instead of registering custom field sets imperatively through plugin lifecycle hooks (see [Add a custom field to the Administration](#add-a-custom-field-to-the-administration) below), you can define them declaratively in a `Resources/config/custom-fields.xml` file shipped with your plugin (under `src`). Shopware then handles creation, updates, and removal automatically during the plugin lifecycle (`install`, `update`, `uninstall`) — no `CustomFieldsInstaller` service or lifecycle hooks required.
 
 Place the file at `<plugin root>/src/Resources/config/custom-fields.xml`:
 
 <<< @/docs/snippets/config/custom-fields-standalone.xml
 
-On every install or update, Shopware syncs the defined sets:
+On every `install` or `update`, Shopware syncs the defined sets:
 
 * Sets and fields present in the XML are created or updated.
 * Sets and fields that were previously defined by your plugin but are no longer in the XML are removed.
-* On uninstall (without keeping user data), the plugin's custom field sets are removed.
+* On `uninstall` (without keeping user data), the plugin's custom field sets are removed.
 
 ::: warning
 The names of the custom fields are global and should always contain a vendor prefix, like "swag" for "Shopware AG", to keep them unique. This applies to the name of the custom field set as well as to each field name.
@@ -304,7 +304,7 @@ $this->customFieldSetRepository->create([
 ], $context);
 ```
 
-This will now create a custom field set with the name `swag_example_set` and the field, `swag_example_size`. This time we also define its type, which should be of type integer here. The type is important to mention, because the Administration will use this information to display a proper field. Also, when trying to write the custom field `swag_example_size`, the value has to be an integer.
+This will now create a custom field set with the name `swag_example_set` and the field, `swag_example_size`. This time we also define its type, which should be of type integer here. The type is important to mention because the Administration will use this information to display a proper field. Also, when trying to write the custom field `swag_example_size`, the value has to be an integer.
 
 The translated labels are added to both the field and the set, which are going to be displayed in the Administration. Also, the fallback language can be defined in case the system language is not guaranteed to be either en_GB or de_DE.
 

--- a/snippets/config/custom-fields-standalone.xml
+++ b/snippets/config/custom-fields-standalone.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<custom-fields xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/System/CustomField/Schema/custom-fields-1.0.xsd">
+    <!-- register each custom field set you may want to add -->
+    <custom-field-set>
+        <!-- the technical name of the custom field set, needs to be unique, therefore use your vendor prefix -->
+        <name>swag_example_set</name>
+        <!-- Translatable, the label of the field set -->
+        <label>Example Set</label>
+        <label lang="de-DE">Beispiel-Set</label>
+        <!-- define the entities to which your field set should be assigned -->
+        <related-entities>
+            <product/>
+        </related-entities>
+        <!-- define the fields in your set -->
+        <fields>
+            <!-- the element type defines the type of the field -->
+            <!-- the name needs to be unique, therefore use your vendor prefix -->
+            <int name="swag_example_weight">
+                <!-- Translatable, the label of the field -->
+                <label>Weight</label>
+                <!-- Optional, Default = 1, order your fields by specifying the position -->
+                <position>1</position>
+            </int>
+            <text name="swag_example_code">
+                <label>Example field</label>
+                <position>2</position>
+                <!-- Optional, Default = false, mark a field as required -->
+                <required>false</required>
+                <!-- Optional, Translatable, the help text for the field -->
+                <help-text>Example field</help-text>
+            </text>
+        </fields>
+    </custom-field-set>
+</custom-fields>

--- a/snippets/config/custom-fields-standalone.xml
+++ b/snippets/config/custom-fields-standalone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <custom-fields xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/System/CustomField/Schema/custom-fields-1.0.xsd">
     <!-- register each custom field set you may want to add -->


### PR DESCRIPTION
## Summary

Documents the new declarative custom fields feature shipping in **Shopware 6.7.13.0**:

- New section in the plugin guide on defining custom field sets via `Resources/config/custom-fields.xml` (lifecycle-managed creation/update/removal — no `CustomFieldsInstaller` boilerplate).
- Updated the apps guide with the same standalone-file approach and a deprecation warning for the inline `<custom-fields>` manifest definition (deprecated in 6.7.13.0, removed in 6.8.0.0).
- New reusable `snippets/config/custom-fields-standalone.xml` snippet referenced by both guides.

## Related links

- Core PR: shopware/shopware#15729 (feat: support custom-fields.xml for plugins and apps)

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

- Schema URL, field-type examples, and file path were verified against the implementation in shopware/shopware#15729, not assumed.
- Docker spellcheck (`make spellcheck`) passes; markdown lint (`make fix`) reports no changes. No new wordlist entries were needed (new terms are either standard English or wrapped in code spans).
- The feature in the core PR is targeted at 6.7.13.0; this docs PR should be merged once that core PR lands.