### PR TITLE
docs: document environment variable config limitation

### DIFF
--- a/guides/hosting/configurations/index.md
+++ b/guides/hosting/configurations/index.md
@@ -54,7 +54,7 @@ bin/console config:dump-reference shopware
 
 Symfony environment variable placeholders, such as `%env(int:CART_EXPIRE_DAYS)%`, are resolved at runtime. They cannot be used for Shopware configuration options that enforce a positive minimum value while the service container is compiled. Symfony validates these options against an integer placeholder value of `0`, which fails the minimum-value constraint.
 
-The following options are affected:
+The following options are affected (depending on your Shopware version and its configuration constraints):
 
 - `shopware.filesystem.batch_write_size`
 - `shopware.sitemap.batchsize`

--- a/guides/hosting/configurations/index.md
+++ b/guides/hosting/configurations/index.md
@@ -41,3 +41,31 @@ If you want to aim at a specific environment, you can create a configuration fil
 ```
 
 For more information on environment-specific configurations, check out the [Symfony Configuration Environments](https://symfony.com/doc/current/configuration.html#configuration-environments) section.
+
+## Available options
+
+Use the following command to display all Shopware configuration options and their default values for your installed version:
+
+```bash
+bin/console config:dump-reference shopware
+```
+
+## Runtime environment variables
+
+Symfony environment variable placeholders, such as `%env(int:CART_EXPIRE_DAYS)%`, are resolved at runtime. They cannot be used for Shopware configuration options that enforce a positive minimum value while the service container is compiled. Symfony validates these options against an integer placeholder value of `0`, which fails the minimum-value constraint.
+
+The following options are affected:
+
+- `shopware.filesystem.batch_write_size`
+- `shopware.sitemap.batchsize`
+- `shopware.media.presigned_upload.expiration_minutes`
+- `shopware.dal.batch_size`
+- `shopware.dal.max_rule_prices`
+- `shopware.dal.versioning.expire_days`
+- `shopware.cart.expire_days`
+- `shopware.order.deep_link.expire_days`
+- `shopware.sales_channel_context.expire_days`
+- `shopware.product.search_keyword.relevant_keyword_count`
+- `shopware.mcp.app_tool_timeout`
+
+Configure these options with literal values in `config/packages/shopware.yaml` or an environment-specific configuration file instead of using `%env(...)%` placeholders.


### PR DESCRIPTION
## Summary

- document how to display the complete Shopware configuration reference
- explain why runtime environment variable placeholders cannot be used with positive-minimum configuration options
- list all currently affected Shopware options

## Related links

- shopware/shopware#18256

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

The affected option list is based on the positive minimum-value constraints in Shopware's current `Configuration.php`.
