### PR TITLE
docs: correct Go version requirement for building from source

### DIFF
--- a/products/tools/cli/installation.md
+++ b/products/tools/cli/installation.md
@@ -171,7 +171,7 @@ docker run \
 
 ## Building from source
 
-If you prefer to compile the CLI yourself (requires Go 1.20+ and Git):
+If you prefer to compile the CLI yourself (requires Go 1.26.4+ and Git):
 
 ```bash
 git clone https://github.com/shopware/shopware-cli


### PR DESCRIPTION
## Summary

The **Building from source** section currently states that Go 1.20 or later is required, but the current `go.mod` in `shopware/shopware-cli` declares Go 1.26.4 as the minimum version.

Building with Go 1.20 fails while parsing `go.mod`, before dependencies can be resolved:

```text
go: errors parsing go.mod:
/src/go.mod:3: invalid go version '1.26.4': must match format 1.23
```

This change updates the documented requirement to match `go.mod`.

## Related links

* [`go.mod`, line 3](https://github.com/shopware/shopware-cli/blob/main/go.mod#L3)

## Checklist

* [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
* [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
* [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
* [ ] Any required dependent changes in downstream modules have already been merged and published.
* [x] This pull request is ready for review.

## Notes

I used “Go 1.26.4 or later” to match `go.mod` exactly. Writing “Go 1.26 or later” would also include versions 1.26.0 through 1.26.3, which do not satisfy the declared minimum.

Alternatively, the documentation could refer readers directly to the version declared in `go.mod` to avoid duplicating a value that may become outdated.
