### PR TITLE
docs: stop recommending updateDestructive for plugins

### DIFF
--- a/concepts/framework/migrations.md
+++ b/concepts/framework/migrations.md
@@ -7,7 +7,7 @@ nav:
 
 # Migrations
 
-Migrations are PHP classes containing database schema changesets. These changesets can be applied or reverted to bring the database into a certain state. You might know the concept of migrations from other Frameworks or Symfony as well.
+Migrations are PHP classes containing database schema changesets. You might know the concept of migrations from other frameworks or Symfony as well.
 
 ## Adding migrations to a plugin
 
@@ -17,6 +17,12 @@ Each migration filename follows a specific pattern. To ease plugin development, 
 
 ## Modifying the database
 
-Each migration can have two methods. The `update` and `updateDestructive`. The `update` method must contain only non-destructive changes which can be rolled back at any time. The `updateDestructive` method can contain destructive changes, like dropping columns or tables, which cannot be reversed. For examples of database migrations, refer to the below guide:
+Each migration implements an `update()` method. That is where you put schema and data changes for your plugin. On plugin install and update, Shopware runs `update()` for every new migration once. There is no automatic rollback of migrations; remove plugin data in the plugin lifecycle `uninstall` method when appropriate.
+
+::: info
+Shopware core migrations also define an optional `updateDestructive()` method for delayed destructive changes across major versions. Plugin install and update never execute it, and it is not useful for plugin development. See the [Database migration](../../guides/plugins/plugins/database/database-migrations) guide for the full plugin workflow.
+:::
+
+For examples of database migrations, refer to the guide below:
 
 <PageRef page="../../guides/plugins/plugins/database/database-migrations" title="Database migration" />

--- a/guides/development/testing/unit/php-unit.md
+++ b/guides/development/testing/unit/php-unit.md
@@ -156,10 +156,6 @@ class Migration1611740369ExampleDescriptionTest extends TestCase
         $migration->update($conn);
         $actualSchema = $conn->fetchAssoc('SHOW CREATE TABLE `swag_basic_example_general_settings`')['Create Table'];
         static::assertSame($expectedSchema, $actualSchema, 'Schema changed!. Run init again to have clean state');
-
-        $migration->updateDestructive($conn);
-        $actualSchema = $conn->fetchAssoc('SHOW CREATE TABLE `swag_basic_example_general_settings`')['Create Table'];
-        static::assertSame($expectedSchema, $actualSchema, 'Schema changed!. Run init again to have clean state');
  }
 
     public function testNoTable(): void

--- a/guides/plugins/plugins/checkout/cart/tax-provider.md
+++ b/guides/plugins/plugins/checkout/cart/tax-provider.md
@@ -146,10 +146,6 @@ class MigrationTaxProvider extends MigrationStep
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }
 ```
 

--- a/guides/plugins/plugins/checkout/document/add-custom-document-type.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document-type.md
@@ -60,10 +60,6 @@ class Migration1616677952AddDocumentType extends MigrationStep
         $this->addDocumentBaseConfig($connection, $documentTypeId);
     }
 
-    public function updateDestructive(Connection $connection): void
-    {
-    }
-
     private function addTranslations(Connection $connection, string $documentTypeId): void
     {
         $englishName = 'Example document type name';
@@ -465,10 +461,6 @@ class Migration1616974646AddDocumentNumberRange extends MigrationStep
         $this->insertNumberRange($connection, $numberRangeId, $numberRangeTypeId);
         $this->insertTranslations($connection, $numberRangeId, $numberRangeTypeId);
 
-    }
-
-    public function updateDestructive(Connection $connection): void
-    {
     }
 
     private function insertNumberRange(Connection $connection, string $numberRangeId, string $numberRangeTypeId): void

--- a/guides/plugins/plugins/checkout/document/add-custom-document.md
+++ b/guides/plugins/plugins/checkout/document/add-custom-document.md
@@ -75,10 +75,6 @@ class Migration1616668698AddDocument extends MigrationStep
         ]);
     }
 
-    public function updateDestructive(Connection $connection): void
-    {
-    }
-
     private function getDocumentTypeId(Connection $connection): string
     {
         $sql = <<<SQL

--- a/guides/plugins/plugins/content/mail/add-mail-template.md
+++ b/guides/plugins/plugins/content/mail/add-mail-template.md
@@ -61,10 +61,6 @@ class Migration1616418675AddMailTemplate extends MigrationStep
         $this->createMailTemplate($connection, $mailTemplateTypeId);
     }
 
-    public function updateDestructive(Connection $connection): void
-    {
-    }
-
     private function getMailTemplateTypeId(Connection $connection): string
     {
         $sql = <<<SQL

--- a/guides/plugins/plugins/content/seo/add-custom-seo-url.md
+++ b/guides/plugins/plugins/content/seo/add-custom-seo-url.md
@@ -103,10 +103,6 @@ class Migration1619094740AddStaticSeoUrl extends MigrationStep
         ), $connection);
     }
 
-    public function updateDestructive(Connection $connection): void
-    {
-    }
-
     private function getSeoMetaArray(Connection $connection): array
     {
         return [
@@ -401,10 +397,6 @@ class Migration1619514731AddExampleSeoUrlTemplate extends MigrationStep
             'template' => ExamplePageSeoUrlRoute::DEFAULT_TEMPLATE,
             'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
-    }
-
-    public function updateDestructive(Connection $connection): void
-    {
     }
 }
 ```

--- a/guides/plugins/plugins/database/database-migrations.md
+++ b/guides/plugins/plugins/database/database-migrations.md
@@ -7,7 +7,7 @@ nav:
 
 # Database Migrations
 
-Migrations are PHP classes used to manage incremental and reversible database schema changes. Shopware comes with a pre-built migration system to take away most of the work for you. Throughout this guide, you will find the `$` symbol representing your command line.
+Migrations are PHP classes used to manage incremental database schema changes. Shopware comes with a pre-built migration system to take away most of the work for you. Throughout this guide, you will find the `$` symbol representing your command line.
 
 ## Prerequisites
 
@@ -68,6 +68,9 @@ namespace Swag\BasicExample\Migration;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
+/**
+ * @internal
+ */
 class Migration1611740369ExampleDescription extends MigrationStep
 {
     public function getCreationTimestamp(): int
@@ -79,27 +82,25 @@ class Migration1611740369ExampleDescription extends MigrationStep
     {
         // implement update
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-        // implement update destructive
-    }
 }
 ```
 
-As you can see, your migration contains three methods:
+As you can see, your migration contains two methods:
 
 * `getCreationTimestamp()`
 * `update()`
-* `updateDestructive()`
 
-There is no need to change `getCreationTimestamp()`, it returns the timestamp that's also part of the file name. In the `update()` method you implement non-destructive changes which should always be **reversible**. The `updateDestructive()` method is the follow-up step, that is run after `update()` and used for **destructive non-reversible changes**, like dropping columns or tables. Destructive migrations are only executed explicitly.
+There is no need to change `getCreationTimestamp()`, it returns the timestamp that's also part of the file name. Implement **all** schema and data changes for the plugin in `update()`. That method is what Shopware runs automatically when the plugin is installed or updated.
 
 ::: info
-You do not add instructions to revert your migrations within the migration class itself. `updateDestructive` is not meant to revert instructions in `update`. Reverting changes in the database is done explicitly in plugin lifecycle method `uninstall`, as explained in the [Plugin Lifecycle guide](../plugin-fundamentals/plugin-lifecycle.md#uninstall).
+There is no migration rollback. You do not add instructions to reverse your migrations inside the migration class. Cleaning up the database when the plugin is removed belongs in the plugin lifecycle method `uninstall`, as explained in the [Plugin Lifecycle guide](../plugin-fundamentals/plugin-lifecycle.md#uninstall).
 :::
 
-Here's an example of a non-destructive migration, creating a new table:
+::: warning
+`MigrationStep` also defines an optional `updateDestructive()` method. Shopware core uses it for delayed, major-version destructive changes. **Plugin install and update never run `updateDestructive()`.** In practice, merchants and platforms also do not run `database:migrate-destructive` for plugins. Put every change your plugin needs into `update()`, and handle uninstall cleanup in `uninstall()`.
+:::
+
+Here's an example of a migration creating a new table:
 
 ```php
 // <plugin root>/src/Migration/Migration1611740369ExampleDescription.php
@@ -110,6 +111,9 @@ namespace Swag\BasicExample\Migration;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
+/**
+ * @internal
+ */
 class Migration1611740369ExampleDescription extends MigrationStep
 {
     public function getCreationTimestamp(): int
@@ -131,10 +135,6 @@ CREATE TABLE IF NOT EXISTS `swag_basic_example_general_settings` (
 SQL;
 
         $connection->executeStatement($query);
-    }
-
-    public function updateDestructive(Connection $connection): void
-    {
     }
 }
 ```
@@ -158,22 +158,21 @@ _Note: Your plugin has to be activated, otherwise your custom entity definition 
 
 ## Execute migration
 
-When you install your plugin, the migration directory is added to a MigrationCollection and all migrations are executed. Also, when you update a plugin via the Plugin Manager, all **new** migrations are executed. If you want to perform a migration manually as part of your development process, simply create it after installing your plugin. This way, your plugin migration directory will already be registered during the installation process and you can run any newly created migration by hand using one of the following commands.
+When you install your plugin, the migration directory is added to a MigrationCollection and all migrations' `update()` methods are executed. Also, when you update a plugin via the Plugin Manager, all **new** migrations are executed the same way. If you want to perform a migration manually as part of your development process, simply create it after installing your plugin. This way, your plugin migration directory will already be registered during the installation process and you can run any newly created migration by hand:
+
+```bash
+$ ./bin/console database:migrate SwagBasicExample --all
+```
 
 ::: warning
 When updating a plugin, do not change a migration that was already executed, since every migration is only run once.
 :::
 
-| Command                      | Arguments               | Usage                                                           |
-|:-----------------------------|:------------------------|:----------------------------------------------------------------|
-| database:migrate             | identifier \(optional\) | Calls the update\(\) methods of unhandled migrations            |
-| database:migrate-destructive | identifier \(optional\) | Calls the updateDestructive\(\) methods of unhandled migrations |
+| Command          | Arguments               | Usage                                                |
+|:-----------------|:------------------------|:-----------------------------------------------------|
+| database:migrate | identifier \(optional\) | Calls the `update()` methods of unhandled migrations |
 
-The identifier argument is used to decide which migrations should be executed. Per default, the identifier is set to run Shopware Core migrations. To run your plugin migrations, set the identifier argument to your plugin's bundle name, in this example `SwagBasicExample`.
-
-```bash
-$ ./bin/console database:migrate SwagBasicExample --all
-```
+The identifier argument decides which migrations should be executed. Per default, the identifier is set to run Shopware Core migrations. To run your plugin migrations, set the identifier argument to your plugin's bundle name, in this example `SwagBasicExample`.
 
 ## Advanced migration control
 
@@ -187,9 +186,6 @@ Therefore, a typical update method might look more like this:
         $updateContext->setAutoMigrate(false); // disable auto migration execution
 
         $migrationCollection = $updateContext->getMigrationCollection();
-
-        // execute all DESTRUCTIVE migrations until and including 2019-11-01T00:00:00+00:00
-        $migrationCollection->migrateDestructiveInPlace(1572566400);
 
         // execute all UPDATE migrations until and including 2019-12-12T09:30:51+00:00
         $migrationCollection->migrateInPlace(1576143014);

--- a/guides/plugins/plugins/framework/data-handling/add-complex-data-to-existing-entities.md
+++ b/guides/plugins/plugins/framework/data-handling/add-complex-data-to-existing-entities.md
@@ -238,10 +238,6 @@ CREATE TABLE IF NOT EXISTS `swag_example_extension` (
 SQL;
         $connection->executeStatement($sql);
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }
 ```
 

--- a/guides/plugins/plugins/framework/data-handling/add-custom-complex-data.md
+++ b/guides/plugins/plugins/framework/data-handling/add-custom-complex-data.md
@@ -59,10 +59,6 @@ CREATE TABLE IF NOT EXISTS `swag_example` (
 SQL;
         $connection->executeStatement($sql);
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }
 ```
 

--- a/guides/plugins/plugins/framework/data-handling/add-data-translations.md
+++ b/guides/plugins/plugins/framework/data-handling/add-data-translations.md
@@ -83,10 +83,6 @@ CREATE TABLE IF NOT EXISTS `swag_example_translation` (
 SQL;
         $connection->executeStatement($query);
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }
 ```
 

--- a/guides/plugins/plugins/framework/data-handling/field-inheritance.md
+++ b/guides/plugins/plugins/framework/data-handling/field-inheritance.md
@@ -65,10 +65,6 @@ class Migration1615363012MakeInheritedColumnsNullable extends MigrationStep
         
         $connection->executeStatement($query);
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }
 ```
 
@@ -283,7 +279,6 @@ class Migration1615363013AddInheritedAssociation extends MigrationStep
         
         $this->updateInheritance($connection, 'swag_example', 'tax');
     }
-
 }
 ```
 

--- a/guides/plugins/plugins/storefront/howto/add-custom-sorting-product-listing.md
+++ b/guides/plugins/plugins/storefront/howto/add-custom-sorting-product-listing.md
@@ -86,10 +86,6 @@ class Migration1615470599ExampleSorting extends MigrationStep
             ]
         );
     }
-
-    public function updateDestructive(Connection $connection): void
-    {
-    }
 }
 ```
 


### PR DESCRIPTION
## Summary

- Align plugin migration docs with Shopware core behavior: plugin install and update only run `update()`, never `updateDestructive()`.
- Advise plugin authors to put all needed schema/data changes in `update()` and clean up in `uninstall()`; treat `updateDestructive()` as core-only and not useful for plugins.
- Remove empty `updateDestructive()` stubs from plugin guide examples, drop `database:migrate-destructive` / manual destructive examples from the plugin migration guide, and simplify the related migration unit test sample.

## Related links

- Validated against `shopware/shopware` trunk (`MigrationStep`, `MigrationRuntime`, `PluginLifecycleService::runMigrations()`).

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

- Core coding guideline `resources/guidelines/code/core/database-migations.md` was left unchanged (synced from core; still correct for platform migrations).
- Redirects and wordlist: no pages moved/renamed; no new terms introduced.
- Draft until review; checklist item for ready-for-review left unchecked on purpose.