### PR TITLE
docs(redis): explain cache tag keys without TTL filling Redis

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -674,6 +674,7 @@ Nvidia
 OAuth
 OData
 OIDC
+OOM
 OPENSEARCH
 ORM
 ORMs
@@ -1451,6 +1452,7 @@ eslintrc
 et
 eu
 everytime
+evictable
 evolvability
 exampler
 explainer

--- a/guides/hosting/infrastructure/redis.md
+++ b/guides/hosting/infrastructure/redis.md
@@ -30,6 +30,10 @@ For key eviction policy you should use `volatile-lru`, which only automatically 
 
 The caching data (HTTP-Cache & Object cache) is what should be stored in this instance.
 
+::: warning
+A cache Redis reaching its memory limit is normal — `volatile-lru` keeps evicting expired keys to make room. The problem is having too many keys **without** a TTL: `volatile-lru` can only evict keys that have one. Symfony's tag-aware cache adapter stores tag-index sets without a TTL, and they accumulate orphaned entries over time. If they are never pruned, they leave Redis with too little evictable data and it runs out of memory. See [Cache tags and keys without a TTL](../performance/caches#cache-tags-and-keys-without-a-ttl) for how to detect and prune them.
+:::
+
 <PageRef page="../performance/caches" />
 
 ## Durable, but "aging" data

--- a/guides/hosting/infrastructure/redis.md
+++ b/guides/hosting/infrastructure/redis.md
@@ -7,7 +7,7 @@ nav:
 
 # Redis
 
-[Redis](https://redis.io/docs/latest/get-started/) is an in-memory data storage, that offers high performance and can be used as a cache, message broker, and database. It is a key-value store that supports various data structures like strings, hashes, lists, sets, and sorted sets.
+[Redis](https://redis.io/docs/latest/get-started/) is an in-memory data storage that offers high performance and can be used as a cache, message broker, and database. It is a key-value store that supports various data structures like strings, hashes, lists, sets, and sorted sets.
 Especially in high-performance and high-throughput scenarios it can give better results, than relying on a traditional relational database.
 Therefore, multiple adapter exists in shopware, to offload some tasks from the DB to Redis.
 
@@ -16,8 +16,8 @@ However, as the data that is stored in Redis differs and also the access pattern
 The data stored in Redis can be roughly classified into those three categories:
 
 1. Ephemeral data: This data is not critical and can be easily recreated when lost, e.g., caches.
-2. Durable, but "aging" data: This data is important and cannot easily be recreated, but the relevance of the data decreases over time, e.g. sessions.
-3. Durable and critical data: This data is important and cannot easily be recreated, e.g. carts, number ranges.
+2. Durable, but "aging" data: This data is important and cannot easily be recreated, but the relevance of the data decreases over time, e.g., sessions.
+3. Durable and critical data: This data is important and cannot easily be recreated, e.g., carts, number ranges.
 
 Please note that in current Redis versions, it is not possible to use different eviction policies for different databases in the same Redis instance. Therefore, it is recommended to use separate Redis instances for different types of data.
 
@@ -31,16 +31,16 @@ For key eviction policy you should use `volatile-lru`, which only automatically 
 The caching data (HTTP-Cache & Object cache) is what should be stored in this instance.
 
 ::: warning
-A cache Redis reaching its memory limit is normal — `volatile-lru` keeps evicting least recently used keys that have a TTL set to make room. The problem is having too many keys **without** a TTL: `volatile-lru` can only evict keys that have one. Symfony's tag-aware cache adapter stores tag-index sets without a TTL, and they accumulate orphaned entries over time. If they are never pruned, they leave Redis with too little evictable data and it runs out of memory. See [Cache tags and keys without a TTL](../performance/caches#cache-tags-and-keys-without-a-ttl) for how to detect and prune them.
+A cache Redis reaching its memory limit is normal — `volatile-lru` keeps evicting least recently used keys that have a TTL set to make room. The problem is having too many keys **without** a TTL: `volatile-lru` can only evict keys that have one. Symfony's tag-aware cache adapter stores tag-index sets without a TTL, and they accumulate orphaned entries over time. If they are never pruned, they leave Redis with too little evictable data, and it runs out of memory. See [Cache tags and keys without a TTL](../performance/caches#cache-tags-and-keys-without-a-ttl) for how to detect and prune them.
 :::
 
 <PageRef page="../performance/caches" />
 
 ## Durable, but "aging" data
 
-As the data stored here is durable and should be persistent, even in the case of a Redis restart, it is recommended to configure the used Redis instance that it will not just keep the data in memory, but also store it on the disk. This can be done by using snapshots (RDB) and Append Only Files (AOF), refer to the [Redis docs](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/) for details.
+As the data stored here is durable and should be persistent, even in the case of a Redis restart, it is recommended to configure the used Redis instance that it will not just keep the data in memory but also store it on the disk. This can be done by using snapshots (RDB) and Append Only Files (AOF), refer to the [Redis docs](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/) for details.
 
-`allkeys-lru` should be used as key eviction policy here, as by default more recent data is more important than older data, therefore the oldest values should be discarded, when Redis reach the max memory.
+`allkeys-lru` should be used as key eviction policy here, as by default more recent data is more important than older data, therefore, the oldest values should be discarded, when Redis reach the max memory.
 
 The session data is what should be stored in this instance.
 
@@ -48,15 +48,15 @@ The session data is what should be stored in this instance.
 
 ## Durable and critical data
 
-Again this is durable data, that can not easily be recreated, therefore it should be persisted as well.
+Again, this is durable data that cannot easily be recreated, therefore, it should be persisted as well.
 
 As the data is critical, it is important to use a key eviction policy that will not delete data that is not expired, therefore `volatile-lru` should be used.
 
-The cart, number range, lock store and increment data is what should be stored in this instance.
+The cart, number range, lock store, and increment data are what should be stored in this instance.
 
 ## Configuration
 
-Starting with v6.6.8.0 Shopware supports configuring different reusable Redis connections in the`config/packages/shopware.yaml` file under the `shopware` section:
+Starting with v6.6.8.0, Shopware supports configuring different reusable Redis connections in the`config/packages/shopware.yaml` file under the `shopware` section:
 
 ```yaml
 shopware:

--- a/guides/hosting/infrastructure/redis.md
+++ b/guides/hosting/infrastructure/redis.md
@@ -31,7 +31,7 @@ For key eviction policy you should use `volatile-lru`, which only automatically 
 The caching data (HTTP-Cache & Object cache) is what should be stored in this instance.
 
 ::: warning
-A cache Redis reaching its memory limit is normal — `volatile-lru` keeps evicting expired keys to make room. The problem is having too many keys **without** a TTL: `volatile-lru` can only evict keys that have one. Symfony's tag-aware cache adapter stores tag-index sets without a TTL, and they accumulate orphaned entries over time. If they are never pruned, they leave Redis with too little evictable data and it runs out of memory. See [Cache tags and keys without a TTL](../performance/caches#cache-tags-and-keys-without-a-ttl) for how to detect and prune them.
+A cache Redis reaching its memory limit is normal — `volatile-lru` keeps evicting least recently used keys that have a TTL set to make room. The problem is having too many keys **without** a TTL: `volatile-lru` can only evict keys that have one. Symfony's tag-aware cache adapter stores tag-index sets without a TTL, and they accumulate orphaned entries over time. If they are never pruned, they leave Redis with too little evictable data and it runs out of memory. See [Cache tags and keys without a TTL](../performance/caches#cache-tags-and-keys-without-a-ttl) for how to detect and prune them.
 :::
 
 <PageRef page="../performance/caches" />

--- a/guides/hosting/performance/caches.md
+++ b/guides/hosting/performance/caches.md
@@ -160,7 +160,7 @@ This section explains a common surprise when running Shopware's cache on Redis: 
 A few Redis basics first, so the rest makes sense:
 
 * **TTL (Time To Live)** is an expiry timer on a key. A cache item written with a TTL of one hour is automatically deleted an hour later. A key with **no TTL** is *persistent* — Redis keeps it until something explicitly deletes it.
-* **`maxmemory`** is the memory limit you give Redis. When Redis reaches it, it does not just start rejecting writes — first it tries to free space using its **eviction policy**.
+* **`maxmemory`** is the memory limit you give Redis. When Redis reaches it, it does not just start rejecting `writes` — first it tries to free space using its **eviction policy**.
 * The recommended policy for the cache is **`volatile-lru`**. The `volatile` part is the catch: it will only evict keys that **have a TTL**. Keys without a TTL are off-limits — Redis will never evict them, no matter how full it gets.
 
 So a cache Redis sitting at its `maxmemory` limit is completely normal and healthy. It fills up over time, and `volatile-lru` keeps evicting least recently used keys that have a TTL set to make room for new ones. **Full is fine** — as long as enough of that memory is held by keys *with* a TTL, so Redis always has something it is allowed to evict.
@@ -177,7 +177,7 @@ Here is the catch: **these tag-index keys have no TTL.** Only the cached items t
 2. An hour passes. The cached page **expires and is removed** — but its entry in the `product-123` tag set is **not** removed. The set now points at a key that no longer exists. That leftover entry is called an **orphaned tag**.
 3. Repeat this millions of times a day on a busy shop, and the tag sets keep growing with orphaned entries — and because they have no TTL, `volatile-lru` can never evict them.
 
-While the tag sets are a small share of total memory, everything is fine: there are plenty of expiring cache items for Redis to evict. The trouble starts when the persistent, no-TTL tag data grows large enough that Redis no longer has *enough* evictable keys to reclaim. At that point Redis cannot free space for new writes and starts returning **out-of-memory (OOM) errors** — even though `volatile-lru` is set correctly.
+While the tag sets are a small share of total memory, everything is fine: there are plenty of expiring cache items for Redis to evict. The trouble starts when the persistent, no-TTL tag data grows large enough that Redis no longer has *enough* evictable keys to reclaim. At that point Redis cannot free space for new `writes` and starts returning **out-of-memory (OOM) errors** — even though `volatile-lru` is set correctly.
 
 ::: warning
 The problem is **not** that the cache Redis is full — that is expected and healthy. The problem is having **too many keys without a TTL**, which leaves Redis nothing it is allowed to evict. If your cache instance throws OOM errors, do not just raise `maxmemory` — first check how much memory is held by keys *without* a TTL.
@@ -222,4 +222,4 @@ shopware-redis-cli-helper --url redis://127.0.0.1:6379/0 cleanup
 shopware-redis-cli-helper --url redis://127.0.0.1:6379/0 cleanup --apply
 ```
 
-The important part is **step 3 on a schedule** — run the cleanup as a recurring cron job (for example, nightly) rather than once. Orphaned tags accumulate continuously, so a one-off cleanup fixes today's symptom but the instance will fill up again. A regular prune keeps the no-TTL share small and permanently avoids the OOM errors.
+The important part is **step 3 on a schedule** — run the cleanup as a recurring cron job (for example, nightly) rather than once. Orphaned tags accumulate continuously, so a one-off cleanup fixes today's symptom, but the instance will fill up again. A regular prune keeps the no-TTL share small and permanently avoids the OOM errors.

--- a/guides/hosting/performance/caches.md
+++ b/guides/hosting/performance/caches.md
@@ -150,3 +150,76 @@ redis://auth@/var/run/redis.sock
 ```
 
 For more information or other adapters checkout [Symfony FrameworkBundle](https://symfony.com/doc/current/cache.html#configuring-cache-with-frameworkbundle) documentation.
+
+### Cache tags and keys without a TTL
+
+This section explains a common surprise when running Shopware's cache on Redis: the cache instance runs out of memory even though eviction is configured correctly. The short version is that some cache keys never expire, and if too many of them pile up, Redis has nothing left to clean up. Read on for what that means and how to fix it.
+
+#### Background: TTL and eviction
+
+A few Redis basics first, so the rest makes sense:
+
+* **TTL (time to live)** is an expiry timer on a key. A cache item written with a TTL of one hour is automatically deleted an hour later. A key with **no TTL** is *persistent* — Redis keeps it until something explicitly deletes it.
+* **`maxmemory`** is the memory limit you give Redis. When Redis reaches it, it does not just start rejecting writes — first it tries to free space using its **eviction policy**.
+* The recommended policy for the cache is **`volatile-lru`**. The `volatile` part is the catch: it will only evict keys that **have a TTL**. Keys without a TTL are off-limits — Redis will never evict them, no matter how full it gets.
+
+So a cache Redis sitting at its `maxmemory` limit is completely normal and healthy. It fills up over time, and `volatile-lru` keeps deleting expired (or soon-to-expire) keys to make room for new ones. **Full is fine** — as long as enough of that memory is held by keys *with* a TTL, so Redis always has something it is allowed to evict.
+
+#### The problem: cache tags never expire
+
+Shopware needs to invalidate related cache entries together — for example, when a product changes, every cached page that shows that product must be dropped. This is done with **cache tags**, and it requires the `redis_tag_aware` adapter (configured above).
+
+To make tags work, Symfony keeps a **tag index** in Redis. For each tag (say, `product-123`) it stores a Redis *set* listing every cache key that carries that tag. These index keys contain the `\x01tags\x01` marker in their name.
+
+Here is the catch: **these tag-index keys have no TTL.** Only the cached items themselves expire. Walk through what happens to a single cached page:
+
+1. Shopware caches a product page with a one-hour TTL, and adds its key to the `product-123` tag set so it can be invalidated later.
+2. An hour passes. The cached page **expires and is removed** — but its entry in the `product-123` tag set is **not** removed. The set now points at a key that no longer exists. That leftover entry is called an **orphaned tag**.
+3. Repeat this millions of times a day on a busy shop, and the tag sets keep growing with orphaned entries — and because they have no TTL, `volatile-lru` can never evict them.
+
+While the tag sets are a small share of total memory, everything is fine: there are plenty of expiring cache items for Redis to evict. The trouble starts when the persistent, no-TTL tag data grows large enough that Redis no longer has *enough* evictable keys to reclaim. At that point Redis cannot free space for new writes and starts returning **out-of-memory (OOM) errors** — even though `volatile-lru` is set correctly.
+
+::: warning
+The problem is **not** that the cache Redis is full — that is expected and healthy. The problem is having **too many keys without a TTL**, which leaves Redis nothing it is allowed to evict. If your cache instance throws OOM errors, do not just raise `maxmemory` — first check how much memory is held by keys *without* a TTL.
+:::
+
+#### How to tell if this is your problem
+
+Signs that point at orphaned tags rather than a genuinely undersized cache:
+
+* Redis reports OOM errors (`OOM command not allowed when used memory > 'maxmemory'`) while the eviction policy is `volatile-lru`.
+* Raising `maxmemory` only postpones the problem — it fills up again.
+* A large share of the used memory is in keys with **no TTL** (in a healthy cache, almost everything should have a TTL).
+
+You can get a rough read directly from `redis-cli`:
+
+```bash
+# How many keys have no expiry set at all?
+redis-cli INFO keyspace
+# e.g. "db0:keys=1000000,expires=200000,avg_ttl=0"
+# -> 800000 keys (1,000,000 - 200,000) have NO TTL. That is a red flag.
+```
+
+`keys` is the total number of keys and `expires` is how many of them have a TTL; the difference is the number of persistent keys. If that difference is large, orphaned tag sets are the likely cause.
+
+#### The fix: prune orphaned tags regularly
+
+Symfony does not clean up these tag sets on its own, so you have to remove the orphaned entries yourself, on a schedule. Either of these tools does the job (both iterate with the non-blocking `SCAN` command and are safe to run against production):
+
+* **[FroshTools](https://github.com/FriendsOfShopware/FroshTools)** — a Shopware plugin that adds the `frosh:redis-tag:cleanup` console command. It scans the tag sets and removes members pointing at keys that no longer exist.
+* **[shopware-redis-cli-helper](https://github.com/shyim/shopware-redis-cli-helper)** — a standalone command-line tool that does the same job faster. Its `insights` command has a **Persistent** view showing exactly how much memory is held by no-TTL keys (handy to confirm the diagnosis first), and its `cleanup` command prunes the orphaned tags.
+
+Using the standalone helper, for example:
+
+```bash
+# 1. Confirm the diagnosis: see how much memory is held by keys without a TTL
+shopware-redis-cli-helper --url redis://127.0.0.1:6379/0 insights
+
+# 2. Preview what a cleanup would remove (dry run — changes nothing)
+shopware-redis-cli-helper --url redis://127.0.0.1:6379/0 cleanup
+
+# 3. Apply the cleanup for real
+shopware-redis-cli-helper --url redis://127.0.0.1:6379/0 cleanup --apply
+```
+
+The important part is **step 3 on a schedule** — run the cleanup as a recurring cron job (for example, nightly) rather than once. Orphaned tags accumulate continuously, so a one-off cleanup fixes today's symptom but the instance will fill up again. A regular prune keeps the no-TTL share small and permanently avoids the OOM errors.

--- a/guides/hosting/performance/caches.md
+++ b/guides/hosting/performance/caches.md
@@ -159,7 +159,7 @@ This section explains a common surprise when running Shopware's cache on Redis: 
 
 A few Redis basics first, so the rest makes sense:
 
-* **TTL (time to live)** is an expiry timer on a key. A cache item written with a TTL of one hour is automatically deleted an hour later. A key with **no TTL** is *persistent* — Redis keeps it until something explicitly deletes it.
+* **TTL (Time To Live)** is an expiry timer on a key. A cache item written with a TTL of one hour is automatically deleted an hour later. A key with **no TTL** is *persistent* — Redis keeps it until something explicitly deletes it.
 * **`maxmemory`** is the memory limit you give Redis. When Redis reaches it, it does not just start rejecting writes — first it tries to free space using its **eviction policy**.
 * The recommended policy for the cache is **`volatile-lru`**. The `volatile` part is the catch: it will only evict keys that **have a TTL**. Keys without a TTL are off-limits — Redis will never evict them, no matter how full it gets.
 

--- a/guides/hosting/performance/caches.md
+++ b/guides/hosting/performance/caches.md
@@ -163,7 +163,7 @@ A few Redis basics first, so the rest makes sense:
 * **`maxmemory`** is the memory limit you give Redis. When Redis reaches it, it does not just start rejecting writes — first it tries to free space using its **eviction policy**.
 * The recommended policy for the cache is **`volatile-lru`**. The `volatile` part is the catch: it will only evict keys that **have a TTL**. Keys without a TTL are off-limits — Redis will never evict them, no matter how full it gets.
 
-So a cache Redis sitting at its `maxmemory` limit is completely normal and healthy. It fills up over time, and `volatile-lru` keeps deleting expired (or soon-to-expire) keys to make room for new ones. **Full is fine** — as long as enough of that memory is held by keys *with* a TTL, so Redis always has something it is allowed to evict.
+So a cache Redis sitting at its `maxmemory` limit is completely normal and healthy. It fills up over time, and `volatile-lru` keeps evicting least recently used keys that have a TTL set to make room for new ones. **Full is fine** — as long as enough of that memory is held by keys *with* a TTL, so Redis always has something it is allowed to evict.
 
 #### The problem: cache tags never expire
 


### PR DESCRIPTION
## Summary

Documents a real customer case: a cache Redis that kept running out of memory even though `volatile-lru` was configured correctly.

- Shopware's `redis_tag_aware` cache adapter stores a **tag index** in Redis (one set per cache tag) so related entries can be invalidated together. These tag-index keys have **no TTL**.
- When cached items expire, their entries in the tag sets are not removed, leaving orphaned members. Because `volatile-lru` only evicts keys *with* a TTL, these persistent sets accumulate and can never be evicted — under high cache churn Redis eventually has too little evictable data left and returns OOM errors.
- A full cache Redis is healthy; the real problem is having **too many keys without a TTL**. Symfony does not prune the tag sets automatically, so operators must do it on a schedule.

Changes:

- **`guides/hosting/performance/caches.md`** — new self-contained section *"Cache tags and keys without a TTL"*, written for a junior dev/DevOps reader: a TTL + eviction primer, a before/after walkthrough of how orphaned tags accumulate, a `redis-cli INFO keyspace` self-diagnosis, and a scheduled-cleanup fix.
- **`guides/hosting/infrastructure/redis.md`** — a cross-linked warning in the ephemeral-data section where `volatile-lru` is recommended.
- **`.wordlist.txt`** — added `evictable` and `OOM`.

## Related links

- Cleanup tooling: [FroshTools](https://github.com/FriendsOfShopware/FroshTools) (`frosh:redis-tag:cleanup`) and [shopware-redis-cli-helper](https://github.com/shyim/shopware-redis-cli-helper).
- Symfony [RedisTagAwareAdapter](https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html).

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted. <!-- N/A: no pages moved, renamed, or deleted -->
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published. <!-- N/A: docs-only change -->
- [ ] This pull request is ready for review. <!-- still a draft -->

## Notes

`shopware-redis-cli-helper` currently lives under a personal GitHub account. If linking a personal repo from official docs is undesirable, I can drop it and keep only the FroshTools reference.
