### PR TITLE
docs: document plugin snackbar service

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1984,6 +1984,8 @@ slotConfig
 slowlog
 sm
 smartbar
+snackbar
+snackbars
 snakeCase
 sortings
 sourcemaps

--- a/guides/plugins/plugins/administration/data-handling-processing/the-shopware-object.md
+++ b/guides/plugins/plugins/administration/data-handling-processing/the-shopware-object.md
@@ -50,6 +50,26 @@ Module.register('your-module', {});
 
 Learn more about them here: [Creating administration module](../module-component-management/add-custom-module.md)
 
+## Display a snackbar
+
+Use the `snackbarService` for brief feedback in the Administration, such as confirming that a plugin action completed. It displays the message in the global Meteor snackbar.
+
+```javascript
+Shopware.Service('snackbarService').addSnackbar({
+    id: 'my-plugin-saved',
+    message: 'The settings have been saved.',
+    variant: 'info',
+});
+```
+
+To dismiss a snackbar before its duration expires, pass the same ID to `removeSnackbar()`:
+
+```javascript
+Shopware.Service('snackbarService').removeSnackbar('my-plugin-saved');
+```
+
+The snackbar service is separate from the legacy notification system. Continue using notifications when you need their title, actions, or system-notification behavior.
+
 ## A more general overview
 
 We now have discussed the most commonly used parts of the `Shopware` object, but there is much more to discover. Take a look at all these options in a brief overview below:

--- a/guides/plugins/plugins/administration/data-handling-processing/the-shopware-object.md
+++ b/guides/plugins/plugins/administration/data-handling-processing/the-shopware-object.md
@@ -50,26 +50,6 @@ Module.register('your-module', {});
 
 Learn more about them here: [Creating administration module](../module-component-management/add-custom-module.md)
 
-## Display a snackbar
-
-Use the `snackbarService` for brief feedback in the Administration, such as confirming that a plugin action completed. It displays the message in the global Meteor snackbar.
-
-```javascript
-Shopware.Service('snackbarService').addSnackbar({
-    id: 'my-plugin-saved',
-    message: 'The settings have been saved.',
-    variant: 'info',
-});
-```
-
-To dismiss a snackbar before its duration expires, pass the same ID to `removeSnackbar()`:
-
-```javascript
-Shopware.Service('snackbarService').removeSnackbar('my-plugin-saved');
-```
-
-The snackbar service is separate from the legacy notification system. Continue using notifications when you need their title, actions, or system-notification behavior.
-
 ## A more general overview
 
 We now have discussed the most commonly used parts of the `Shopware` object, but there is much more to discover. Take a look at all these options in a brief overview below:

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -42,3 +42,23 @@ Component.register('swag-basic-example', {
     }
 });
 ```
+
+## Using snackbars for brief feedback
+
+For brief feedback such as confirming that a plugin action completed, use the global Meteor snackbar instead of the notification mixin:
+
+```javascript
+Shopware.Service('snackbarService').addSnackbar({
+    id: 'my-plugin-saved',
+    message: 'The settings have been saved.',
+    variant: 'info',
+});
+```
+
+To dismiss a snackbar before its duration expires, pass the same ID to `removeSnackbar()`:
+
+```javascript
+Shopware.Service('snackbarService').removeSnackbar('my-plugin-saved');
+```
+
+The snackbar service is separate from the legacy notification system. Continue using the notification mixin when you need its title, actions, or system-notification behavior.

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -45,6 +45,10 @@ Component.register('swag-basic-example', {
 
 ## Using snackbars for brief feedback
 
+::: info
+The snackbar service is available from Shopware 6.7.14.0.
+:::
+
 For brief feedback such as confirming that a plugin action completed, use the global Meteor snackbar instead of the notification mixin:
 
 ```javascript

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -52,17 +52,16 @@ The snackbar service is available from Shopware 6.7.14.0.
 For brief feedback such as confirming that a plugin action completed, use the global Meteor snackbar instead of the notification mixin:
 
 ```javascript
-Shopware.Service('snackbarService').addSnackbar({
-    id: 'my-plugin-saved',
+const snackbar = Shopware.Service('snackbarService').addSnackbar({
     message: 'The settings have been saved.',
-    variant: 'info',
+    variant: 'success',
 });
 ```
 
-To dismiss a snackbar before its duration expires, pass the same ID to `removeSnackbar()`:
+To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
 
 ```javascript
-Shopware.Service('snackbarService').removeSnackbar('my-plugin-saved');
+Shopware.Service('snackbarService').removeSnackbar(snackbar.id);
 ```
 
 The snackbar service is separate from the legacy notification system. Continue using the notification mixin when you need its title, actions, or system-notification behavior.

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -64,4 +64,18 @@ To dismiss a snackbar before its duration expires, pass its generated ID to `rem
 Shopware.Service('snackbarService').removeSnackbar(snackbar.id);
 ```
 
+For Composition API extensions, use the `useSnackbar()` composable. It is experimental until Shopware 6.8.0 and requires the `ADMIN_COMPOSITION_API_EXTENSION_SYSTEM` feature flag:
+
+```javascript
+import useSnackbar from 'src/app/composables/use-snackbar';
+
+const { addSnackbar, removeSnackbar } = useSnackbar();
+const snackbar = addSnackbar({
+    message: 'The settings have been saved.',
+    variant: 'success',
+});
+
+removeSnackbar(snackbar.id);
+```
+
 The snackbar service is separate from the legacy notification system. Continue using the notification mixin when you need its title, actions, or system-notification behavior.

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -49,7 +49,7 @@ Component.register('swag-basic-example', {
 The snackbar service is available from Shopware 6.7.14.0.
 :::
 
-For brief feedback such as confirming that a plugin action completed, use the global Meteor snackbar instead of the notification mixin:
+For brief feedback such as confirming that a plugin action is completed, use the global Meteor snackbar instead of the notification mixin:
 
 ```javascript
 const snackbar = Shopware.Service('snackbarService').addSnackbar({

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -49,33 +49,16 @@ Component.register('swag-basic-example', {
 The snackbar service is available from Shopware 6.7.14.0.
 :::
 
-For brief feedback such as confirming that a plugin action is completed, use the global Meteor snackbar instead of the notification mixin:
+For brief feedback such as confirming that a plugin action is completed, use the global Meteor snackbar instead of the notification mixin. To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
 
 ```javascript
-const snackbar = Shopware.Service('snackbarService').addSnackbar({
-    message: 'The settings have been saved.',
-    variant: 'success',
-});
-```
-
-To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
-
-```javascript
-Shopware.Service('snackbarService').removeSnackbar(snackbar.id);
-```
-
-For Composition API extensions, use the `useSnackbar()` composable. It is experimental until Shopware 6.8.0 and requires the `ADMIN_COMPOSITION_API_EXTENSION_SYSTEM` feature flag:
-
-```javascript
-import useSnackbar from 'src/app/composables/use-snackbar';
-
-const { addSnackbar, removeSnackbar } = useSnackbar();
-const snackbar = addSnackbar({
+const snackbarService = Shopware.Service('snackbarService');
+const snackbar = snackbarService.addSnackbar({
     message: 'The settings have been saved.',
     variant: 'success',
 });
 
-removeSnackbar(snackbar.id);
+snackbarService.removeSnackbar(snackbar.id);
 ```
 
 The snackbar service is separate from the legacy notification system. Continue using the notification mixin when you need its title, actions, or system-notification behavior.

--- a/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
+++ b/guides/plugins/plugins/administration/mixins-directives/using-mixins.md
@@ -43,22 +43,4 @@ Component.register('swag-basic-example', {
 });
 ```
 
-## Using snackbars for brief feedback
-
-::: info
-The snackbar service is available from Shopware 6.7.14.0.
-:::
-
-For brief feedback such as confirming that a plugin action is completed, use the global Meteor snackbar instead of the notification mixin. To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
-
-```javascript
-const snackbarService = Shopware.Service('snackbarService');
-const snackbar = snackbarService.addSnackbar({
-    message: 'The settings have been saved.',
-    variant: 'success',
-});
-
-snackbarService.removeSnackbar(snackbar.id);
-```
-
-The snackbar service is separate from the legacy notification system. Continue using the notification mixin when you need its title, actions, or system-notification behavior.
+For guidance on choosing notifications or snackbars, see [Displaying user feedback](../services-utilities/displaying-user-feedback.md).

--- a/guides/plugins/plugins/administration/services-utilities/displaying-user-feedback.md
+++ b/guides/plugins/plugins/administration/services-utilities/displaying-user-feedback.md
@@ -51,5 +51,6 @@ const snackbar = snackbarService.addSnackbar({
     variant: 'success',
 });
 
+// when you want to remove it later
 snackbarService.removeSnackbar(snackbar.id);
 ```

--- a/guides/plugins/plugins/administration/services-utilities/displaying-user-feedback.md
+++ b/guides/plugins/plugins/administration/services-utilities/displaying-user-feedback.md
@@ -42,7 +42,7 @@ For more information about using mixins, see [Using Mixins](../mixins-directives
 The snackbar service is available from Shopware 6.7.14.0.
 :::
 
-Use the global Meteor snackbar for brief feedback, such as confirming that a plugin action completed. To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
+Use the global Meteor snackbar for brief feedback, such as confirming that a plugin action completed:
 
 ```javascript
 const snackbarService = Shopware.Service('snackbarService');
@@ -50,7 +50,10 @@ const snackbar = snackbarService.addSnackbar({
     message: 'The settings have been saved.',
     variant: 'success',
 });
+```
 
-// when you want to remove it later
+To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
+
+```javascript
 snackbarService.removeSnackbar(snackbar.id);
 ```

--- a/guides/plugins/plugins/administration/services-utilities/displaying-user-feedback.md
+++ b/guides/plugins/plugins/administration/services-utilities/displaying-user-feedback.md
@@ -1,0 +1,55 @@
+---
+nav:
+  title: Displaying User Feedback
+  position: 120
+
+---
+
+# Displaying user feedback
+
+Use notifications and snackbars to provide feedback after a plugin action. Choose the feedback mechanism based on how much information the user needs and whether they need to act on it.
+
+| Use | When to use it |
+| --- | --- |
+| Notification | The feedback needs a title, actions, or should be kept as a system notification. |
+| Snackbar | The feedback is a brief, non-blocking confirmation of a completed action. |
+
+## Notifications
+
+Use the notification mixin when the user needs more context or an action:
+
+```javascript
+const { Component, Mixin } = Shopware;
+
+Component.register('swag-basic-example', {
+    mixins: [
+        Mixin.getByName('notification'),
+    ],
+
+    methods: {
+        greet() {
+            this.createNotificationSuccess({ title: 'Settings saved' });
+        },
+    },
+});
+```
+
+For more information about using mixins, see [Using Mixins](../mixins-directives/using-mixins.md).
+
+## Snackbars
+
+::: info
+The snackbar service is available from Shopware 6.7.14.0.
+:::
+
+Use the global Meteor snackbar for brief feedback, such as confirming that a plugin action completed. To dismiss a snackbar before its duration expires, pass its generated ID to `removeSnackbar()`:
+
+```javascript
+const snackbarService = Shopware.Service('snackbarService');
+const snackbar = snackbarService.addSnackbar({
+    message: 'The settings have been saved.',
+    variant: 'success',
+});
+
+snackbarService.removeSnackbar(snackbar.id);
+```

--- a/guides/plugins/plugins/administration/services-utilities/index.md
+++ b/guides/plugins/plugins/administration/services-utilities/index.md
@@ -18,6 +18,7 @@ These guides covers how to create, extend, and use services and utility helpers 
 - [Add Custom Service](./add-custom-service)
 - [Injecting Services](./injecting-services)
 - [Extending Services](./extending-services)
+- [Displaying User Feedback](./displaying-user-feedback)
 - [Making API Requests](./making-api-requests)
 - [Add Filter](./add-filter)
 - [Using Filter](./using-filter)


### PR DESCRIPTION
## Summary

Documents `Shopware.Service('snackbarService')` for Administration plugins, including adding and removing a global Meteor snackbar and its distinction from legacy notifications.

## Related links

- Related implementation: https://github.com/shopware/shopware/pull/18579
- Related issue: https://github.com/shopware/shopware/issues/16176

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

The documentation PR should merge after the implementation PR.
