### PR TITLE
add/translated-info

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1122,6 +1122,7 @@ Validator
 Valkey
 VariantListingConfigField
 Vercel
+Verkaufskanal
 VersionDataPayload
 VersionDataPayloadField
 VersionField

--- a/concepts/framework/data-abstraction-layer.md
+++ b/concepts/framework/data-abstraction-layer.md
@@ -72,6 +72,8 @@ This serves as a final fallback to ensure only one label for the entity in the e
 The translations for a record are stored in a separate table.
 The name of this table is always the same as the table for which the records are translated, with the additional suffix `_translation`.
 
+On read, every translatable property is exposed twice: as the plain field for the current language (which may be `null`) and under `translated` with inheritance applied. Prefer `translated` in storefront and sales-channel contexts; use the plain field in Admin/CRUD flows where you need to know what is stored for that language. See [Plain vs translated entity fields](translations/plain-vs-translated-fields.md).
+
 ### Versioning
 
 Another feature that the DAL offers is versioning.

--- a/concepts/framework/translations/index.md
+++ b/concepts/framework/translations/index.md
@@ -10,6 +10,8 @@ nav:
 Shopware 6 is a multilingual platform that supports multiple languages and locales. This section provides an overview of
 how translations are managed in Shopware 6.
 
+<PageRef page="./plain-vs-translated-fields" title="Plain vs translated entity fields" />
+
 <PageRef page="./built-in-translation-system" title="Built-in Translation Handling" />
 
 <PageRef page="./fallback-language-selection" title="Fallback language selection" />

--- a/concepts/framework/translations/plain-vs-translated-fields.md
+++ b/concepts/framework/translations/plain-vs-translated-fields.md
@@ -1,0 +1,124 @@
+---
+nav:
+  title: Plain vs translated entity fields
+  position: 20
+
+---
+
+# Plain vs translated entity fields
+
+When you read translatable entity data—via the DAL (`EntityRepository`), the Admin API, the Store API, or Twig templates (storefront, documents, mail)—you can access a field in two ways:
+
+* `salesChannel.name` — the **plain** value for the current language of the context
+* `salesChannel.translated.name` — the **resolved** value after language inheritance
+
+The same pattern applies to every translatable field (`product.name`, `category.description`, custom fields on the `translated` object, and so on).
+
+## Why both exist
+
+The Data Abstraction Layer is built for Shopware’s CRUD-style Admin API and Administration UI. Editors need to see **what is actually stored for the language they are editing**, including empty overrides, versus **what the customer would see** after fallbacks.
+
+| Access                    | Meaning                                                                                                        |
+|---------------------------|----------------------------------------------------------------------------------------------------------------|
+| `entity.field`            | Value stored for the **current context language** only. May be `null` if that language has no own translation. |
+| `entity.translated.field` | Value after walking the language inheritance chain. Prefer this whenever you need a displayable string.        |
+
+## Inheritance example
+
+Assume this language chain:
+
+```text
+EN (root) → DE → AT
+```
+
+And these stored names for a sales channel:
+
+| Language | Stored `name`        |
+|----------|----------------------|
+| EN       | `SalesChannel`       |
+| DE       | `Verkaufskanal`      |
+| AT       | *(not set / `null`)* |
+
+### Austrian context (`AT` inherits from `DE`)
+
+| Access                         | Result          | Reason              |
+|--------------------------------|-----------------|---------------------|
+| `salesChannel.name`            | `null`          | AT has no own value |
+| `salesChannel.translated.name` | `Verkaufskanal` | Falls back to DE    |
+
+### Austrian context when DE is also empty
+
+If DE is also `null`:
+
+| Access                         | Result                   |
+|--------------------------------|--------------------------|
+| `salesChannel.name`            | `null`                   |
+| `salesChannel.translated.name` | `SalesChannel` (EN root) |
+
+### German context (`DE`)
+
+| Access                         | Result          |
+|--------------------------------|-----------------|
+| `salesChannel.name`            | `Verkaufskanal` |
+| `salesChannel.translated.name` | `Verkaufskanal` |
+
+When the current language has its own translation, plain and translated values are the same.
+
+The DAL resolves up to three language levels when reading: current language, optional parent language, then system language. See [Data Abstraction Layer — Translations](../data-abstraction-layer.md#translations).
+
+## Which variant to use
+
+### Prefer `translated` (default for display)
+
+Use `entity.translated.field` in almost every **consumer** or **sales-channel** context:
+
+* Storefront Twig templates
+* Document and mail templates (including merchant-edited ones)
+* Store API clients and headless storefronts
+* PHP code that runs in a sales-channel / storefront context and only needs a value to show or send
+
+In these contexts you almost always want a resolved label, never an empty field that only exists because the current language inherits from another.
+
+```twig
+{# Storefront / mail / document — always prefer translated #}
+{{ salesChannel.translated.name }}
+{{ product.translated.name }}
+{{ product.translated.customFields.my_field }}
+```
+
+```php
+// Sales-channel / storefront PHP — prefer the translated value
+$name = $salesChannel->getTranslation('name'); // resolved via inheritance
+// Not: $salesChannel->getName(); // plain value for the current language only (may be null)
+```
+
+### Prefer plain `field` (Admin / editing)
+
+Use `entity.field` when you must know **whether this language has its own value**:
+
+* Administration forms and listings that edit translations per language
+* Admin API integrations that write or diff language-specific payloads
+* Logic that decides “override vs inherit” for a given language
+
+There, `null` is meaningful: it means “not set in this language; inherit from the parent language.”
+
+```js
+// Admin / CRUD: plain field shows the language-specific stored value
+salesChannel.name; // may be null while translated.name is filled
+salesChannel.translated.name; // resolved preview for the same row
+```
+
+## API responses
+
+Both Admin API and Store API entity payloads expose the plain fields and a nested `translated` object. Selecting the language (for example with the [`sw-language-id`](../../../guides/development/integrations-api/request-headers.md#sw-language-id) header) changes which language the plain fields refer to; `translated` still applies inheritance for missing values.
+
+::: tip
+When building storefronts or integrations that only **display** data, always read from `translated`. Relying on the plain field leads to empty labels for inherited languages.
+:::
+
+## Related guides
+
+* [Data Abstraction Layer — Translations](../data-abstraction-layer.md#translations)
+* [Adding data translations](../../../guides/plugins/plugins/framework/data-handling/add-data-translations.md)
+* [Field inheritance](../../../guides/plugins/plugins/framework/data-handling/field-inheritance.md) (parent–child entity inheritance, including translated fields)
+* [Request headers — `sw-language-id`](../../../guides/development/integrations-api/request-headers.md#sw-language-id)

--- a/concepts/framework/translations/plain-vs-translated-fields.md
+++ b/concepts/framework/translations/plain-vs-translated-fields.md
@@ -16,7 +16,7 @@ The same pattern applies to every translatable field (`product.name`, `category.
 
 ## Why both exist
 
-The Data Abstraction Layer is built for Shopware’s CRUD-style Admin API and Administration UI. Editors need to see **what is actually stored for the language they are editing**, including empty overrides, versus **what the customer would see** after fallbacks.
+The Data Abstraction Layer is built for Shopware’s CRUD-style Admin API and Administration UI. Editors need to see **what is actually stored for the language they are editing**, including empty overrides, versus **what the customer would see** after fallbacks. The following table summarizes what each variant means.
 
 | Access                    | Meaning                                                                                                        |
 |---------------------------|----------------------------------------------------------------------------------------------------------------|

--- a/guides/development/integrations-api/request-headers.md
+++ b/guides/development/integrations-api/request-headers.md
@@ -19,9 +19,9 @@ POST /api/search/product
 ```
 
 ::: info
-Shopware only populates a translatable field if there is an explicit translation for that field. Instead, the `translated` object always contains values, with fallbacks if necessary.
+Shopware only populates a translatable field if there is an explicit translation for that field. The nested `translated` object always contains values, with language inheritance applied when necessary.
 
-**Example:** You instruct Shopware to fetch the French translation of a product using the `sw-language-id` header, but there's no French translation for the product's name. The resulting field `product.name` will be `null`. When building applications, always use `product.translated.[value]` to access translated values, ensuring you always get a valid translation or a fallback value.
+**Example:** You instruct Shopware to fetch the French translation of a product using the `sw-language-id` header, but there's no French translation for the product's name. The resulting field `product.name` will be `null`. When building storefronts or other display-only clients, always use `product.translated.[value]` so you get a resolved translation or fallback. Prefer the plain field only in Admin/CRUD flows where you need the language-specific stored value. See [Plain vs translated entity fields](../../../concepts/framework/translations/plain-vs-translated-fields.md).
 :::
 
 ## sw-version-id

--- a/guides/plugins/plugins/framework/data-handling/add-data-translations.md
+++ b/guides/plugins/plugins/framework/data-handling/add-data-translations.md
@@ -11,6 +11,8 @@ nav:
 
 In this guide you'll learn how to add translations to entities.
 
+When reading translated data later, prefer `entity.translated.field` in storefront and sales-channel contexts, and use the plain `entity.field` in Admin/CRUD flows where you need the value stored for the current language. See [Plain vs translated entity fields](../../../../../concepts/framework/translations/plain-vs-translated-fields.md).
+
 ## Prerequisites
 
 This guide is built upon the [Plugin base guide](../../plugin-base-guide), but any plugin will work here. Just note that all examples are using the plugin mentioned above.


### PR DESCRIPTION
This pull request improves the documentation around Shopware's translation handling by clarifying the difference between plain and translated entity fields, and by introducing a new dedicated guide on this topic. The changes help developers understand when to use each field variant in different contexts, reducing confusion and improving best practices for multilingual data handling.

**Documentation improvements for translation handling:**

* Added a new guide, `plain-vs-translated-fields.md`, explaining the difference between plain and translated fields, with examples and recommendations for when to use each variant.
* Updated existing documentation (`data-abstraction-layer.md`, `add-data-translations.md`, and `request-headers.md`) to reference the new guide and clarify that `translated` fields should be preferred in storefront/sales-channel contexts, while plain fields are for Admin/CRUD flows. [[1]](diffhunk://#diff-ec533957e4dca9b00a5986844d850e53e3528d10987277130d4488f1c9c18675R75-R76) [[2]](diffhunk://#diff-3df9b6823892bf2f8c3b7f7079c8c40f379a2daabc5170b4a62c50157663bff8R14-R15) [[3]](diffhunk://#diff-1b5415eaf85192fbe8f964fbc54777a099839a89153cc32b4feeb59db2916813L22-R24)
* Added navigation entries to include the new guide in the translations documentation section.

**Wordlist update:**

* Added the term `Verkaufskanal` to `.wordlist.txt` to support proper spellchecking and recognition in documentation.## Summary

<!-- Describe the documentation change in a few sentences or bullet points. -->

## Related links

[[<!-- Link related issues, pull requests, commits, or source references. -->](https://github.com/shopware/docs/issues/2200)
](https://github.com/shopware/docs/issues/2200)

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
