### PR TITLE
chore(docs): document rate limiter defaults

### DIFF
--- a/guides/hosting/infrastructure/rate-limiter.md
+++ b/guides/hosting/infrastructure/rate-limiter.md
@@ -15,6 +15,35 @@ This functionality is available starting with Shopware 6.4.6.0.
 
 Shopware 6 provides certain rate limits by default that reduces the risk of brute-force attacks for pages like login or password reset.
 
+These rate limiters are always active. You do not need to add the `shopware.api.rate_limiter` map to your `shopware.yml` for them to work. The core already ships with the defaults documented below, and the `shopware.yml` is only used to override them (for example, to raise a limit or disable a limiter).
+
+## Default rate limiters
+
+The following limiters are enabled by default. The values listed here reflect the current Shopware core configuration and may change between versions. When in doubt, the source of truth is `Shopware\Core\Framework\Resources\config\packages\shopware.yaml` in the version you are running.
+
+| Limiter | Protects | Policy | Reset | Limits |
+| --- | --- | --- | --- | --- |
+| `login` | Storefront / Store-API customer authentication. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `guest_login` | Storefront / Store-API after-order guest authentication. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `oauth` | API OAuth authentication / Administration login. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `reset_password` | Storefront / Store-API customer password reset. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `user_recovery` | Administration user password recovery. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `contact_form` | Storefront / Store-API contact form. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `revocation_request_form` | Store-API revocation request form. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `newsletter_form` | Store-API newsletter registration. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `notification` | Store-API notification endpoint. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `cart_add_line_item` | Adding line items to the cart. | `system_config` | 1 hour | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
+| `mcp_admin_api` | MCP server Admin API access (keyed per OAuth token). | `time_backoff` | 1 hour | 300 / 60s, 1000 / 10min |
+| `mcp_store_api` | MCP server Store API access (keyed per sales-channel context token). | `time_backoff` | 1 hour | 120 / 60s, 600 / 10min |
+| `app_shop_verify` | App shop registration verification. | `sliding_window` | n/a | 60 / 60min |
+
+In the table above, `Limits` uses the `limit / interval` notation, and `s` / `min` are seconds / minutes.
+
+::: info
+The `notification` limiter is available starting with Shopware 6.4.8.0. The `mcp_admin_api` and `mcp_store_api` limiters are available starting with Shopware 6.8.0.0.
+:::
+
 ## Configuration
 
 The configuration for the rate limiter of Shopware 6 resides in the general bundle configuration:
@@ -26,16 +55,9 @@ The configuration for the rate limiter of Shopware 6 resides in the general bund
       └── shopware.yml
 ```
 
-To configure the default rate limiters for your shop, you need to add the `shopware.api.rate_limiter` map to the `shopware.yml`. Under this key, you can separately define the rate limiters.
+To override the [default rate limiters](#default-rate-limiters) for your shop, you need to add the `shopware.api.rate_limiter` map to the `shopware.yml`. Under this key, you can separately define each rate limiter. Any key you set is merged into the defaults, so you only need to configure the values you want to change.
 
-In the following, you can find a list of the default limiters:
-
-- `login`: Storefront / Store-API customer authentication.
-- `guest_login`: Storefront / Store-API after order guest authentication.
-- `oauth`: API oauth authentication / Administration login.
-- `reset_password`: Storefront / Store-API customer password reset.
-- `user_recovery`: Administration user password recovery.
-- `contact_form`: Storefront / Store-API contact form.
+The following example disables the `login` limiter and overrides the `oauth` limiter:
 
 ```yaml
 // <shop root>/config/packages/shopware.yaml

--- a/guides/hosting/infrastructure/rate-limiter.md
+++ b/guides/hosting/infrastructure/rate-limiter.md
@@ -19,24 +19,24 @@ These rate limiters are always active. You do not need to add the `shopware.api.
 
 ## Default rate limiters
 
-The following limiters are enabled by default. The values listed here reflect the current Shopware core configuration and may change between versions. When in doubt, the source of truth is `Shopware\Core\Framework\Resources\config\packages\shopware.yaml` in the version you are running.
+The following limiters are enabled by default. The values listed here reflect the current Shopware core configuration and may change between versions. When in doubt, the source of truth is `src/Core/Framework/Resources/config/packages/shopware.yaml` in the version you are running.
 
 | Limiter | Protects | Since | Policy | Reset | Limits |
 | --- | --- | --- | --- | --- | --- |
-| `login` | Storefront / Store-API customer authentication. | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `guest_login` | Storefront / Store-API after-order guest authentication. | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `oauth` | API OAuth authentication / Administration login. | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `reset_password` | Storefront / Store-API customer password reset. | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `user_recovery` | Administration user password recovery. | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `contact_form` | Storefront / Store-API contact form. | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `notification` | Store-API notification endpoint. | 6.4.8.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `newsletter_form` | Store-API newsletter registration. | 6.4.16.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `cart_add_line_item` | Adding line items to the cart. | 6.4.18.0 | `system_config` | 1 hour | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
-| `revocation_request_form` | Store-API revocation request form. | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe. | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `app_shop_verify` | App shop registration verification. | 6.7.9.0 | `sliding_window` | n/a | 60 / 60min |
-| `mcp_admin_api` | MCP server Admin API access (keyed per OAuth token). | 6.8.0.0 | `time_backoff` | 1 hour | 300 / 60s, 1000 / 10min |
-| `mcp_store_api` | MCP server Store API access (keyed per sales-channel context token). | 6.8.0.0 | `time_backoff` | 1 hour | 120 / 60s, 600 / 10min |
+| `login` | Storefront / Store-API customer authentication | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `guest_login` | Storefront / Store-API after-order guest authentication | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `oauth` | API OAuth authentication / Administration login | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `reset_password` | Storefront / Store-API customer password reset | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `user_recovery` | Administration user password recovery | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `contact_form` | Storefront / Store-API contact form | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `notification` | Store-API notification endpoint | 6.4.8.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `newsletter_form` | Store-API newsletter registration | 6.4.16.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `cart_add_line_item` | Adding line items to the cart | 6.4.18.0 | `system_config` | 1 hour | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
+| `revocation_request_form` | Store-API revocation request form | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `app_shop_verify` | App shop registration verification | 6.7.9.0 | `sliding_window` | n/a | 60 / 60min |
+| `mcp_admin_api` | MCP server Admin API access (keyed per OAuth token) | 6.8.0.0 | `time_backoff` | 1 hour | 300 / 60s, 1000 / 10min |
+| `mcp_store_api` | MCP server Store API access (keyed per sales-channel context token) | 6.8.0.0 | `time_backoff` | 1 hour | 120 / 60s, 600 / 10min |
 
 In the table above, `Limits` uses the `limit / interval` notation, and `s` / `min` are seconds / minutes. When you add a new default limiter to the core, add a row here with its introduction version so this table stays complete.
 
@@ -56,7 +56,7 @@ To override the [default rate limiters](#default-rate-limiters) for your shop, y
 The following example disables the `login` limiter and overrides the `oauth` limiter:
 
 ```yaml
-// <shop root>/config/packages/shopware.yaml
+// <shop root>/config/packages/shopware.yml
 shopware:
   api:
     rate_limiter:

--- a/guides/hosting/infrastructure/rate-limiter.md
+++ b/guides/hosting/infrastructure/rate-limiter.md
@@ -21,22 +21,22 @@ These rate limiters are always active. You do not need to add the `shopware.api.
 
 The following limiters are enabled by default. The values listed here reflect the current Shopware core configuration and may change between versions. When in doubt, the source of truth is `src/Core/Framework/Resources/config/packages/shopware.yaml` in the version you are running.
 
-| Limiter | Protects | Since | Policy | Reset | Limits |
-| --- | --- | --- | --- | --- | --- |
-| `login` | Storefront / Store-API customer authentication | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `guest_login` | Storefront / Store-API after-order guest authentication | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `oauth` | API OAuth authentication / Administration login | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `reset_password` | Storefront / Store-API customer password reset | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `user_recovery` | Administration user password recovery | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `contact_form` | Storefront / Store-API contact form | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `notification` | Store-API notification endpoint | 6.4.8.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `newsletter_form` | Store-API newsletter registration | 6.4.16.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `cart_add_line_item` | Adding line items to the cart | 6.4.18.0 | `system_config` | 1 hour | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
-| `revocation_request_form` | Store-API revocation request form | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `app_shop_verify` | App shop registration verification | 6.7.9.0 | `sliding_window` | n/a | 60 / 60min |
-| `mcp_admin_api` | MCP server Admin API access (keyed per OAuth token) | 6.8.0.0 | `time_backoff` | 1 hour | 300 / 60s, 1000 / 10min |
-| `mcp_store_api` | MCP server Store API access (keyed per sales-channel context token) | 6.8.0.0 | `time_backoff` | 1 hour | 120 / 60s, 600 / 10min |
+| Limiter                       | Protects                                                            | Since    | Policy           | Reset    | Limits                                                     |
+|-------------------------------|---------------------------------------------------------------------|----------|------------------|----------|------------------------------------------------------------|
+| `login`                       | Storefront / Store-API customer authentication                      | 6.4.6.0  | `time_backoff`   | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s                               |
+| `guest_login`                 | Storefront / Store-API after-order guest authentication             | 6.4.6.0  | `time_backoff`   | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s                               |
+| `oauth`                       | API OAuth authentication / Administration login                     | 6.4.6.0  | `time_backoff`   | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s                               |
+| `reset_password`              | Storefront / Store-API customer password reset                      | 6.4.6.0  | `time_backoff`   | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s                                 |
+| `user_recovery`               | Administration user password recovery                               | 6.4.6.0  | `time_backoff`   | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s                                 |
+| `contact_form`                | Storefront / Store-API contact form                                 | 6.4.6.0  | `time_backoff`   | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s                                 |
+| `notification`                | Store-API notification endpoint                                     | 6.4.8.0  | `time_backoff`   | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s                               |
+| `newsletter_form`             | Store-API newsletter registration                                   | 6.4.16.0 | `time_backoff`   | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s                                 |
+| `cart_add_line_item`          | Adding line items to the cart                                       | 6.4.18.0 | `system_config`  | 1 hour   | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
+| `revocation_request_form`     | Store-API revocation request form                                   | 6.7.9.0  | `time_backoff`   | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s                                 |
+| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe                                    | 6.7.9.0  | `time_backoff`   | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s                                 |
+| `app_shop_verify`             | App shop registration verification                                  | 6.7.9.0  | `sliding_window` | n/a      | 60 / 60min                                                 |
+| `mcp_admin_api`               | MCP server Admin API access (keyed per OAuth token)                 | 6.8.0.0  | `time_backoff`   | 1 hour   | 300 / 60s, 1000 / 10min                                    |
+| `mcp_store_api`               | MCP server Store API access (keyed per sales-channel context token) | 6.8.0.0  | `time_backoff`   | 1 hour   | 120 / 60s, 600 / 10min                                     |
 
 In the table above, `Limits` uses the `limit / interval` notation, and `s` / `min` are seconds / minutes. When you add a new default limiter to the core, add a row here with its introduction version so this table stays complete.
 

--- a/guides/hosting/infrastructure/rate-limiter.md
+++ b/guides/hosting/infrastructure/rate-limiter.md
@@ -21,28 +21,24 @@ These rate limiters are always active. You do not need to add the `shopware.api.
 
 The following limiters are enabled by default. The values listed here reflect the current Shopware core configuration and may change between versions. When in doubt, the source of truth is `Shopware\Core\Framework\Resources\config\packages\shopware.yaml` in the version you are running.
 
-| Limiter | Protects | Policy | Reset | Limits |
-| --- | --- | --- | --- | --- |
-| `login` | Storefront / Store-API customer authentication. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `guest_login` | Storefront / Store-API after-order guest authentication. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `oauth` | API OAuth authentication / Administration login. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `reset_password` | Storefront / Store-API customer password reset. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `user_recovery` | Administration user password recovery. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `contact_form` | Storefront / Store-API contact form. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `revocation_request_form` | Store-API revocation request form. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `newsletter_form` | Store-API newsletter registration. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe. | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
-| `notification` | Store-API notification endpoint. | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
-| `cart_add_line_item` | Adding line items to the cart. | `system_config` | 1 hour | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
-| `mcp_admin_api` | MCP server Admin API access (keyed per OAuth token). | `time_backoff` | 1 hour | 300 / 60s, 1000 / 10min |
-| `mcp_store_api` | MCP server Store API access (keyed per sales-channel context token). | `time_backoff` | 1 hour | 120 / 60s, 600 / 10min |
-| `app_shop_verify` | App shop registration verification. | `sliding_window` | n/a | 60 / 60min |
+| Limiter | Protects | Since | Policy | Reset | Limits |
+| --- | --- | --- | --- | --- | --- |
+| `login` | Storefront / Store-API customer authentication. | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `guest_login` | Storefront / Store-API after-order guest authentication. | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `oauth` | API OAuth authentication / Administration login. | 6.4.6.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `reset_password` | Storefront / Store-API customer password reset. | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `user_recovery` | Administration user password recovery. | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `contact_form` | Storefront / Store-API contact form. | 6.4.6.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `notification` | Store-API notification endpoint. | 6.4.8.0 | `time_backoff` | 24 hours | 10 / 10s, 15 / 30s, 20 / 60s |
+| `newsletter_form` | Store-API newsletter registration. | 6.4.16.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `cart_add_line_item` | Adding line items to the cart. | 6.4.18.0 | `system_config` | 1 hour | Limit read from `core.cart.lineItemAddLimit`, interval 60s |
+| `revocation_request_form` | Store-API revocation request form. | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `newsletter_unsubscribe_form` | Store-API newsletter unsubscribe. | 6.7.9.0 | `time_backoff` | 24 hours | 3 / 30s, 5 / 60s, 10 / 90s |
+| `app_shop_verify` | App shop registration verification. | 6.7.9.0 | `sliding_window` | n/a | 60 / 60min |
+| `mcp_admin_api` | MCP server Admin API access (keyed per OAuth token). | 6.8.0.0 | `time_backoff` | 1 hour | 300 / 60s, 1000 / 10min |
+| `mcp_store_api` | MCP server Store API access (keyed per sales-channel context token). | 6.8.0.0 | `time_backoff` | 1 hour | 120 / 60s, 600 / 10min |
 
-In the table above, `Limits` uses the `limit / interval` notation, and `s` / `min` are seconds / minutes.
-
-::: info
-The `notification` limiter is available starting with Shopware 6.4.8.0. The `mcp_admin_api` and `mcp_store_api` limiters are available starting with Shopware 6.8.0.0.
-:::
+In the table above, `Limits` uses the `limit / interval` notation, and `s` / `min` are seconds / minutes. When you add a new default limiter to the core, add a row here with its introduction version so this table stays complete.
 
 ## Configuration
 

--- a/guides/hosting/infrastructure/rate-limiter.md
+++ b/guides/hosting/infrastructure/rate-limiter.md
@@ -55,8 +55,9 @@ To override the [default rate limiters](#default-rate-limiters) for your shop, y
 
 The following example disables the `login` limiter and overrides the `oauth` limiter:
 
-```yaml
-// <shop root>/config/packages/shopware.yml
+::: code-group
+
+```yaml [SHOP_ROOT/config/packages/shopware.yaml]
 shopware:
   api:
     rate_limiter:
@@ -73,6 +74,8 @@ shopware:
             interval: '60 seconds'
 ```
 
+:::
+
 ::: info
 The following optional limiters are available starting with Shopware 6.7.10.0.
 :::
@@ -88,8 +91,9 @@ The `time_backoff` policy is built by Shopware itself. It enables you to throttl
 Below you can find an example which throttles the request for 10 seconds after 3 requests and starting from 5 requests it always
 throttles for 60 seconds. If there are no more requests, it will be reset after 24 hours.
 
-```yaml
-// <plugin root>/src/Resources/config/rate_limiter.yaml
+::: code-group
+
+```yaml [PLUGIN_ROOT/src/Resources/config/rate_limiter.yaml]
 example_route:
     enabled: true
     policy: 'time_backoff'
@@ -100,3 +104,5 @@ example_route:
         - limit: 5
           interval: '60 seconds'
 ```
+
+:::


### PR DESCRIPTION
## What

Extends the Rate Limiter hosting guide with a complete overview of the rate limiters Shopware ships by default:

- New **Default rate limiters** table listing every core limiter with its `Since` version, policy, reset window, and limits.
- Clarifies in the Overview that these limiters are **always active** and that `shopware.yml` is only used to *override* the defaults, not to enable them.
- Reworks the Configuration section to make clear that the `rate_limiter` map is merged into the defaults, so you only configure the values you want to change.
- Removes the separate version info block, since the introduction version now lives in the table's `Since` column.

## Why

The page previously listed only 6 of the default limiters by name and never stated their actual values. This led to recurring questions about whether the rate limiter works at all without adding `shopware.api.rate_limiter` to `shopware.yml` (it does, the core ships the defaults). Documenting the concrete values and the "always active" behaviour answers this directly.

## Source of truth

Values were taken from `src/Core/Framework/Resources/config/packages/shopware.yaml`. Each `Since` version was verified against the release folder its changelog entry landed in (for older limiters) or the release tag the introducing commit first shipped in (for recent ones).

The table also notes that values can change between versions and points readers at the config file, and asks contributors to add a row whenever a new default limiter is introduced.
