### PR TITLE
Content-addressable asset building & Vite manifest generation section

### DIFF
--- a/guides/installation/advanced-options.md
+++ b/guides/installation/advanced-options.md
@@ -5,9 +5,26 @@ nav:
 
 ---
 
-# Advanced options
+# Advanced Options
 
 This section covers optional and advanced Docker configuration for Shopware projects. Refer to it once your local environment is running and you want to customize your setup, mirror production more closely, or support advanced workflows.
+
+## Installing into an existing directory
+
+If you already have a target directory, `cd` into it and run the `project create` command. When prompted for a project name, leave the field empty. The project will
+be scaffolded in the current directory:
+
+```bash
+cd /path/to/project
+shopware-cli project create
+```
+
+In non-interactive mode, omit the project name argument (or pass `.`) to
+achieve the same result:
+
+```bash
+shopware-cli project create --no-interaction
+```
 
 ## Customizing the runtime environment
 

--- a/guides/installation/index.md
+++ b/guides/installation/index.md
@@ -7,7 +7,7 @@ nav:
 # Shopware 6 Community Edition Installation
 
 :::info
-The recommended way for developers to build Shopware is with the Docker setup, made simple as of **March 2026** with a [Shopware CLI](../../products/tools/cli/index.md) installation path. Docker provides a consistent, production-like environment for development. Previous installation methods are available in the [Legacy Setups](./legacy-setups/index.md) section.
+The recommended way for developers to build Shopware is with the Docker setup, made simple with a [Shopware CLI](../../products/tools/cli/index.md) installation path. Docker provides a consistent, production-like environment for development. Previous installation methods are available in the [Legacy Setups](./legacy-setups/index.md) section.
 :::
 
 Welcome to the Installation Guide for Shopware 6 Community Edition (CE)! This guide will help you set up a local Shopware 6 development environment, whether you’re:
@@ -47,6 +47,8 @@ Alternatively, you can run the CLI without a separate installation via:
 ```bash
 npx @shopware-ag/shopware-cli project create my-shop
 ```
+
+If you already have a target directory, see [Installing into an existing directory](./advanced-options.md#installing-into-an-existing-directory).
 
 ### Select Shopware version
 

--- a/products/tools/cli/extension-commands/build.md
+++ b/products/tools/cli/extension-commands/build.md
@@ -65,7 +65,7 @@ Also `shopware-cli project ci` detects know automatically this bundle and builds
 Building with esbuild works completely standalone without the Shopware codebase. This means if you import files from Shopware, you have to copy it to your extension.
 :::
 
-esbuild can be used for JavaScript bundling, offering a significantly faster alternative to the standard Shopware bundling process, as it eliminates the need to involve Shopware for asset building.
+The `esbuild` bundler can be used for JavaScript bundling, offering a significantly faster alternative to the standard Shopware bundling process, as it eliminates the need to involve Shopware for asset building.
 
 ```yaml
 # .shopware-extension.yml

--- a/products/tools/cli/extension-commands/build.md
+++ b/products/tools/cli/extension-commands/build.md
@@ -81,14 +81,13 @@ build:
 ### Content-addressable assets and Vite manifest
 
 When building with esbuild, Shopware CLI emits content-hashed variants of the
-compiled JS and CSS files (e.g. `<name>-<hash>.js`) alongside the unhashed
-files, in the same directories.
+compiled JS and CSS files (e.g. `<name>-<hash>.js`) alongside files without hashes in the same directories.
 
 - **Shopware 6.7+**: The generated `.vite/manifest.json` and `.vite/entrypoints.json`
   reference the hashed filenames, so browser and CDN caches are invalidated
   automatically whenever the extension assets change. Note that an existing
   `.vite/manifest.json` is overwritten on each esbuild build.
-- **Shopware < 6.7**: The unhashed files are kept for backward compatibility and
+- **Shopware < 6.7**: The files without hashes are kept for backward compatibility and
   continue to be loaded as before.
 
 No configuration is required. This happens automatically when esbuild is enabled.

--- a/products/tools/cli/extension-commands/build.md
+++ b/products/tools/cli/extension-commands/build.md
@@ -44,7 +44,7 @@ build:
 
 ## Extension as bundle
 
-If your extension is not a plugin but itself a bundle, make sure your composer type is `shopware-bundle` and that you have set a `shopware-bundle-name` in the `extra` part of the Composer definition like this:
+If your extension is not a plugin but itself a bundle, make sure your Composer package type is `shopware-bundle` and that you have set a `shopware-bundle-name` in the `extra` part of the Composer definition like this:
 
 ```json
 {

--- a/products/tools/cli/extension-commands/build.md
+++ b/products/tools/cli/extension-commands/build.md
@@ -44,7 +44,7 @@ build:
 
 ## Extension as bundle
 
-If your extension is not a plugin but itself a bundle, make sure your composer type is `shopware-bundle` and that you have set a `shopware-bundle-name` in the `extra` part of the composer definition like this:
+If your extension is not a plugin but itself a bundle, make sure your composer type is `shopware-bundle` and that you have set a `shopware-bundle-name` in the `extra` part of the Composer definition like this:
 
 ```json
 {
@@ -65,7 +65,7 @@ Also `shopware-cli project ci` detects know automatically this bundle and builds
 Building with esbuild works completely standalone without the Shopware codebase. This means if you import files from Shopware, you have to copy it to your extension.
 :::
 
-Esbuild can be used for JavaScript bundling, offering a significantly faster alternative to the standard Shopware bundling process, as it eliminates the need to involve Shopware for asset building.
+esbuild can be used for JavaScript bundling, offering a significantly faster alternative to the standard Shopware bundling process, as it eliminates the need to involve Shopware for asset building.
 
 ```yaml
 # .shopware-extension.yml
@@ -77,6 +77,21 @@ build:
       # Use esbuild for Storefront
       enable_es_build_for_storefront: true
 ```
+
+### Content-addressable assets and Vite manifest
+
+When building with esbuild, Shopware CLI emits content-hashed variants of the
+compiled JS and CSS files (e.g. `<name>-<hash>.js`) alongside the unhashed
+files, in the same directories.
+
+- **Shopware 6.7+**: The generated `.vite/manifest.json` and `.vite/entrypoints.json`
+  reference the hashed filenames, so browser and CDN caches are invalidated
+  automatically whenever the extension assets change. Note that an existing
+  `.vite/manifest.json` is overwritten on each esbuild build.
+- **Shopware < 6.7**: The unhashed files are kept for backward compatibility and
+  continue to be loaded as before.
+
+No configuration is required. This happens automatically when esbuild is enabled.
 
 ## Creating an archive
 
@@ -90,9 +105,9 @@ The command copies the extension to a temporary directory, builds the assets, de
 
 **By default, the command picks the latest released git tag**, use the `--disable-git` flag to disable this behavior and use the current source code. Besides disabling it completely, you can also specify a specific tag or commit using `--git-commit`.
 
-### Bundling composer dependencies
+### Bundling Composer dependencies
 
-Before Shopware 6.5, bundling the composer dependencies into the zip file is required. Shopware CLI automatically runs `composer install` and removes duplicate composer dependencies to avoid conflicts.
+Before Shopware 6.5, bundling the Composer dependencies into the ZIP file is required. Shopware CLI automatically runs `composer install` and removes duplicate Composer dependencies to avoid conflicts.
 
 To disable this behavior, you can adjust the configuration:
 


### PR DESCRIPTION
## Summary

Adds a short section to the CLI docs about this new feature.

## Related links

https://github.com/shopware/shopware-cli/pull/1207

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
