### PR TITLE
feat: announce support for mysql 8.4 in paas native

### DIFF
--- a/products/paas/shopware/fundamentals/application-yaml.md
+++ b/products/paas/shopware/fundamentals/application-yaml.md
@@ -116,13 +116,15 @@ For more details, see the [Environment variables](./environment-variables.md) pa
 
 ### `services.mysql`
 
-Configures the managed MySQL database.
+Configures the managed MySQL database. Shopware PaaS Native supports MySQL versions `8.0` and `8.4`.
 
 ```yaml
 services:
   mysql:
-    version: "8.0"
+    version: "8.4"
 ```
+
+Once MySQL `8.4` has been configured, downgrading to MySQL `8.0` is not possible.
 
 ### `services.opensearch`
 


### PR DESCRIPTION
## Summary

Document support for MySQL 8.4 for PaaS Native.

## Related links

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
