### PR TITLE
fix: disable markdown check for script references

### DIFF
--- a/.github/workflows/markdown-style-check.yml
+++ b/.github/workflows/markdown-style-check.yml
@@ -25,5 +25,5 @@ jobs:
       with:
         config: 'markdown-style-config.yml'
         args: './'
-        ignore: './resources/references/adr/* ./assets/adr/* ./resources/guidelines/code/core/* ./snippets/guide/*'
+        ignore: './resources/references/adr/* ./assets/adr/* ./resources/guidelines/code/core/* ./snippets/guide/* ./resources/references/app-reference/script-reference/*'
       continue-on-error: false

--- a/resources/guidelines/code/core/ci-workflows.md
+++ b/resources/guidelines/code/core/ci-workflows.md
@@ -92,7 +92,7 @@ skipped job is visible in the UI, a suppressed failure is not.
   one audit at a time; the remaining audits are disabled there and report a few
   hundred findings between them, so enabling one is its own piece of work.
 - zizmor cannot parse a workflow whose `strategy:` is a dynamic
-  <code v-pre>${{ fromJson(...) }}<code> matrix, and it *warns and exits 0* rather than failing —
+  <code v-pre>${{ fromJson(...) }}</code> matrix, and it *warns and exits 0* rather than failing —
   an unparsed file is an unaudited file. `zizmor-collection-guard.ts` reconciles
   those warnings against a known list so a new one fails the lint, and so a
   listed file that starts parsing again is reported as a stale entry.


### PR DESCRIPTION
## Summary

<!-- Describe the documentation change in a few sentences or bullet points. -->

## Related links

<!-- Link related issues, pull requests, commits, or source references. -->

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
