### PR TITLE
docs(filesystem): restructure hosting filesystem guide and document S3 migration

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -175,6 +175,7 @@ CashRoundingConfigField
 CategoryRoute
 CentOS
 Centric
+Ceph
 Cerebro
 Chai
 ChangeCustomerSpecificFeaturesAction
@@ -338,6 +339,7 @@ Devops
 Devtool
 DifferentAddressesRule
 Differentiator
+DigitalOcean
 DirectoryLoader
 Direnv
 DiscountFacade
@@ -349,6 +351,8 @@ Dotenv
 DynamoDB
 ECDSA
 ECONNREFUSED
+ECS
+EKS
 ENUM
 ENUMS
 EOL
@@ -471,12 +475,14 @@ HMAC
 HMR
 Hacktober
 HeaderPagelet
+Hetzner
 Homebrew
 Hono
 HookClasses
 HookExecutor
 Hotjar
 HowTos
+IAM
 IANA
 IDEs
 IETF
@@ -620,6 +626,7 @@ Middleware
 MigrationCollection
 MigrationStep
 MimeType
+MinIO
 Minio
 Mixin
 Mixins
@@ -1843,6 +1850,7 @@ realtime
 rebase
 rebasing
 rebranded
+rebuildable
 recalculable
 redis
 refactorings
@@ -2055,6 +2063,7 @@ typeSingleSelectAndCheck
 typehint
 typehinted
 ui
+umask
 un
 uncomment
 uncommenting
@@ -2076,6 +2085,7 @@ untrusted
 untyped
 updateDestructive
 updateViaAdminApi
+uploadable
 upsert
 uri
 url

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -192,8 +192,6 @@ shopware:
 Omit the `credentials` block on AWS infrastructure (EC2, ECS, EKS) and grant access through an **IAM role** instead. This keeps long-lived secrets out of your configuration.
 :::
 
-For advanced control over timeouts, retries, and proxies, see [Custom HTTP client for S3](#custom-http-client-for-s3).
-
 ### Google Cloud Storage
 
 Install the adapter package first:

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -18,25 +18,25 @@ Shopware uses [Flysystem](https://flysystem.thephpleague.com/docs/) to talk to a
 
 ### Which storage should I use?
 
-| Scenario | Recommended storage |
-|----------|---------------------|
-| Local development / single server, small media library | `local` (the default — no setup needed) |
-| Single server, want backups & redundancy | S3 or an S3-compatible bucket |
-| Multiple app servers (cluster) | **Required:** S3 or S3-compatible shared bucket |
-| Already on local but serving heavy traffic | Keep `local`, put a [CDN](#serving-files-through-a-cdn) in front |
+| Scenario                                               | Recommended storage                                              |
+|--------------------------------------------------------|------------------------------------------------------------------|
+| Local development / single server, small media library | `local` (the default — no setup needed)                          |
+| Single server, want backups & redundancy               | S3 or an S3-compatible bucket                                    |
+| Multiple app servers (cluster)                         | **Required:** S3 or S3-compatible shared bucket                  |
+| Already on local but serving heavy traffic             | Keep `local`, put a [CDN](#serving-files-through-a-cdn) in front |
 
 ## How the filesystem is structured
 
 The filesystem is split into separate **adapters**, one per purpose. Each adapter can point at a different storage backend, but in practice you usually configure them all the same way. The following table lists the adapters and their default visibility and paths.
 
-| Filesystem | Visibility | What it holds | Default local path |
-|------------|------------|---------------|--------------------|
-| `public`   | public  | Product images, media files, generally accessible files | `public/` |
-| `private`  | private | Invoices, delivery notes, downloadable product files | `files/` |
-| `theme`    | public  | Compiled theme files (CSS, JS) | inherits `public` |
-| `asset`    | public  | Bundle/plugin assets | inherits `public` |
-| `sitemap`  | public  | Generated sitemap files | inherits `public` |
-| `temp`     | private | Temporary working files | `var/` |
+| Filesystem | Visibility | What it holds                                           | Default local path |
+|------------|------------|---------------------------------------------------------|--------------------|
+| `public`   | public     | Product images, media files, generally accessible files | `public/`          |
+| `private`  | private    | Invoices, delivery notes, downloadable product files    | `files/`           |
+| `theme`    | public     | Compiled theme files (CSS, JS)                          | inherits `public`  |
+| `asset`    | public     | Bundle/plugin assets                                    | inherits `public`  |
+| `sitemap`  | public     | Generated sitemap files                                 | inherits `public`  |
+| `temp`     | private    | Temporary working files                                 | `var/`             |
 
 ::: info
 `theme`, `asset`, and `sitemap` **inherit the `public` configuration** when you don't configure them explicitly. So configuring `public` for S3 automatically moves theme, asset, and sitemap files to S3 too. See [Fallback adapter configuration](#fallback-adapter-configuration) for the important caveat when you change `public` later.
@@ -55,12 +55,12 @@ The filesystem configuration lives in the bundle configuration:
 
 To use a non-default storage, add a `filesystem:` map under the `shopware:` key. Each adapter accepts the following keys:
 
-| Key | Description |
-|-----|-------------|
-| `type` | The adapter to use: `local`, `amazon-s3`, or `google-storage`. **Required** |
-| `url` | Public base URL under which the files are reachable. If omitted, Shopware derives it from `APP_URL`. Use this to point public files at a CDN domain |
-| `visibility` | `public` (default) or `private`. Only `private` is meaningful for the `private` filesystem |
-| `config` | Adapter-specific options (bucket, region, credentials, root, …). See [Supported adapters](#supported-adapters) |
+| Key          | Description                                                                                                                                         |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `type`       | The adapter to use: `local`, `amazon-s3`, or `google-storage`. **Required**                                                                         |
+| `url`        | Public base URL under which the files are reachable. If omitted, Shopware derives it from `APP_URL`. Use this to point public files at a CDN domain |
+| `visibility` | `public` (default) or `private`. Only `private` is meaningful for the `private` filesystem                                                          |
+| `config`     | Adapter-specific options (bucket, region, credentials, root, …). See [Supported adapters](#supported-adapters)                                      |
 
 ```yaml
 shopware:
@@ -144,11 +144,11 @@ shopware:
         root: "%kernel.project_dir%/public"
 ```
 
-| `config` key | Description |
-|--------------|-------------|
-| `root` | Directory the files are stored in. **Required.** |
-| `file` / `dir` | Optional permission overrides, e.g. `file: { public: 0644 }`. Defaults derive from the process umask. |
-| `enforce_file_permissions` | Apply the permissions above on write. Defaults to `true`. |
+| `config` key               | Description                                                                                           |
+|----------------------------|-------------------------------------------------------------------------------------------------------|
+| `root`                     | Directory the files are stored in. **Required.**                                                      |
+| `file` / `dir`             | Optional permission overrides, e.g. `file: { public: 0644 }`. Defaults derive from the process umask. |
+| `enforce_file_permissions` | Apply the permissions above on write. Defaults to `true`.                                             |
 
 ### Amazon S3 (and S3-compatible providers)
 
@@ -178,15 +178,15 @@ shopware:
           secret: "{your-secret-key}"
 ```
 
-| `config` key | Description |
-|--------------|-------------|
-| `bucket` | Bucket name. **Required.** |
-| `region` | Bucket region, e.g. `eu-central-1`. **Required.** |
-| `endpoint` | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers. |
-| `use_path_style_endpoint` | Set to `true` when the provider does **not** put the bucket in the subdomain (e.g. MinIO in its default setup). |
-| `root` | Prefix inside the bucket all paths are stored under. Optional. |
-| `credentials.key` / `credentials.secret` | Access key and secret. Optional — if omitted, AWS credential discovery (env vars, instance/IAM role) is used. |
-| `options` | Extra options passed through to the underlying AsyncAws S3 client. Optional. |
+| `config` key                             | Description                                                                                                     |
+|------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `bucket`                                 | Bucket name. **Required.**                                                                                      |
+| `region`                                 | Bucket region, e.g. `eu-central-1`. **Required.**                                                               |
+| `endpoint`                               | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers.                               |
+| `use_path_style_endpoint`                | Set to `true` when the provider does **not** put the bucket in the subdomain (e.g. MinIO in its default setup). |
+| `root`                                   | Prefix inside the bucket all paths are stored under. Optional.                                                  |
+| `credentials.key` / `credentials.secret` | Access key and secret. Optional — if omitted, AWS credential discovery (env vars, instance/IAM role) is used.   |
+| `options`                                | Extra options passed through to the underlying AsyncAws S3 client. Optional.                                    |
 
 ::: warning
 Omit the `credentials` block on AWS infrastructure (EC2, ECS, EKS) and grant access through an **IAM role** instead. This keeps long-lived secrets out of your configuration.
@@ -214,13 +214,13 @@ shopware:
         keyFilePath: "{path-to-your-service-account-key.json}"
 ```
 
-| `config` key | Description |
-|--------------|-------------|
-| `bucket` | Bucket name. **Required.** |
-| `projectId` | Google Cloud project ID. **Required.** |
-| `keyFilePath` | Path to a service account key JSON file. |
-| `keyFile` | The service account key as an inline array (alternative to `keyFilePath`). |
-| `root` | Prefix inside the bucket. Optional. |
+| `config` key  | Description                                                                |
+|---------------|----------------------------------------------------------------------------|
+| `bucket`      | Bucket name. **Required.**                                                 |
+| `projectId`   | Google Cloud project ID. **Required.**                                     |
+| `keyFilePath` | Path to a service account key JSON file.                                   |
+| `keyFile`     | The service account key as an inline array (alternative to `keyFilePath`). |
+| `root`        | Prefix inside the bucket. Optional.                                        |
 
 The bucket must use the [fine-grained ACL mode](https://cloud.google.com/storage/docs/access-control#choose_between_uniform_and_fine-grained_access) so that Shopware can manage object visibility.
 
@@ -244,10 +244,10 @@ Run the migration during low-traffic hours or in maintenance mode. Files uploade
 
 With the default `local` adapter the files live in the project directory:
 
-| Filesystem | Default location |
-|------------|------------------|
+| Filesystem | Default location                                                                       |
+|------------|----------------------------------------------------------------------------------------|
 | `public`   | `public/media`, `public/thumbnail`, `public/theme`, `public/bundles`, `public/sitemap` |
-| `private`  | `files/` |
+| `private`  | `files/`                                                                               |
 
 [`rclone`](https://rclone.org/) is recommended: it works with any S3-compatible provider, resumes interrupted transfers, and re-syncs only changed files. The AWS CLI works for native S3 as well.
 
@@ -360,12 +360,12 @@ Note the **prod** in the config path above — CDNs are typically used in produc
 
 Shopware can lay out media paths using different strategies. The strategy affects how predictable a file's URL is and how well it caches. It is set via the `SHOPWARE_CDN_STRATEGY_DEFAULT` environment variable (mapped to `cdn.strategy`).
 
-| Strategy | Behavior |
-|----------|----------|
-| `id` (default) | Path is derived from a hash of the media ID. URLs are not guessable from the filename. |
-| `filename` | Path is derived from a hash of the filename. |
-| `physical_filename` | Path includes a timestamp and the physical filename. |
-| `plain` | Simple, human-readable path without hashing. |
+| Strategy            | Behavior                                                                               |
+|---------------------|----------------------------------------------------------------------------------------|
+| `id` (default)      | Path is derived from a hash of the media ID. URLs are not guessable from the filename. |
+| `filename`          | Path is derived from a hash of the filename.                                           |
+| `physical_filename` | Path includes a timestamp and the physical filename.                                   |
+| `plain`             | Simple, human-readable path without hashing.                                           |
 
 ```dotenv
 # .env
@@ -407,11 +407,11 @@ shopware:
     private_local_path_prefix: ""          # used by the x-accel strategy
 ```
 
-| Strategy | Description |
-|----------|-------------|
-| `php` (default) | Streamed through PHP as `application/octet-stream`. Works everywhere, but PHP handles the whole transfer. |
-| `x-sendfile` | Apache offloads the file transfer. Requires the [`mod_xsendfile`](https://github.com/nmaier/mod_xsendfile) module. |
-| `x-accel` | Nginx offloads the transfer via internal redirect. Configure the matching `internal` location and set `private_local_path_prefix` accordingly. See the [Nginx X-Accel docs](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/). |
+| Strategy        | Description                                                                                                                                                                                                                                       |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `php` (default) | Streamed through PHP as `application/octet-stream`. Works everywhere, but PHP handles the whole transfer.                                                                                                                                         |
+| `x-sendfile`    | Apache offloads the file transfer. Requires the [`mod_xsendfile`](https://github.com/nmaier/mod_xsendfile) module.                                                                                                                                |
+| `x-accel`       | Nginx offloads the transfer via internal redirect. Configure the matching `internal` location and set `private_local_path_prefix` accordingly. See the [Nginx X-Accel docs](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/). |
 
 Offloading with `x-sendfile`/`x-accel` frees PHP-FPM workers during large downloads and is recommended for high-traffic shops that serve large private files.
 
@@ -419,7 +419,7 @@ Offloading with `x-sendfile`/`x-accel` frees PHP-FPM workers during large downlo
 
 ### Tuning the S3 batch write size
 
-When Shopware writes many files at once (for example during `asset:install` or theme compilation), the S3 adapter batches the uploads. The batch size defaults to `250` and can be tuned:
+When Shopware writes many files at once (for example, during `asset:install` or theme compilation), the S3 adapter batches the uploads. The batch size defaults to `250` and can be tuned:
 
 ```yaml
 shopware:

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -9,23 +9,42 @@ nav:
 
 ## Overview
 
-Shopware 6 stores and processes a wide variety of files. This goes from product images or videos to generated documents such as invoices or delivery notes. This data should be stored securely, and backups should be generated regularly. Therefore, it is advisable to set up storage service, which scales with the size of the data, performs backups, and ensures data redundancy. In addition, for cluster setups with multiple setups, it is **necessary** to share the files via external storage so that each app server can access the corresponding data.
+Shopware 6 stores a wide variety of files — product images and videos, generated documents such as invoices and delivery notes, theme assets, and sitemaps. By default, all of these are written to the local disk inside your project directory. That is fine for a single server, but it stops working as soon as you scale out:
 
-## Flysystem overview
+* In a **cluster** with multiple app servers, every server needs to read and write the same files. Local disk is per-server, so files uploaded on one node are invisible to the others. A **shared, external storage is required** (see [Cluster Setup](../installation-updates/cluster-setup)).
+* Even on a **single server**, external object storage (S3 and compatible providers) gives you automatic backups, redundancy, and storage that scales with your data without filling up the server disk.
 
-Shopware 6 can be used with several cloud storage providers. It uses [Flysystem](https://flysystem.thephpleague.com/docs/) to provide a common interface between different providers as well as the local file system. This enables your shops to read and write files through a common interface.
+Shopware uses [Flysystem](https://flysystem.thephpleague.com/docs/) to talk to all of these storage backends through one common interface, so your shop reads and writes files the same way regardless of where they physically live.
 
-The file system can be divided into multiple adapters. Each adapter can handle one or more of the following directories: media, sitemaps, and more. Of course, you can also use the same configuration for:
+### Which storage should I use?
 
-* private files: invoices, delivery notes, plugin files, etc.
-* public files: product pictures, media files, plugin files in general
-* theme files
-* sitemap files
-* bundle assets files
+| Scenario | Recommended storage |
+|----------|---------------------|
+| Local development / single server, small media library | `local` (the default — no setup needed) |
+| Single server, want backups & redundancy | S3 or an S3-compatible bucket |
+| Multiple app servers (cluster) | **Required:** S3 or S3-compatible shared bucket |
+| Already on local but serving heavy traffic | Keep `local`, put a [CDN](#serving-files-through-a-cdn) in front |
+
+## How the filesystem is structured
+
+The filesystem is split into separate **adapters**, one per purpose. Each adapter can point at a different storage backend, but in practice you usually configure them all the same way.
+
+| Filesystem | Visibility | What it holds | Default local path |
+|------------|------------|---------------|--------------------|
+| `public`   | public  | Product images, media files, generally accessible files | `public/` |
+| `private`  | private | Invoices, delivery notes, downloadable product files | `files/` |
+| `theme`    | public  | Compiled theme files (CSS, JS) | inherits `public` |
+| `asset`    | public  | Bundle/plugin assets | inherits `public` |
+| `sitemap`  | public  | Generated sitemap files | inherits `public` |
+| `temp`     | private | Temporary working files | `var/` |
+
+::: info
+`theme`, `asset`, and `sitemap` **inherit the `public` configuration** when you don't configure them explicitly. So configuring `public` for S3 automatically moves theme, asset, and sitemap files to S3 too. See [Fallback adapter configuration](#fallback-adapter-configuration) for the important caveat when you change `public` later.
+:::
 
 ## Configuration
 
-The configuration for file storage of Shopware 6 resides in the general bundle configuration:
+The filesystem configuration lives in the bundle configuration:
 
 ```text
 <project root>
@@ -34,42 +53,39 @@ The configuration for file storage of Shopware 6 resides in the general bundle c
       └── shopware.yml
 ```
 
-To set up a non-default filesystem for your shop, you need to add the `filesystem:` map to the `shopware.yml`. Under this key, you can separately define your storage for the public, private, theme, sitemap, and asset \(bundle assets\).
+To use a non-default storage, add a `filesystem:` map under the `shopware:` key. Each adapter accepts the following keys:
 
-::: info
-You can also change the URL of the file systems. This is useful if you want to use a different domain for your files. For example, you can use a CDN for your public files.
-:::
+| Key | Description |
+|-----|-------------|
+| `type` | The adapter to use: `local`, `amazon-s3`, or `google-storage`. **Required.** |
+| `url` | Public base URL under which the files are reachable. If omitted, Shopware derives it from `APP_URL`. Use this to point public files at a CDN domain. |
+| `visibility` | `public` (default) or `private`. Only `private` is meaningful for the `private` filesystem. |
+| `config` | Adapter-specific options (bucket, region, credentials, root, …). See [Supported adapters](#supported-adapters). |
 
 ```yaml
 shopware:
   filesystem:
     public:
+      type: "amazon-s3"
       url: "{url-to-your-public-files}"
-      # The Adapter Configuration
+      config:
+        # adapter-specific options
     private:
+      type: "amazon-s3"
       visibility: "private"
-      # The Adapter Configuration
-    theme:
-      url: "{url-to-your-theme-files}"
-      # The Adapter Configuration
-    asset:
-      url: "{url-to-your-asset-files}"
-      # The Adapter Configuration
-    sitemap:
-      url: "{url-to-your-sitemap-files}"
-      # The Adapter Configuration
-
+      config:
+        # adapter-specific options
 ```
 <!-- {"WATCHER_URL":"https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/Resources/config/packages/shopware.yaml","WATCHER_HASH":"183f85ba8f15e8e7d0006b70be20940f","WATCHER_CONTAINS":"filesystem"} -->
 
-### Using YAML anchors to avoid repetition
+### Avoiding repetition with YAML anchors
 
-You can use YAML anchors to avoid repeating the same configuration for multiple filesystems. This is particularly useful when you want to use the same storage backend for public, theme, and sitemap files:
+If multiple filesystems share the same backend, define the configuration once with a YAML anchor (`&name`) and reference it (`*name`) everywhere else. This is the recommended way to move all public-facing files to one bucket:
 
 ```yaml
 shopware:
   filesystem:
-    public: &s3_config
+    public: &s3
       type: "amazon-s3"
       url: "{{S3_URL}}"
       config:
@@ -80,38 +96,23 @@ shopware:
         credentials:
           key: "{{AWS_ACCESS_KEY_ID}}"
           secret: "{{AWS_SECRET_ACCESS_KEY}}"
-    theme: *s3_config
-    sitemap: *s3_config
+    theme: *s3
+    asset: *s3
+    sitemap: *s3
 ```
-
-In this example, the `&s3_config` creates an anchor that can be referenced with `*s3_config` in other filesystem configurations, avoiding duplication.
 
 ### Fallback adapter configuration
 
-By default, the configuration for the theme, asset, and sitemap filesystem will use the configuration from the `public` filesystem if they are not specifically configured.
-This means when you want to change the configuration used for the public filesystem, but the others should use the old configuration you have to set them explicitly.
+`theme`, `asset`, and `sitemap` use the `public` configuration when they are not set explicitly. This matters when you **change** the `public` adapter later: as soon as you do, theme/asset/sitemap follow it — unless you pin them back to the old configuration.
 
-E.g., before you had the following configuration:
-
-```yaml
-shopware:
-  filesystem:
-    public:
-      type: "local"
-      url: "https://your.domain/public"
-      config:
-        root: "%kernel.project_dir%/public"
-
-```
-
-Now you want to change the public filesystem to use an S3 adapter, but the theme, asset, and sitemap filesystem should still use the local adapter. You have to set them explicitly:
+For example, to move only `public` to S3 while keeping theme, asset, and sitemap on local storage, you must set them explicitly:
 
 ```yaml
 shopware:
   filesystem:
     public:
-      url: "{{S3_URL}}"
       type: "amazon-s3"
+      url: "{{S3_URL}}"
       config:
         bucket: "{{AWS_BUCKET}}"
         region: "{{AWS_REGION}}"
@@ -119,270 +120,348 @@ shopware:
         credentials:
           key: "{{AWS_ACCESS_KEY_ID}}"
           secret: "{{AWS_SECRET_ACCESS_KEY}}"
-    theme:
+    theme: &local
       type: "local"
       url: "https://your.domain/public"
       config:
         root: "%kernel.project_dir%/public"
-    asset:
-      type: "local"
-      url: "https://your.domain/public"
-      config:
-        root: "%kernel.project_dir%/public"
-    sitemap:
-      type: "local"
-      url: "https://your.domain/public"
-      config:
-        root: "%kernel.project_dir%/public"
+    asset: *local
+    sitemap: *local
 ```
 
-### Additional configuration
+## Supported adapters
 
-If you want to regulate the uploaded file types, then you could add the keys `allowed_extensions`for the public filesystem or `private_local_download_strategy` for the private filesystem.
-With the `private_local_download_strategy` key you could choose the download strategy for private files (e.g., the downloadable products):
+### Local
+
+The default. Files are stored on the server's disk relative to the project directory.
 
 ```yaml
 shopware:
   filesystem:
     public:
-      # The Adapter Configuration
-    private:
-      # The Adapter Configuration
-    allowed_extensions: # Array with allowed file extensions for public filesystem
-    private_allowed_extensions: # Array with allowed file extensions for private filesystem
-    private_local_download_strategy: # Name of the download strategy: php, x-sendfile or x-accel
+      type: "local"
+      config:
+        root: "%kernel.project_dir%/public"
 ```
 
-The following download strategies are valid:
+| `config` key | Description |
+|--------------|-------------|
+| `root` | Directory the files are stored in. **Required.** |
+| `file` / `dir` | Optional permission overrides, e.g. `file: { public: 0644 }`. Defaults derive from the process umask. |
+| `enforce_file_permissions` | Apply the permissions above on write. Defaults to `true`. |
 
-* `php` (default): A streamed response of content type `application/octet-stream` with binary data
-* `x-sendfile` (Apache only): X-Sendfile allows you to use PHP to instruct the server to send a file to a user, without having to load that file into PHP. You must have the [`mod_xsendfile`](https://github.com/nmaier/mod_xsendfile) Apache module installed.
-* `x-accel` (Nginx only): X-accel allows for internal redirection to a location determined by a header returned from a backend. See the [example configuration](https://docs.nginx.com/).
+### Amazon S3 (and S3-compatible providers)
 
-## CDN configuration
+Works with Amazon S3 and any S3-compatible storage such as MinIO, Cloudflare R2, DigitalOcean Spaces, Hetzner Object Storage, or Ceph.
 
-If your public files are available on a CDN, you can use the following config to serve images and other assets via that CDN.
+Install the adapter package first:
+
+```bash
+composer require league/flysystem-async-aws-s3
+```
+
+```yaml
+shopware:
+  filesystem:
+    public:
+      type: "amazon-s3"
+      url: "https://your-cdn-or-bucket-url"
+      config:
+        bucket: "{your-bucket-name}"
+        region: "{your-bucket-region}"
+        endpoint: "{your-s3-provider-endpoint}"   # optional for AWS, required for most others
+        use_path_style_endpoint: false             # set true for MinIO and similar
+        root: "{optional-prefix-inside-bucket}"
+        # Optional: omit to use the instance role / environment credentials
+        credentials:
+          key: "{your-access-key}"
+          secret: "{your-secret-key}"
+```
+
+| `config` key | Description |
+|--------------|-------------|
+| `bucket` | Bucket name. **Required.** |
+| `region` | Bucket region, e.g. `eu-central-1`. **Required.** |
+| `endpoint` | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers. |
+| `use_path_style_endpoint` | Set to `true` when the provider does **not** put the bucket in the subdomain (e.g. MinIO in its default setup). |
+| `root` | Prefix inside the bucket all paths are stored under. Optional. |
+| `credentials.key` / `credentials.secret` | Access key and secret. Optional — if omitted, AWS credential discovery (env vars, instance/IAM role) is used. |
+| `options` | Extra options passed through to the underlying AsyncAws S3 client. Optional. |
+
+::: warning
+Omit the `credentials` block on AWS infrastructure (EC2, ECS, EKS) and grant access through an **IAM role** instead. This keeps long-lived secrets out of your configuration.
+:::
+
+For advanced control over timeouts, retries, and proxies, see [Custom HTTP client for S3](#custom-http-client-for-s3).
+
+### Google Cloud Storage
+
+Install the adapter package first:
+
+```bash
+composer require league/flysystem-google-cloud-storage
+```
+
+```yaml
+shopware:
+  filesystem:
+    public:
+      type: "google-storage"
+      url: "https://storage.googleapis.com/{your-bucket-name}"
+      config:
+        bucket: "{your-bucket-name}"
+        projectId: "{your-project-id}"
+        keyFilePath: "{path-to-your-service-account-key.json}"
+```
+
+| `config` key | Description |
+|--------------|-------------|
+| `bucket` | Bucket name. **Required.** |
+| `projectId` | Google Cloud project ID. **Required.** |
+| `keyFilePath` | Path to a service account key JSON file. |
+| `keyFile` | The service account key as an inline array (alternative to `keyFilePath`). |
+| `root` | Prefix inside the bucket. Optional. |
+
+The bucket must use the [fine-grained ACL mode](https://cloud.google.com/storage/docs/access-control#choose_between_uniform_and_fine-grained_access) so that Shopware can manage object visibility.
+
+## Migrating an existing filesystem to a new adapter
+
+Changing the `filesystem` configuration only tells Shopware **where** to read and write files from now on. It does **not** move files that already exist. If you switch a shop with existing media from `local` to `amazon-s3` without copying the files first, that media will return 404 errors, because Shopware will look for it in the new (empty) bucket.
+
+A migration therefore has three steps, in this order:
+
+1. Copy the existing files to the new storage.
+2. Update the configuration to point to the new adapter.
+3. Re-generate the files Shopware can rebuild itself (bundle assets, theme).
+
+The example migrates from `local` to `amazon-s3`, but the procedure applies to any adapter.
+
+::: warning
+Run the migration during low-traffic hours or in maintenance mode. Files uploaded between the initial copy and the configuration switch would otherwise land on the old storage. See [Avoiding gaps during the copy](#avoiding-gaps-during-the-copy).
+:::
+
+### 1. Copy the existing files
+
+With the default `local` adapter the files live in the project directory:
+
+| Filesystem | Default location |
+|------------|------------------|
+| `public`   | `public/media`, `public/thumbnail`, `public/theme`, `public/bundles`, `public/sitemap` |
+| `private`  | `files/` |
+
+[`rclone`](https://rclone.org/) is recommended: it works with any S3-compatible provider, resumes interrupted transfers, and re-syncs only changed files. The AWS CLI works for native S3 as well.
+
+Using `rclone` (configure a remote named `s3` first via `rclone config`):
+
+```bash
+# Public files
+rclone copy public/media     s3:your-bucket/media
+rclone copy public/thumbnail s3:your-bucket/thumbnail
+rclone copy public/sitemap   s3:your-bucket/sitemap
+
+# Private files (only if you migrate the private filesystem too)
+rclone copy files            s3:your-bucket-private/files
+```
+
+Using the AWS CLI:
+
+```bash
+aws s3 sync public/media     s3://your-bucket/media
+aws s3 sync public/thumbnail s3://your-bucket/thumbnail
+aws s3 sync public/sitemap   s3://your-bucket/sitemap
+```
+
+::: info
+Keep the relative paths identical. Shopware stores only the **relative** path of a file in the database (for example `media/ab/cd/example.jpg`) and resolves it against the configured adapter at runtime. As long as the path inside the bucket matches the path on disk, no database changes are needed. If you set a `root` for the adapter, the bucket prefix must match that `root`.
+
+You can skip `public/theme` and `public/bundles` here — step 3 regenerates them.
+:::
+
+### 2. Update the configuration
+
+Switch the relevant filesystems to the new adapter. Remember the [fallback behavior](#fallback-adapter-configuration): `theme`, `asset`, and `sitemap` follow `public` unless set explicitly.
+
+```yaml
+# config/packages/shopware.yml
+shopware:
+  filesystem:
+    public: &s3
+      type: "amazon-s3"
+      url: "{{S3_URL}}"
+      config:
+        bucket: "{{AWS_BUCKET}}"
+        region: "{{AWS_REGION}}"
+        endpoint: "{{AWS_ENDPOINT}}"
+        use_path_style_endpoint: true
+        credentials:
+          key: "{{AWS_ACCESS_KEY_ID}}"
+          secret: "{{AWS_SECRET_ACCESS_KEY}}"
+    theme: *s3
+    asset: *s3
+    sitemap: *s3
+```
+
+Install the adapter package if you have not already:
+
+```bash
+composer require league/flysystem-async-aws-s3
+```
+
+### 3. Re-generate rebuildable files
+
+Bundle assets and the compiled theme are derived from the source code, so let Shopware write them directly into the new storage instead of copying them. After the configuration points to the new adapter, run:
+
+```bash
+# Copies bundle (plugin/app) assets into the configured asset filesystem
+bin/console asset:install
+
+# Re-compiles the storefront theme into the configured theme filesystem
+bin/console theme:compile
+```
+
+### Verifying the migration
+
+* Open the storefront and Administration and confirm media loads.
+* In the browser network tab, media URLs should point to your S3 endpoint or CDN domain (the configured `url`), not the local domain.
+* Upload a new media file in the Administration and confirm it appears in the bucket.
+
+Once verified, you can remove the old files from the local `public/` and `files/` directories.
+
+### Avoiding gaps during the copy
+
+For shops with active uploads, do a two-pass sync so nothing created during the migration is lost:
+
+1. Run the copy from step 1 once while the shop is still live.
+2. Switch the configuration (step 2) and deploy.
+3. Run the same `rclone copy` / `aws s3 sync` commands again — both only transfer files that are missing or changed, so this second pass catches anything uploaded during the window.
+
+Alternatively, enable maintenance mode for the duration of the migration to prevent uploads entirely.
+
+## Serving files through a CDN
+
+To serve public files from a CDN, set the `url` of the public filesystem to your CDN domain. This changes only the URL Shopware generates for the files; where they are stored is still controlled by `type`/`config`.
 
 ```yaml
 # <project root>/config/packages/prod/shopware.yml
 shopware:
   filesystem:
     public:
-      url: "YOUR_CDN_URL"
+      url: "https://cdn.your-domain.com"
       type: "local"
       config:
         root: "%kernel.project_dir%/public"
 ```
 
 ::: info
-Be aware of the **prod** in the config path. CDNs are typically for production environments, but you can also set them for all environments in `config/packages/shopware.yml`.
+Note the **prod** in the config path above — CDNs are typically used in production only. To enable it everywhere, put it in `config/packages/shopware.yml` instead.
 :::
 
-## Supported adapter configurations
+### Media URL strategy
 
-### Local
+Shopware can lay out media paths using different strategies. The strategy affects how predictable a file's URL is and how well it caches. It is set via the `SHOPWARE_CDN_STRATEGY_DEFAULT` environment variable (mapped to `cdn.strategy`).
+
+| Strategy | Behavior |
+|----------|----------|
+| `id` (default) | Path is derived from a hash of the media ID. URLs are not guessable from the filename. |
+| `filename` | Path is derived from a hash of the filename. |
+| `physical_filename` | Path includes a timestamp and the physical filename. |
+| `plain` | Simple, human-readable path without hashing. |
+
+```dotenv
+# .env
+SHOPWARE_CDN_STRATEGY_DEFAULT=id
+```
+
+::: warning
+Changing the strategy on a shop with existing media changes the generated paths for those files, which will break existing URLs unless the files are moved to match. Choose a strategy before going live, or plan a migration of the affected paths.
+:::
+
+## Restricting uploadable file types
+
+Shopware whitelists the file extensions that may be uploaded. Public and private filesystems have separate lists.
 
 ```yaml
 shopware:
-    filesystem:
-      {ADAPTER_NAME}:
-        type: "local"
-        config:
-          root: "%kernel.project_dir%/public"
+  filesystem:
+    # ... adapter configuration ...
+    allowed_extensions:          # Extensions allowed for the public filesystem
+      - jpg
+      - png
+      # ...
+    private_allowed_extensions:  # Extensions allowed for the private filesystem
+      - pdf
+      - zip
+      # ...
 ```
 
-### Amazon S3
+Shopware ships with a sensible default list (common image, video, audio, and document formats; the private list additionally allows `zip`, `rar`, and `xml`). Override these keys only to add or remove specific extensions.
 
-In order to use the S3 adapter you need to install the `league/flysystem-async-aws-s3` package.
+## Private file download strategy
 
-```bash
-composer require league/flysystem-async-aws-s3
-```
-
-Example configuration:
+For private files served from **local** storage (e.g. downloadable products and invoices), you can choose how the file is delivered to the client:
 
 ```yaml
 shopware:
-    filesystem:
-      {ADAPTER_NAME}:
-        type: "amazon-s3"
-        url: "https://your-cloudfront-url"
-        visibility: "private" # Default is "public", can be set only on shopware.filesystem.private
-        config:
-            bucket: "{your-public-bucket-name}"
-            region: "{your-bucket-region}"
-            endpoint: "{your-s3-provider-endpoint}"
-            root: "{your-root-folder}"
-            # Optional, otherwise will be automatically discovered with AWS content discovery
-            credentials:
-              key: '{your-access-key}'
-              secret: '{your-secret-key}'
+  filesystem:
+    private_local_download_strategy: php   # php (default), x-sendfile, or x-accel
+    private_local_path_prefix: ""          # used by the x-accel strategy
 ```
 
-If your S3 provider does not use buckets as subdomain like Minio in default configuration, you need to set `use_path_style_endpoint` to `true` inside `config`.
+| Strategy | Description |
+|----------|-------------|
+| `php` (default) | Streamed through PHP as `application/octet-stream`. Works everywhere, but PHP handles the whole transfer. |
+| `x-sendfile` | Apache offloads the file transfer. Requires the [`mod_xsendfile`](https://github.com/nmaier/mod_xsendfile) module. |
+| `x-accel` | Nginx offloads the transfer via internal redirect. Configure the matching `internal` location and set `private_local_path_prefix` accordingly. See the [Nginx X-Accel docs](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/). |
 
-#### Custom HTTP client for S3
+Offloading with `x-sendfile`/`x-accel` frees PHP-FPM workers during large downloads and is recommended for high-traffic shops that serve large private files.
 
-:::info
-Since Shopware 6.7.9.0, you can register a custom HTTP client for S3 operations.
-:::
+## Advanced
 
-By default, the underlying AsyncAws S3 client creates its own HTTP client internally, which includes a `RetryableHttpClient` with an AWS-specific retry strategy. This handles transient errors like throttling (HTTP 429), server errors (HTTP 5xx), and other AWS-specific error codes automatically.
+### Tuning the S3 batch write size
 
-If you need to customize the HTTP behavior for S3 operations (e.g., timeouts, HTTP protocol version, or proxy settings), you can register a service with the ID `shopware.filesystem.s3.client`. When this service exists, Shopware injects it into both the filesystem adapter and pre-signed URL generation.
-
-::: info
-When you provide a custom HTTP client, AsyncAws will **not** wrap it in its own `RetryableHttpClient`. If you need retry behavior, you must configure it yourself as shown below.
-:::
-
-**Simple configuration** (custom timeouts, no retry handling):
-
-```yaml
-# config/packages/framework.yaml
-framework:
-    http_client:
-        scoped_clients:
-            s3.http_client:
-                base_uri: '{your-s3-endpoint}'
-                timeout: 30.0
-                http_version: '1.1'
-```
-
-```php
-// config/services.php
-<?php declare(strict_types=1);
-
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-return static function (ContainerConfigurator $configurator): void {
-    $services = $configurator->services();
-
-    $services->alias('shopware.filesystem.s3.client', 's3.http_client');
-};
-```
-
-**Recommended configuration** (custom settings with AWS retry support):
-
-```yaml
-# config/packages/framework.yaml
-framework:
-    http_client:
-        scoped_clients:
-            s3.http_client:
-                base_uri: '{your-s3-endpoint}'
-                timeout: 30.0
-                http_version: '1.1'
-```
-
-```php
-// config/services.php
-<?php declare(strict_types=1);
-
-use AsyncAws\Core\HttpClient\AwsRetryStrategy;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\HttpClient\RetryableHttpClient;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
-return static function (ContainerConfigurator $configurator): void {
-    $services = $configurator->services();
-
-    $services->set(AwsRetryStrategy::class);
-
-    $services->set('shopware.filesystem.s3.client', RetryableHttpClient::class)
-        ->args([
-            service('s3.http_client'),
-            service(AwsRetryStrategy::class),
-            3, // max retries
-        ]);
-};
-```
-
-This wraps your scoped client in a `RetryableHttpClient` with the same `AwsRetryStrategy` that AsyncAws uses by default, preserving retry behavior for AWS-specific transient errors while allowing you to control timeouts, HTTP version, and other transport-level settings.
-
-**Without scoped clients** (standalone service definition with retry support):
-
-```php
-// config/services.php
-<?php declare(strict_types=1);
-
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symfony\Component\HttpClient\HttpClient;
-use Symfony\Component\HttpClient\RetryableHttpClient;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
-return static function (ContainerConfigurator $configurator): void {
-    $services = $configurator->services();
-
-    $services->set('s3.http_client', HttpClientInterface::class)
-        ->factory([HttpClient::class, 'create'])
-        ->args([
-            ['timeout' => 30],
-        ]);
-
-    $services->set('shopware.filesystem.s3.client', RetryableHttpClient::class)
-        ->args([
-            service('s3.http_client'),
-            null, // default retry strategy
-            3, // max retries
-        ]);
-};
-```
-
-This creates a plain HTTP client via `HttpClient::create()` with custom options and wraps it in a `RetryableHttpClient` with the default retry strategy.
-
-### Google Cloud Platform
-
-To use the Google Cloud Platform adapter, you need to install the `league/flysystem-google-cloud-storage` package.
-
-```bash
-composer require league/flysystem-google-cloud-storage
-```
-
-Example configuration:
+When Shopware writes many files at once (for example during `asset:install` or theme compilation), the S3 adapter batches the uploads. The batch size defaults to `250` and can be tuned:
 
 ```yaml
 shopware:
-    filesystem:
-      {ADAPTER_NAME}:
-        type: "google-storage"
-        url: "https://storage.googleapis.com/{your-public-bucket-name}"
-        visibility: "private" # Default is "public", can be set only on shopware.filesystem.private
-        config:
-            bucket: "{your-public-bucket-name}"
-            projectId: "{your-project-id}"
-            keyFilePath: "{path-to-your-keyfile}"
+  filesystem:
+    batch_write_size: 250
 ```
 
-The bucket needs to use the "Fine-grained" [ACL mode](https://cloud.google.com/storage/docs/access-control#choose_between_uniform_and_fine-grained_access). This is required so that Shopware can manage the ACL of the objects.
+### Add your own adapter
 
-## Add your own adapter
-
-To create your own adapter, check out the [official Flysystem guide](https://flysystem.thephpleague.com/v1/docs/advanced/creating-an-adapter/).
-
-To make your adapter available in Shopware, you will need to create an AdapterFactory for your Flysystem provided adapter. An example of that could look like this:
+To support a storage backend Shopware does not ship with, create a Flysystem adapter (see the [official Flysystem guide](https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/)) and wrap it in an `AdapterFactory`:
 
 ```php
 <?php
 
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AdapterFactoryInterface;
-use League\Flysystem\AdapterInterface;
+use League\Flysystem\FilesystemAdapter;
 
 class MyFlysystemAdapterFactory implements AdapterFactoryInterface
 {
     public function getType(): string
     {
-        return 'my-adapter-prefix'; // This must match with the type in the YAML file
+        return 'my-adapter-prefix'; // Must match the `type` in the YAML config
     }
 
-    public function create(array $config): AdapterInterface
+    public function create(array $config): FilesystemAdapter
     {
-        // $config contains the given config from the YAML
+        // $config contains the `config` block from the YAML
         return new MyFlysystemAdapter($config);
     }
 }
 ```
 
-This new class needs to be registered in the DI with the tag `shopware.filesystem.factory` to be usable.
+Register the class in the DI container with the tag `shopware.filesystem.factory` to make it usable as a `type`.
+
+## Troubleshooting
+
+**Media returns 404 after switching to S3.** The existing files were not copied to the new bucket, or the paths/`root` prefix don't match. Follow the [migration procedure](#migrating-an-existing-filesystem-to-a-new-adapter).
+
+**Files load, but from the wrong (local) domain.** The `url` is not set (or is overridden by the fallback). Set the `url` of the affected filesystem to your bucket/CDN domain.
+
+**Theme or plugin assets are missing after the switch.** Run `bin/console asset:install` and `bin/console theme:compile` so they are written to the new storage. Also check the [fallback behavior](#fallback-adapter-configuration).
+
+**`MissingDependencyException` for the adapter.** Install the adapter package: `league/flysystem-async-aws-s3` for S3 or `league/flysystem-google-cloud-storage` for Google Cloud.
+
+**S3-compatible provider (MinIO etc.) returns errors about the bucket host.** Set `use_path_style_endpoint: true` in the adapter `config`.

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -152,7 +152,7 @@ shopware:
 
 ### Amazon S3 (and S3-compatible providers)
 
-Works with Amazon S3 and any S3-compatible storage such as MinIO, Cloudflare R2, DigitalOcean Spaces, Hetzner Object Storage, or Ceph.
+Works with Amazon S3 and any S3-compatible storage such as **MinIO, Cloudflare R2, DigitalOcean Spaces, Hetzner Object Storage, or Ceph**.
 
 Install the adapter package first:
 
@@ -180,13 +180,13 @@ shopware:
 
 | `config` key                             | Description                                                                                                     |
 |------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| `bucket`                                 | Bucket name. **Required.**                                                                                      |
-| `region`                                 | Bucket region, e.g. `eu-central-1`. **Required.**                                                               |
-| `endpoint`                               | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers.                               |
-| `use_path_style_endpoint`                | Set to `true` when the provider does **not** put the bucket in the subdomain (e.g. MinIO in its default setup). |
-| `root`                                   | Prefix inside the bucket all paths are stored under. Optional.                                                  |
-| `credentials.key` / `credentials.secret` | Access key and secret. Optional — if omitted, AWS credential discovery (env vars, instance/IAM role) is used.   |
-| `options`                                | Extra options passed through to the underlying AsyncAws S3 client. Optional.                                    |
+| `bucket`                                 | Bucket name (**Required**)                                                                                      |
+| `region`                                 | Bucket region, e.g. `eu-central-1` (**Required**)                                                               |
+| `endpoint`                               | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers                           |
+| `use_path_style_endpoint`                | Set to `true` when the provider does **not** put the bucket in the subdomain (e.g. MinIO in its default setup) |
+| `root`                                   | Prefix inside the bucket all paths are stored under (**Optional**)                                               |
+| `credentials.key` / `credentials.secret` | Access key and secret. Optional — if omitted, AWS credential discovery (env vars, instance/IAM role) is used.  |
+| `options`                                | Extra options passed through to the underlying AsyncAws S3 client (**Optional**)                                  |
 
 ::: warning
 Omit the `credentials` block on AWS infrastructure (EC2, ECS, EKS) and grant access through an **IAM role** instead. This keeps long-lived secrets out of your configuration.
@@ -216,11 +216,11 @@ shopware:
 
 | `config` key  | Description                                                                |
 |---------------|----------------------------------------------------------------------------|
-| `bucket`      | Bucket name. **Required.**                                                 |
-| `projectId`   | Google Cloud project ID. **Required.**                                     |
+| `bucket`      | Bucket name (**Required**)                                                 |
+| `projectId`   | Google Cloud project ID (**Required**)                                     |
 | `keyFilePath` | Path to a service account key JSON file.                                   |
 | `keyFile`     | The service account key as an inline array (alternative to `keyFilePath`). |
-| `root`        | Prefix inside the bucket. Optional.                                        |
+| `root`        | Prefix inside the bucket (**Optional**)                                        |
 
 The bucket must use the [fine-grained ACL mode](https://cloud.google.com/storage/docs/access-control#choose_between_uniform_and_fine-grained_access) so that Shopware can manage object visibility.
 

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -178,15 +178,15 @@ shopware:
           secret: "{your-secret-key}"
 ```
 
-| `config` key                             | Description                                                                                                     |
-|------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| `bucket`                                 | Bucket name (**Required**)                                                                                      |
-| `region`                                 | Bucket region, e.g. `eu-central-1` (**Required**)                                                               |
-| `endpoint`                               | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers                           |
+| `config` key                             | Description                                                                                                    |
+|------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `bucket`                                 | Bucket name (**Required**)                                                                                     |
+| `region`                                 | Bucket region, e.g. `eu-central-1` (**Required**)                                                              |
+| `endpoint`                               | Custom endpoint URL. Optional for AWS; required for most S3-compatible providers                               |
 | `use_path_style_endpoint`                | Set to `true` when the provider does **not** put the bucket in the subdomain (e.g. MinIO in its default setup) |
-| `root`                                   | Prefix inside the bucket all paths are stored under (**Optional**)                                               |
+| `root`                                   | Prefix inside the bucket all paths are stored under (**Optional**)                                             |
 | `credentials.key` / `credentials.secret` | Access key and secret. Optional — if omitted, AWS credential discovery (env vars, instance/IAM role) is used.  |
-| `options`                                | Extra options passed through to the underlying AsyncAws S3 client (**Optional**)                                  |
+| `options`                                | Extra options passed through to the underlying AsyncAws S3 client (**Optional**)                               |
 
 ::: warning
 Omit the `credentials` block on AWS infrastructure (EC2, ECS, EKS) and grant access through an **IAM role** instead. This keeps long-lived secrets out of your configuration.
@@ -218,7 +218,7 @@ shopware:
 | `projectId`   | Google Cloud project ID (**Required**)                                     |
 | `keyFilePath` | Path to a service account key JSON file.                                   |
 | `keyFile`     | The service account key as an inline array (alternative to `keyFilePath`). |
-| `root`        | Prefix inside the bucket (**Optional**)                                        |
+| `root`        | Prefix inside the bucket (**Optional**)                                    |
 
 The bucket must use the [fine-grained ACL mode](https://cloud.google.com/storage/docs/access-control#choose_between_uniform_and_fine-grained_access) so that Shopware can manage object visibility.
 

--- a/guides/hosting/infrastructure/filesystem.md
+++ b/guides/hosting/infrastructure/filesystem.md
@@ -27,7 +27,7 @@ Shopware uses [Flysystem](https://flysystem.thephpleague.com/docs/) to talk to a
 
 ## How the filesystem is structured
 
-The filesystem is split into separate **adapters**, one per purpose. Each adapter can point at a different storage backend, but in practice you usually configure them all the same way.
+The filesystem is split into separate **adapters**, one per purpose. Each adapter can point at a different storage backend, but in practice you usually configure them all the same way. The following table lists the adapters and their default visibility and paths.
 
 | Filesystem | Visibility | What it holds | Default local path |
 |------------|------------|---------------|--------------------|
@@ -57,10 +57,10 @@ To use a non-default storage, add a `filesystem:` map under the `shopware:` key.
 
 | Key | Description |
 |-----|-------------|
-| `type` | The adapter to use: `local`, `amazon-s3`, or `google-storage`. **Required.** |
-| `url` | Public base URL under which the files are reachable. If omitted, Shopware derives it from `APP_URL`. Use this to point public files at a CDN domain. |
-| `visibility` | `public` (default) or `private`. Only `private` is meaningful for the `private` filesystem. |
-| `config` | Adapter-specific options (bucket, region, credentials, root, …). See [Supported adapters](#supported-adapters). |
+| `type` | The adapter to use: `local`, `amazon-s3`, or `google-storage`. **Required** |
+| `url` | Public base URL under which the files are reachable. If omitted, Shopware derives it from `APP_URL`. Use this to point public files at a CDN domain |
+| `visibility` | `public` (default) or `private`. Only `private` is meaningful for the `private` filesystem |
+| `config` | Adapter-specific options (bucket, region, credentials, root, …). See [Supported adapters](#supported-adapters) |
 
 ```yaml
 shopware:

--- a/guides/hosting/installation-updates/cluster-setup.md
+++ b/guides/hosting/installation-updates/cluster-setup.md
@@ -88,7 +88,7 @@ Please refer to the guide below.
 In a multi-app-server system, manage specific directories over a shared filesystem.
 This includes assets, theme files, and private as well as public filesystems. The recommendation is to use an S3 compatible bucket.
 
-For more information, refer to the [filesystems](../infrastructure/filesystem) section of this guide.
+For more information, refer to the [filesystems](../infrastructure/filesystem) section of this guide. If you are moving an existing single-server shop to a shared S3 bucket, follow the [migration guide](../infrastructure/filesystem#migrating-an-existing-filesystem-to-a-new-adapter) to copy the existing files and switch the configuration without losing media.
 
 ### Shared directories
 


### PR DESCRIPTION
## Summary

Reworks the hosting filesystem documentation and adds a concrete S3 migration guide.

- **`guides/hosting/infrastructure/filesystem.md`** — rewritten from a scattered config dump into a task-oriented guide:
  - Storage decision table (when to use `local` vs. S3 vs. a shared bucket for clusters vs. CDN).
  - Filesystem structure table covering all adapters (`public`, `private`, `theme`, `asset`, `sitemap`, `temp`) with visibility and default paths.
  - Complete per-adapter config reference for `local`, `amazon-s3` (incl. S3-compatible providers like MinIO/R2/Spaces), and `google-storage`, verified against the Shopware source.
  - Media URL strategies (`id`, `filename`, `physical_filename`, `plain`), upload restrictions, private download strategies (`php`/`x-sendfile`/`x-accel`), `batch_write_size` tuning, custom S3 HTTP client, and custom adapters.
  - A **Troubleshooting** section mapping common symptoms (404 media, wrong domain, missing assets, missing dependency, MinIO host errors) to fixes.
- **New "Migrating an existing filesystem to a new adapter" section** — step-by-step move from local to S3 (copy files with `rclone`/`aws s3 sync`, switch config, regenerate assets/theme, verify, plus a two-pass strategy to avoid gaps).
- **`guides/hosting/installation-updates/cluster-setup.md`** — cross-links the new migration guide from the filesystem section.

## Related links

- Addresses shopware/shopware-cli#834 (documenting how an actual local→S3 migration is performed).
- Source references: `src/Core/Framework/Adapter/Filesystem/` and `src/Core/Framework/DependencyInjection/Configuration.php` in shopware/shopware.

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted. _(N/A — no pages moved, renamed, or deleted.)_
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published. _(N/A — docs-only change.)_
- [ ] This pull request is ready for review. _(Draft — pending review of tone/structure.)_

## Notes

- All new prose terms were verified against the Dockerized CI spellcheck (`rojopolis/spellcheck-github-actions`); `.wordlist.txt` was updated and re-sorted with `LC_ALL=C sort` to match CI ordering.
- Technical details (adapter `type` strings, config keys, default paths, download/path strategies, package requirements) were cross-checked against the Shopware core source.
