### PR TITLE
feat: update PaaS Native quickstart to refer to the new project creat…

### DIFF
--- a/products/paas/shopware/get-started/quickstart.md
+++ b/products/paas/shopware/get-started/quickstart.md
@@ -30,7 +30,7 @@ Verify the installation:
 sw-paas version
 ```
 
-## Step 2: Create Your First Project and Connect Your Git Repository
+## Step 2: Create your first project and connect your Git repository
 
 Start the project creation wizard:
 
@@ -46,7 +46,7 @@ The wizard prompts you for the organization, project name, and Git repository. W
 
 Ensure the key has **read access** to the repository, then confirm in the wizard that you added the key. The CLI then completes the project creation.
 
-## Step 3: Create and deploy an Application Instance of the project
+## Step 3: Create and deploy an application instance of the project
 
 Create your application:
 

--- a/products/paas/shopware/get-started/quickstart.md
+++ b/products/paas/shopware/get-started/quickstart.md
@@ -30,48 +30,23 @@ Verify the installation:
 sw-paas version
 ```
 
-## Step 2: Connect Your Git Repository
+## Step 2: Create Your First Project and Connect Your Git Repository
 
-To connect your private git repository with our backend, you need to add an SSH key to your repository. This key is used to clone your repository and deploy your code to the cluster.
-
-### 2.1 Generate and Store SSH Key
-
-Run the following command to create an SSH key and store it securely in your organization's vault:
+Start the project creation wizard:
 
 ```sh
-sw-paas vault create --type ssh
+sw-paas project create
 ```
 
-This command will generate a new SSH key pair and store the private key securely.
-
-::: info
-Organization vs Project Level
-
-- **Organization level**: All projects can use the key
-- **Project level**: Only a specific project can use the key (add `--project` flag)
-
-Project-level keys override organization-level keys.
-:::
-
-### 2.2 Add Public Key to Repository
-
-After running the command, the CLI will display the generated public key. Copy this public key and add it to your repository settings:
+The wizard prompts you for the organization, project name, and Git repository. When asked whether to create a project SSH key for the repository, answer `y`. The CLI creates the key, displays its public key, and waits for you to add it to your repository settings:
 
 - **GitHub**: Go to `Settings` → `Deploy keys` → `Add deploy key`
 - **GitLab**: Go to `Settings` → `Repository` → `Deploy Keys`
 - **Bitbucket**: Go to `Repository settings` → `Access keys`
 
-Ensure the key has **read access** to the repository.
+Ensure the key has **read access** to the repository, then confirm in the wizard that you added the key. The CLI then completes the project creation.
 
-## Step 3: Create Your First Project
-
-Initialize a new PaaS project:
-
-```sh
-sw-paas project create --name "my-shopware-app" --repository "git@github.com:username/repo.git"
-```
-
-## Step 4: Create and deploy an Application Instance of the project
+## Step 3: Create and deploy an Application Instance of the project
 
 Create your application:
 


### PR DESCRIPTION
This pull request updates the onboarding flow in the Shopware PaaS quickstart guide to streamline the project creation and Git repository connection process. The steps for generating and managing SSH keys are now integrated into the project creation wizard, making the instructions clearer and more user-friendly.

**Improvements to onboarding flow:**

* Combined the steps for project creation and Git repository connection into a single wizard-driven process using the `sw-paas project create` command, eliminating the need for separate SSH key management commands.
* Updated instructions to guide users through the wizard prompts for organization, project name, and repository, including automated SSH key generation and public key handling.
* Removed redundant and manual steps for generating, storing, and assigning SSH keys, reducing complexity for new users.
* Clarified how to add the generated public key to repository settings on GitHub, GitLab, and Bitbucket, and streamlined confirmation and completion steps.
