### PR TITLE
Update theme configuration translation guidelines

### DIFF
--- a/guides/plugins/themes/configuration/theme-configuration.md
+++ b/guides/plugins/themes/configuration/theme-configuration.md
@@ -254,6 +254,8 @@ The following parameters can be defined for a config field item:
 
 Since the translations in `theme.config` are only used by the Theme Manager in the administration, we decided to use snippet keys for translating the configuration in order to ensure inheritance.
 
+Store these snippet keys in Administration snippet files, for example `<plugin root>/src/Resources/app/administration/src/app/snippet/de.json` and `<plugin root>/src/Resources/app/administration/src/app/snippet/en.json`. Locale-specific files such as `de-DE.json` and `en-GB.json` are also supported and override the base language files.
+
 Each snippet key begins with `sw-theme`, followed by the theme’s technical name, or its respective parent theme name, since snippets are inherited from the parent theme as well. It then includes the names of the relevant `tab`, `block`, `section`, and `field`. If you're translating field options, a numeric index is added to the snippet path. If any of these elements are unnamed, `default` will be used as the replacement in the key.
 
 At the end of the key, you append `label`. For fields, you may alternatively use `helpText` instead of `label`.

--- a/guides/plugins/themes/configuration/theme-configuration.md
+++ b/guides/plugins/themes/configuration/theme-configuration.md
@@ -254,7 +254,7 @@ The following parameters can be defined for a config field item:
 
 Since the translations in `theme.config` are only used by the Theme Manager in the administration, we decided to use snippet keys for translating the configuration in order to ensure inheritance.
 
-Store these snippet keys in Administration snippet files, for example `<plugin root>/src/Resources/app/administration/src/app/snippet/de.json` and `<plugin root>/src/Resources/app/administration/src/app/snippet/en.json`. Locale-specific files such as `de-DE.json` and `en-GB.json` are also supported and override the base language files.
+Store these snippet keys in Administration snippet files, for example, `<plugin root>/src/Resources/app/administration/src/app/snippet/de.json` and `<plugin root>/src/Resources/app/administration/src/app/snippet/en.json`. Locale-specific files such as `de-DE.json` and `en-GB.json` are also supported and override the base language files.
 
 Each snippet key begins with `sw-theme`, followed by the theme’s technical name, or its respective parent theme name, since snippets are inherited from the parent theme as well. It then includes the names of the relevant `tab`, `block`, `section`, and `field`. If you're translating field options, a numeric index is added to the snippet path. If any of these elements are unnamed, `default` will be used as the replacement in the key.
 


### PR DESCRIPTION
Clarified usage of snippet keys for translations in theme configuration, including file storage locations and naming conventions.

## Summary

<!-- Describe the documentation change in a few sentences or bullet points. -->

## Related links

<!-- Link related issues, pull requests, commits, or source references. -->

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
Beyond this change, the documentation should be updated to include code examples from the snippet files.