### PR TITLE
docs(cdn): update domain ownership instructions and clarify DNS challenge configuration

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -417,6 +417,7 @@ ExtensionAPI
 FLAC
 FPM
 FQCN
+FQDN
 FastRoute
 Fastly
 Fastly's

--- a/products/paas/shopware/cdn/index.md
+++ b/products/paas/shopware/cdn/index.md
@@ -127,7 +127,7 @@ dig _shopware-challenge.example.com TXT
 
 Ensure the responses match the values you configured in Step 1.
 
-### Step 3: Domain ownership - Create a `TXT` record to prove domain ownership:
+### Step 3: Domain ownership - Create a `TXT` record to prove domain ownership
 
 ```dns
 _shopware-challenge.<domain> IN TXT "shopware-challenge=<organization id>"

--- a/products/paas/shopware/cdn/index.md
+++ b/products/paas/shopware/cdn/index.md
@@ -148,7 +148,7 @@ _shopware-challenge.example.com.  IN  TXT  "shopware-challenge=abc123"
 ```
 
 ::: info
-**DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 3.
+**DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 4.
 :::
 
 ### Step 4: Create Domain in PaaS

--- a/products/paas/shopware/cdn/index.md
+++ b/products/paas/shopware/cdn/index.md
@@ -102,32 +102,7 @@ If your custom domain is an apex/root domain (e.g., `example.com`), you need to 
 2a04:4e42:600::820
 ```
 
-### Step 2: Verify DNS Propagation
-
-Before creating the domain in the PaaS platform, verify that your DNS records have propagated correctly using the `dig` command or online DNS lookup tools.
-
-**For non-apex domains (CNAME):**
-
-```bash
-dig shop.example.com CNAME
-```
-
-**For apex domains:**
-
-```bash
-# Verify A records
-dig example.com A
-
-# Verify AAAA records
-dig example.com AAAA
-
-# Verify TXT record
-dig _shopware-challenge.example.com TXT
-```
-
-Ensure the responses match the values you configured in Step 1.
-
-### Step 3: Domain ownership - Create a `TXT` record to prove domain ownership
+### Step 2: Domain ownership - Create a `TXT` record to prove domain ownership
 
 ```dns
 _shopware-challenge.<domain> IN TXT "shopware-challenge=<organization id>"
@@ -152,7 +127,37 @@ The challenge record needs to stay as long as the domain is configured in our Pa
 :::
 
 ::: info **DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 4.
+Use Step 3 to validate all records are correct and propagated.
 :::
+
+### Step 3: Verify DNS Propagation
+
+Before creating the domain in the PaaS platform, verify that your DNS records have propagated correctly using the `dig` command or online DNS lookup tools.
+
+**For non-apex domains (CNAME):**
+
+```bash
+dig shop.example.com CNAME
+```
+
+**For apex domains:**
+
+```bash
+# Verify A records
+dig example.com A
+
+# Verify AAAA records
+dig example.com AAAA
+```
+
+**For challenge record:**
+
+```bash
+# Verify TXT record
+dig _shopware-challenge.example.com TXT
+```
+
+Ensure the responses match the values you configured in Step 1 and 2.
 
 ### Step 4: Create Domain in PaaS
 

--- a/products/paas/shopware/cdn/index.md
+++ b/products/paas/shopware/cdn/index.md
@@ -102,24 +102,6 @@ If your custom domain is an apex/root domain (e.g., `example.com`), you need to 
 2a04:4e42:600::820
 ```
 
-**3. Domain ownership** - Create a `TXT` record to prove domain ownership:
-
-```dns
-_shopware-challenge.<domain> IN TXT "shopware-challenge=<organization id>"
-```
-
-Replace `<domain>` with your actual domain and `<organization id>` with your organization ID from `sw-paas org list`.
-
-**Example for domain `example.com` with organization ID `abc123`:**
-
-```dns
-_shopware-challenge.example.com.  IN  TXT  "shopware-challenge=abc123"
-```
-
-::: info
-**DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 3.
-:::
-
 ### Step 2: Verify DNS Propagation
 
 Before creating the domain in the PaaS platform, verify that your DNS records have propagated correctly using the `dig` command or online DNS lookup tools.
@@ -145,7 +127,31 @@ dig _shopware-challenge.example.com TXT
 
 Ensure the responses match the values you configured in Step 1.
 
-### Step 3: Create Domain in PaaS
+### Step 3: Domain ownership - Create a `TXT` record to prove domain ownership:
+
+```dns
+_shopware-challenge.<domain> IN TXT "shopware-challenge=<organization id>"
+```
+
+Replace `<domain>` with your actual domain and `<organization id>` with your organization ID from `sw-paas org list`.
+
+Example with the following setup:
+
+- your application FQDN is `myshop.example.com`
+- then your domain is `example.com`
+- your organization ID is `abc123`
+
+Create the following record:
+
+```dns
+_shopware-challenge.example.com.  IN  TXT  "shopware-challenge=abc123"
+```
+
+::: info
+**DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 3.
+:::
+
+### Step 4: Create Domain in PaaS
 
 Once DNS records are configured and propagated, create the domain using the CLI:
 

--- a/products/paas/shopware/cdn/index.md
+++ b/products/paas/shopware/cdn/index.md
@@ -148,7 +148,10 @@ _shopware-challenge.example.com.  IN  TXT  "shopware-challenge=abc123"
 ```
 
 ::: info
-**DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 4.
+The challenge record needs to stay as long as the domain is configured in our PaaS.
+:::
+
+::: info **DNS Propagation Time:** DNS changes typically propagate within 15-30 minutes but can take up to 48 hours depending on TTL settings and DNS provider. We strongly recommend waiting for full propagation before proceeding to Step 4.
 :::
 
 ### Step 4: Create Domain in PaaS

--- a/products/paas/shopware/cdn/index.md
+++ b/products/paas/shopware/cdn/index.md
@@ -174,7 +174,7 @@ You can attach multiple domains to a single shop by running this command for eac
 If validation fails, verify your DNS configuration and wait for propagation before retrying.
 :::
 
-### Step 4: Deploy Application
+### Step 5: Deploy Application
 
 After successful domain creation, trigger an application deployment to activate the domain:
 
@@ -190,7 +190,7 @@ sw-paas application update
 
 You may use the same commit to trigger a deployment.
 
-### Step 5: Configure in Shopware
+### Step 6: Configure in Shopware
 
 After deployment completes:
 


### PR DESCRIPTION


## Summary

Restructures the custom domain setup guide in the PaaS CDN docs to fix the step ordering. The domain ownership TXT record instructions were previously bundled into Step 1 (DNS records), but verification (Step 2) logically comes before proving ownership. This moves the TXT record creation into its own dedicated step after DNS propagation is verified.

## Changes

Moved the domain ownership TXT record instructions out of Step 1 into a new Step 3: Domain ownership, pushing "Create Domain in PaaS" to Step 4.
Clarified the domain-vs-FQDN example: now spells out that for an application FQDN of myshop.example.com, the domain is example.com (org ID abc123), making the relationship between the application hostname and the challenge record explicit.

## Related links

<!-- Link related issues, pull requests, commits, or source references. -->

## Checklist

- [ x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
