### PR TITLE
Mark native Vue systems experimental, remove roadmap timelines

### DIFF
--- a/guides/plugins/plugins/administration/module-component-management/customizing-components.md
+++ b/guides/plugins/plugins/administration/module-component-management/customizing-components.md
@@ -227,6 +227,10 @@ import './sw-dashboard-index-override/';
 
 ## Experimental: Composition API extension system
 
+:::warning
+The Composition API extension system is **experimental**. Its API can still change, and there is no committed timeline or release version for when it will become the standard.
+:::
+
 Shopware 6 is introducing a new way to extend components using the Composition API. This system is currently in an experimental state and is needed for the future migration of components from the Options API to the Composition API.
 
 ### Current status and future plans

--- a/guides/upgrades-migrations/administration/vue-native.md
+++ b/guides/upgrades-migrations/administration/vue-native.md
@@ -8,7 +8,7 @@ nav:
 
 :::info
 This article was updated. It previously described the migration as a fixed roadmap tied to specific Shopware versions.
-Those version-based timelines have been removed, because the new systems are still experimental and no release version is committed yet.
+Those version-based timelines have been removed because the new systems are still experimental and no release version is committed yet.
 The article now describes the direction of the migration rather than when each step will happen.
 :::
 
@@ -66,7 +66,7 @@ Our transition to a more native Vue.js approach is driven by several key factors
 
 #### Why Make This Change?
 
-We aim to better align with Vue's ecosystem, to minimize the amount of specifications new Developers need to learn.
+We aim to better align with Vue's ecosystem to minimize the number of specifications new Developers need to learn.
 The Composition API has become the new standard for Vue documentation and projects across GitHub.
 Renowned libraries like `vue-i18n` are dropping support of the Options API, as seen in their [migration guide](https://vue-i18n.intlify.dev/guide/migration/vue3#summary), and we expect similar transitions from other tools in the ecosystem.
 This also aligns with Vue's best practices, as highlighted in the official [Composition API FAQ](https://vuejs.org/guide/extras/composition-api-faq.html#why-composition-api).
@@ -103,10 +103,10 @@ We will gradually transform all component templates from external `*.html.twig` 
 
 The following table shows the current status of both systems and the direction they are heading in:
 
-| System                      | Status today | Long-term direction                                                             |
-|-----------------------------|--------------|----------------------------------------------------------------------------------|
-| Twig.js blocks              | Standard     | Will be deprecated and removed once the migration to native blocks is complete   |
-| Native blocks (`sw-block`)  | Experimental | Will become the standard for core components and extensions                      |
+| System                     | Status today | Long-term direction                                                            |
+|----------------------------|--------------|--------------------------------------------------------------------------------|
+| Twig.js blocks             | Standard     | Will be deprecated and removed once the migration to native blocks is complete |
+| Native blocks (`sw-block`) | Experimental | Will become the standard for core components and extensions                    |
 
 ### 3. Vuex to Pinia
 
@@ -146,13 +146,13 @@ Shopware.Component.register('sw-text-field', {
  <input type=text v-model="value" @change="onChange">
  {% endblock %}
  `,
-   
+
    data() {
        return {
            value: null,
  }
  },
-   
+
    methods: {
        onChange() {
            this.$emit('update:value', this.value);
@@ -170,11 +170,11 @@ Shopware.Component.override('sw-text-field', {
    template: `
  {% block sw-text-field %}
  {% parent %}
-       
+
  {{ helpText }}
  {% endblock %}
  `,
-   
+
    props: {
        helpText: {
            type: String,
@@ -262,7 +262,7 @@ For overrides, we created a new convention. They must match the `*.override.vue`
 {# Notice the native block components #}
 <sw-block extends="sw-text-field">
  <sw-block-parent/>
-   
+
  {{ helpText}}
 </sw-block>
 </template>

--- a/guides/upgrades-migrations/administration/vue-native.md
+++ b/guides/upgrades-migrations/administration/vue-native.md
@@ -15,13 +15,12 @@ The article now describes the direction of the migration rather than when each s
 :::warning
 The Composition API extension system and the native block system (`sw-block`) described in this article are **experimental**.
 Their APIs can still change, and there is no committed timeline or release version for when they will become the standard.
-This document serves as a general guideline for our development direction.
 :::
 
 ## Introduction
 
 We are planning a significant shift in our development approach, moving towards a more native Vue.js implementation.
-This document outlines the reasons for this change and provides an overview of the migration path.
+This document outlines the reasons for this change and provides an overview of the migration path. It serves as a general guideline for our development direction.
 
 ## Current status
 
@@ -79,6 +78,8 @@ The transformation will happen gradually to give all of us enough time to adapt.
 
 #### Migration Path
 
+The following table shows the current status of both systems and the direction they are heading in:
+
 | System                           | Status today | Long-term direction                                                                  |
 |----------------------------------|--------------|--------------------------------------------------------------------------------------|
 | Options API                      | Standard     | Will be deprecated and removed once the migration to the Composition API is complete |
@@ -99,6 +100,8 @@ Standard tooling like VSCode, ESLint, and Prettier will work out of the box.
 We will gradually transform all component templates from external `*.html.twig` files with Twig.js into `.vue` files using the native block implementation.
 
 #### Migration Path
+
+The following table shows the current status of both systems and the direction they are heading in:
 
 | System                      | Status today | Long-term direction                                                             |
 |-----------------------------|--------------|----------------------------------------------------------------------------------|

--- a/guides/upgrades-migrations/administration/vue-native.md
+++ b/guides/upgrades-migrations/administration/vue-native.md
@@ -4,17 +4,24 @@ nav:
   position: 15
 ---
 
-# Future Development Roadmap: Moving Towards Vue Native
+# Moving Towards Native Vue
 
 :::info
-The information provided in this article, including timelines and specific implementations, is subject to change.
+This article was updated. It previously described the migration as a fixed roadmap tied to specific Shopware versions.
+Those version-based timelines have been removed, because the new systems are still experimental and no release version is committed yet.
+The article now describes the direction of the migration rather than when each step will happen.
+:::
+
+:::warning
+The Composition API extension system and the native block system (`sw-block`) described in this article are **experimental**.
+Their APIs can still change, and there is no committed timeline or release version for when they will become the standard.
 This document serves as a general guideline for our development direction.
 :::
 
 ## Introduction
 
 We are planning a significant shift in our development approach, moving towards a more native Vue.js implementation.
-This document outlines the reasons for this change and provides an overview of our upgrade path.
+This document outlines the reasons for this change and provides an overview of the migration path.
 
 ## Current status
 
@@ -68,17 +75,14 @@ This also aligns with Vue's best practices, as highlighted in the official [Comp
 #### What Will Change?
 
 We will gradually transform our components from Options API to Composition API. Together with native blocks, this lays the foundation for using Single File Components (SFCs).
-The transformation will be spread across multiple major versions to give all of us enough time to adapt. Take a look at the estimated timeline below.
+The transformation will happen gradually to give all of us enough time to adapt. Breaking changes, like removing the Options API, will only happen in a future major version. There is no committed timeline or release version for this transition.
 
-#### Upgrade Path
+#### Migration Path
 
-| Shopware Version | Options API                     | Composition API              |
-|:----------------:|---------------------------------|------------------------------|
-|       6.7        | Standard                        | Experimental                 |
-|       6.8        | Still supported for extensions* | Standard for Core components |
-|       6.9        | Removed completely              | Standard                     |
-
-*Extensions still can register components using the Options API; overwriting Core components needs the Composition API.
+| System                           | Status today | Long-term direction                                                                  |
+|----------------------------------|--------------|--------------------------------------------------------------------------------------|
+| Options API                      | Standard     | Will be deprecated and removed once the migration to the Composition API is complete |
+| Composition API extension system | Experimental | Will become the standard for core components and extensions                          |
 
 ### 2. TwigJS to Native Blocks
 
@@ -94,15 +98,12 @@ Standard tooling like VSCode, ESLint, and Prettier will work out of the box.
 
 We will gradually transform all component templates from external `*.html.twig` files with Twig.js into `.vue` files using the native block implementation.
 
-#### Upgrade Path
+#### Migration Path
 
-| Shopware Version | Twig.Js                         | Native blocks                |
-|:----------------:|---------------------------------|------------------------------|
-|       6.7        | Standard                        | Experimental                 |
-|       6.8        | Still supported for extensions* | Standard for Core components |
-|       6.9        | Removed completely              | Standard                     |
-
-*Extensions still can register components using Twig.js templates; overwriting Core blocks needs the native block implementation.
+| System                      | Status today | Long-term direction                                                             |
+|-----------------------------|--------------|----------------------------------------------------------------------------------|
+| Twig.js blocks              | Standard     | Will be deprecated and removed once the migration to native blocks is complete   |
+| Native blocks (`sw-block`)  | Experimental | Will become the standard for core components and extensions                      |
 
 ### 3. Vuex to Pinia
 
@@ -127,9 +128,9 @@ We will move all core Vuex states to Pinia stores. The public API will change fr
 
 Now let's take a look at how core and extension components will evolve.
 
-### Shopware 6.7
+### Today: The stable extension system
 
-First, we start with the current status, which is still compatible with Shopware 6.7.
+First, we start with the current status: components are registered with the Options API and use Twig.js templates.
 
 #### Core component
 
@@ -196,9 +197,13 @@ Shopware.Component.register('your-crazy-ai-field', {
 })
 ```
 
-### Shopware 6.8
+### Experimental: The native extension system
 
-In Shopware 6.8, the core uses single-file components with the Composition API.
+:::warning
+The APIs shown in this example are experimental and can still change.
+:::
+
+Once components are migrated, the core will use single-file components with the Composition API. You can already try out this system today as an experimental feature.
 
 #### Core component
 
@@ -290,15 +295,15 @@ Shopware.Component.register('your-crazy-ai-field', {
 })
 ```
 
-### Shopware 6.9
+### Long-term direction
 
-The only difference for 6.9 is that you can no longer register new components via `Shopware.Component.register`.
+Once the migration is complete and the new systems have left the experimental state, registering components via `Shopware.Component.register` with the Options API or Twig.js templates will no longer be possible. This will only happen in a future major version.
 
 ## FAQ
 
-**Will existing extensions built with the Options API continue to work in Shopware 6.8?**
+**Will existing extensions built with the Options API continue to work?**
 
-When you only use `Shopware.Component.register`, yes. If you also use `Shopware.Component.extend/ override, you need to use the composition API extension approach for that.
+When you only use `Shopware.Component.register`, yes. If you use `Shopware.Component.extend`/`Shopware.Component.override` on components that have been migrated to the Composition API, you need to use the Composition API extension approach for those.
 
 **How can I prepare my development team for the transition to Composition API?**
 
@@ -310,11 +315,11 @@ It works with native Vue.js components; therefore, it is compatible with default
 
 **Can I mix Composition API and Options API components during the transition period?**
 
-Yes, as long as you stick to the limitations from the upgrade paths.
+Yes, as long as you stick to the limitations from the migration paths above.
 
 **How will the migration from Twig.js templates to .vue files affect my existing component overrides?**
 
-You need to migrate all your overrides with Shopware 6.8.
+You will need to migrate your overrides to the native block implementation once the components you are overriding have been migrated to `.vue` files.
 
 **What tools or resources will be available to help migrate existing components?**
 
@@ -328,13 +333,13 @@ During our tests, we didn't experience any performance issues.
 
 It has built-in TypeScript support.
 
-**What happens to existing extensions using Twig.js templates after version 6.9?**
+**What happens to existing extensions using Twig.js templates once the migration is complete?**
 
-They will stop working with Shopware version 6.9.
+They will stop working once Twig.js support is removed. This will only happen in a future major version.
 
-**Can I start using the native blocks and Composition API in my extensions before version 6.8?**
+**Can I already use the native blocks and Composition API in my extensions today?**
 
-Yes! You can add new components using SFC and native blocks. But you can't extend core components using the old systems or vice versa.
+Yes! Both systems are available as experimental features. You can add new components using SFC and native blocks. But you can't extend core components using the old systems or vice versa. Keep in mind that experimental APIs can still change.
 
 **Which extensions are affected by these changes?**
 


### PR DESCRIPTION
## Why

Resolves shopware/shopware#18986.

The [Native Vue documentation](https://developer.shopware.com/docs/guides/upgrades-migrations/administration/vue-native.html) described the move to the Composition API and native blocks as a fixed roadmap tied to concrete Shopware versions (6.7 / 6.8 / 6.9). Those timings are no longer accurate. This PR makes sure that:

- the docs no longer promise a timeline or specific release versions for the Composition API extension system and the native block system, and
- both systems are clearly marked as **experimental** wherever they are documented.

## What changed

**`guides/upgrades-migrations/administration/vue-native.md`**
- Retitled from "Future Development Roadmap: Moving Towards Vue Native" to "Moving Towards Native Vue".
- Replaced the `6.7 / 6.8 / 6.9` upgrade-path tables with state-based "Migration Path" tables (*Status today* vs. *Long-term direction*). The direction is kept, but no version or date is attached to it.
- Renamed the version-named example sections ("Shopware 6.8", "Shopware 6.9") to state-based sections ("Today: The stable extension system", "Experimental: The native extension system", "Long-term direction"). All code examples are preserved.
- Rewrote the FAQ answers that referenced specific versions.
- Added an `:::info` note explaining the update (so returning readers know why the roadmap is gone) and a `:::warning` calling out the experimental status.
- The Vuex → Pinia section is intentionally left unchanged — it is out of scope for this issue.

**`guides/plugins/plugins/administration/module-component-management/customizing-components.md`**
- Added an `:::warning` callout under the "Experimental: Composition API extension system" heading.

## Notes / out of scope

- The related ADRs (`2023-02-27-native-extension-system-with-vue`, `2024-09-26-native-block-system`) are mirrored automatically from `shopware/shopware` and were left untouched — their info box already signals they are point-in-time decision records.
- Markdown lint passes for both changed files.
