### PR TITLE
chore: adds to CLI extension Store release page

### DIFF
--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -46,13 +46,13 @@ shopware-cli account producer extension release <name> --version <version>  # do
 Two things are worth keeping in mind:
 
 - **A first submission is not covered by this.** The automatic code review gates *versions* of an extension that is already listed. A brand-new extension additionally goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store review and quality](../../../../guides/development/testing/store/index.md).
-- **Approval is per version, and the automatic review is not the full review.** A version that passes the automatic code review can still be rejected later on manual-review grounds. See [Validating the zip](../validation.md) for what the automated checks do and do not cover.
+- **Approval is per version, and the automatic review is not the full review.** A version that passes the automatic code review can still be rejected later on manual-review grounds. See the [Validation guide](../validation.md) for what the automated checks do and do not cover.
 
 You can verify the state at any time in your Shopware Account under the extension's version overview, which shows the version status, the analyses that ran (basic extension analysis, code quality analysis), and the most recent review result.
 
 ## Waiting for the review result in CI
 
-By default, the command waits 10 seconds and then polls the review result up to 10 times with a 15-second interval (roughly two and a half minutes in total). If the review has not finished by then, the command logs `Skipping waiting for code review result as it took too long` and exits **successfully**—a green pipeline therefore does not by itself prove that the review passed. Check the result in the Account, or poll it in a later job.
+By default, the command waits 10 seconds and then polls the review result up to 10 times with a 15-second interval (roughly two and a half minutes in total). If the review has not finished by then, the command logs `Skipping waiting for code review result as it took too long` and exits successfully. A green pipeline does not by itself prove that the review passed. Check the result in the Account, or poll it in a later job.
 
 Use `--skip-for-review-result` to return immediately after triggering the review, for pipelines that report the outcome separately:
 

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -26,7 +26,7 @@ The upload process:
 
 1. Reads name and version: Both are taken from the zip file, so the extension must already exist in your producer account
 2. Creates or reuses the version: Creates a new binary for that version, or updates the existing binary if that version was already uploaded and is not published yet
-3. Pushes metadata: Sends the German and English changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
+3. Pushes metadata: Sends the changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
 4. Uploads the package: Sends your zip file to the Shopware Store
 5. Triggers the automatic code review and waits for its result (may take several minutes)
 6. Reports results: Shows whether the code review passed, passed with warnings, or failed

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -48,7 +48,7 @@ After the automatic review completes, check the version status in your Shopware 
 Two things are worth keeping in mind:
 
 - A first submission requires additional review. A brand-new extension also goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store Review and Quality guide](../../../../guides/development/testing/store/index.md).
-- The automatic review is not the full Store review. Passing the automatic code review does not guarantee final Store approval. See the [Validation guide](../validation.md) for what the automated checks do and do not cover. 
+- The automatic review is not the full Store review. Passing the automatic code review does not guarantee final Store approval. See the [Validation guide](../validation.md) for what the automated checks do and do not cover.
 
 You can verify the state at any time in your Shopware Account under the extension's version overview, which shows the version status, the analyses that ran (basic extension analysis, code quality analysis), and the most recent review result.
 

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -33,7 +33,7 @@ The upload process:
 
 If the code review fails, the command exits with an error. Fix the issues and upload again.
 
-If a version is already published in the Store, its binary can no longer be replaced. The command detects this, logs `Binary version is already published. Skipping upload`, and exits successfully. Upload a new version instead.
+If a version is already published in the Store, its binary can no longer be replaced. The command detects this, logs a message indicating the binary/version is already published and skips the upload, and exits successfully. Upload a new version instead.
 
 ## What happens after the upload
 

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -40,7 +40,7 @@ If a version is already published in the Store, its binary can no longer be repl
 This workflow does not require a separate CLI release, publish, or approve step. The `upload` command submits the extension version, triggers the automatic code review, and waits for its result by default, unless waiting is skipped with `--skip-for-review-result`.
 
 ```bash
-shopware-cli account producer extension release <name> --version <version>  # does not exist
+shopware-cli account producer extension release <name> --version <version>
 ```
 
 After the automatic review completes, check the version status in your Shopware Account to see whether any further approval or publication steps remain.

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -1,11 +1,11 @@
 ---
 nav:
-  title: Releasing Automated Extension to Shopware Store
+  title: Automatically Release an Extension to the Shopware Store
   position: 2
 
 ---
 
-# Releasing Automated Extension to Shopware Store
+# Automatically Release an Extension to the Shopware Store
 
 ## Prerequisites
 
@@ -37,16 +37,18 @@ If a version is already published in the Store, its binary can no longer be repl
 
 ## What happens after the upload
 
-There is no separate release, publish, or approve command—`upload` is the release. Once the automatic code review passes, the version status in your Shopware Account switches to **Approved** and the version becomes available to customers. Nothing has to be flipped manually in the Account afterwards, and the CLI has no follow-up step:
+There is no separate release, publish, or approve command in Shopware CLI. The `upload` command submits the extension version, triggers the automatic code review, and waits for its result by default, unless waiting is skipped with `--skip-for-review-result`.
 
 ```bash
-shopware-cli account producer extension release <name> --version <version>  # does not exist, not needed
+shopware-cli account producer extension release <name> --version <version>  # does not exist
 ```
+
+After the automatic review completes, check the version status in your Shopware Account to see whether any further approval or publication steps remain.
 
 Two things are worth keeping in mind:
 
-- **A first submission is not covered by this.** The automatic code review gates *versions* of an extension that is already listed. A brand-new extension additionally goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store review and quality](../../../../guides/development/testing/store/index.md).
-- **Approval is per version, and the automatic review is not the full review.** A version that passes the automatic code review can still be rejected later on manual-review grounds. See the [Validation guide](../validation.md) for what the automated checks do and do not cover.
+- A first submission requires additional review. A brand-new extension also goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store review and quality](../../../../guides/development/testing/store/index.md).
+- The automatic review is not the full Store review. Passing the automatic code review does not guarantee final Store approval. See the [Validation guide](../validation.md) for what the automated checks do and do not cover. 
 
 You can verify the state at any time in your Shopware Account under the extension's version overview, which shows the version status, the analyses that ran (basic extension analysis, code quality analysis), and the most recent review result.
 

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -26,7 +26,7 @@ The upload process:
 
 1. Reads name and version: Both are taken from the zip file, so the extension must already exist in your producer account
 2. Creates or reuses the version: Creates a new binary for that version, or updates the existing binary if that version was already uploaded and is not published yet
-3. Pushes metadata: Sends the changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
+3. Pushes metadata: Sends the German and English changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
 4. Uploads the package: Sends your zip file to the Shopware Store
 5. Triggers the automatic code review and waits for its result (may take several minutes)
 6. Reports results: Shows whether the code review passed, passed with warnings, or failed
@@ -38,6 +38,10 @@ If a version is already published in the Store, its binary can no longer be repl
 ## What happens after the upload
 
 This workflow does not require a separate CLI release, publish, or approve step. The `upload` command submits the extension version, triggers the automatic code review, and waits for its result by default, unless waiting is skipped with `--skip-for-review-result`.
+
+```bash
+shopware-cli account producer extension release <name> --version <version>  # does not exist
+```
 
 After the automatic review completes, check the version status in your Shopware Account to see whether any further approval or publication steps remain.
 

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -9,14 +9,14 @@ nav:
 
 ## Prerequisites
 
-- You are logged into the Shopware Store. Checkout the [Authentication](./authentication.md) guide for more information.
-- You have a zip file of your extensions with all assets. Checkout the [Creating a zip](../extension-commands/build.md) guide for more information.
-- The zip file contains a `CHANGELOG*.md` file with a Changelog entry for the new version. Having a German changelog is optional.
-- You have validated the zip file with `shopware-cli extension validate <zip-path>`. See [Validating the zip](../validation.md) for more information.
+- You are logged into the Shopware Store. Check out the [Authentication](./authentication.md) guide for more information.
+- You have a zip file of your extension with all assets. Check out the [Building Extensions and Creating Archives](../extension-commands/build.md) guide for more information.
+- The zip file contains a `CHANGELOG*.md` file with a changelog entry for the new version. Having a German changelog is optional.
+- You have validated the zip file with `shopware-cli extension validate <zip-path>`. See the [Validation](../validation.md) guide for more information.
 
 ## Releasing the extension
 
-To release the extension to the Shopware Store, upload the ZIP file using the `shopware-cli account producer extension upload` command. This is primarily designed for CI/CD pipelines to automate extension releases:
+To release the extension to the Shopware Store, upload the zip file using the `shopware-cli account producer extension upload` command. This is primarily designed for CI/CD pipelines to automate extension releases:
 
 ```bash
 shopware-cli account producer extension upload <zip-path>
@@ -24,10 +24,10 @@ shopware-cli account producer extension upload <zip-path>
 
 The upload process:
 
-1. Reads name and version: Both are taken from the ZIP file, so the extension must already exist in your producer account
+1. Reads name and version: Both are taken from the zip file, so the extension must already exist in your producer account
 2. Creates or reuses the version: Creates a new binary for that version, or updates the existing binary if that version was already uploaded and is not published yet
 3. Pushes metadata: Sends the German and English changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
-4. Uploads the package: Sends your ZIP file to the Shopware Store
+4. Uploads the package: Sends your zip file to the Shopware Store
 5. Triggers the automatic code review and waits for its result (may take several minutes)
 6. Reports results: Shows whether the code review passed, passed with warnings, or failed
 
@@ -37,7 +37,7 @@ If a version is already published in the Store, its binary can no longer be repl
 
 ## What happens after the upload
 
-There is no separate release, publish, or approve command in Shopware CLI. The `upload` command submits the extension version, triggers the automatic code review, and waits for its result by default, unless waiting is skipped with `--skip-for-review-result`.
+This workflow does not require a separate CLI release, publish, or approve step. The `upload` command submits the extension version, triggers the automatic code review, and waits for its result by default, unless waiting is skipped with `--skip-for-review-result`.
 
 ```bash
 shopware-cli account producer extension release <name> --version <version>  # does not exist
@@ -54,7 +54,7 @@ You can verify the state at any time in your Shopware Account under the extensio
 
 ## Waiting for the review result in CI
 
-By default, the command waits 10 seconds and then polls the review result up to 10 times with a 15-second interval (roughly two and a half minutes in total). If the review has not finished by then, the command logs `Skipping waiting for code review result as it took too long` and exits successfully. A green pipeline does not by itself prove that the review passed. Check the result in the Account, or poll it in a later job.
+By default, the command waits 10 seconds and then polls the review result up to 10 times with a 15-second interval (roughly two and a half minutes in total). If the review has not finished by then, the command logs `Skipping waiting for code review result as it took too long` and exits successfully. A green pipeline does not by itself prove that the review passed. Check the result in the Account, or handle the review result separately in your CI/CD workflow.
 
 Use `--skip-for-review-result` to return immediately after triggering the review, for pipelines that report the outcome separately:
 
@@ -62,4 +62,4 @@ Use `--skip-for-review-result` to return immediately after triggering the review
 shopware-cli account producer extension upload <zip-path> --skip-for-review-result
 ```
 
-This workflow means you don't need to use the Shopware Store Admin UI for releasing a version—your CI/CD pipeline can handle the entire process automatically.
+This workflow lets you automate uploading an extension version and triggering its automatic code review from your CI/CD pipeline. Check the version status in your Shopware Account for any remaining review or publication steps.

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -26,7 +26,7 @@ The upload process:
 
 1. Reads name and version: Both are taken from the zip file, so the extension must already exist in your producer account
 2. Creates or reuses the version: Creates a new binary for that version, or updates the existing binary if that version was already uploaded and is not published yet
-3. Pushes metadata: Sends the German and English changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
+3. Pushes metadata: Sends the changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
 4. Uploads the package: Sends your zip file to the Shopware Store
 5. Triggers the automatic code review and waits for its result (may take several minutes)
 6. Reports results: Shows whether the code review passed, passed with warnings, or failed
@@ -38,10 +38,6 @@ If a version is already published in the Store, its binary can no longer be repl
 ## What happens after the upload
 
 This workflow does not require a separate CLI release, publish, or approve step. The `upload` command submits the extension version, triggers the automatic code review, and waits for its result by default, unless waiting is skipped with `--skip-for-review-result`.
-
-```bash
-shopware-cli account producer extension release <name> --version <version>  # does not exist
-```
 
 After the automatic review completes, check the version status in your Shopware Account to see whether any further approval or publication steps remain.
 

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -1,11 +1,11 @@
 ---
 nav:
-  title: Releasing automated extension to Shopware Store
+  title: Releasing Automated Extension to Shopware Store
   position: 2
 
 ---
 
-# Releasing automated extension to Shopware Store
+# Releasing Automated Extension to Shopware Store
 
 ## Prerequisites
 
@@ -24,12 +24,40 @@ shopware-cli account producer extension upload <zip-path>
 
 The upload process:
 
-1. Checks for existing version: Verifies no extension with the same version already exists in the store
-2. Uploads the package: Sends your ZIP file to the Shopware Store
-3. Determines compatibility: Uses the Composer constraint from `composer.json` or `manifest.xml`
-4. Waits for code review: The command automatically waits for the Store's automatic code review to complete (may take several minutes)
-5. Reports results: Shows whether the code review passed or failed
+1. Reads name and version: Both are taken from the ZIP file, so the extension must already exist in your producer account
+2. Creates or reuses the version: Creates a new binary for that version, or updates the existing binary if that version was already uploaded and is not published yet
+3. Pushes metadata: Sends the German and English changelog entries and the list of compatible Shopware versions, derived from the Composer constraint in `composer.json` or `manifest.xml`
+4. Uploads the package: Sends your ZIP file to the Shopware Store
+5. Triggers the automatic code review and waits for its result (may take several minutes)
+6. Reports results: Shows whether the code review passed, passed with warnings, or failed
 
-If the code review fails, fix the issues and upload again. You can skip waiting for the review result with the `--skip-for-review-result` option if needed for CI/CD workflows that handle results separately.
+If the code review fails, the command exits with an error. Fix the issues and upload again.
 
-This workflow means you don't need to use the Shopware Store Admin UI at all—your CI/CD pipeline can handle the entire release process automatically.
+If a version is already published in the Store, its binary can no longer be replaced. The command detects this, logs `Binary version is already published. Skipping upload`, and exits successfully. Upload a new version instead.
+
+## What happens after the upload
+
+There is no separate release, publish, or approve command—`upload` is the release. Once the automatic code review passes, the version status in your Shopware Account switches to **Approved** and the version becomes available to customers. Nothing has to be flipped manually in the Account afterwards, and the CLI has no follow-up step:
+
+```bash
+shopware-cli account producer extension release <name> --version <version>  # does not exist, not needed
+```
+
+Two things are worth keeping in mind:
+
+- **A first submission is not covered by this.** The automatic code review gates *versions* of an extension that is already listed. A brand-new extension additionally goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store review and quality](../../../../guides/development/testing/store/index.md).
+- **Approval is per version, and the automatic review is not the full review.** A version that passes the automatic code review can still be rejected later on manual-review grounds. See [Validating the zip](../validation.md) for what the automated checks do and do not cover.
+
+You can verify the state at any time in your Shopware Account under the extension's version overview, which shows the version status, the analyses that ran (basic extension analysis, code quality analysis), and the most recent review result.
+
+## Waiting for the review result in CI
+
+By default, the command waits 10 seconds and then polls the review result up to 10 times with a 15-second interval (roughly two and a half minutes in total). If the review has not finished by then, the command logs `Skipping waiting for code review result as it took too long` and exits **successfully**—a green pipeline therefore does not by itself prove that the review passed. Check the result in the Account, or poll it in a later job.
+
+Use `--skip-for-review-result` to return immediately after triggering the review, for pipelines that report the outcome separately:
+
+```bash
+shopware-cli account producer extension upload <zip-path> --skip-for-review-result
+```
+
+This workflow means you don't need to use the Shopware Store Admin UI for releasing a version—your CI/CD pipeline can handle the entire process automatically.

--- a/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
+++ b/products/tools/cli/shopware-account-commands/releasing-extension-to-shopware-store.md
@@ -9,10 +9,10 @@ nav:
 
 ## Prerequisites
 
-- You are logged into the Shopware Store. Check out the [Authentication](./authentication.md) guide for more information.
-- You have a zip file of your extension with all assets. Check out the [Building Extensions and Creating Archives](../extension-commands/build.md) guide for more information.
+- You are logged into the Shopware Store. Check out the [Authentication guide](./authentication.md) for more information.
+- You have a zip file of your extension with all assets. Check out the [Building Extensions and Creating Archives guide](../extension-commands/build.md) for more information.
 - The zip file contains a `CHANGELOG*.md` file with a changelog entry for the new version. Having a German changelog is optional.
-- You have validated the zip file with `shopware-cli extension validate <zip-path>`. See the [Validation](../validation.md) guide for more information.
+- You have validated the zip file with `shopware-cli extension validate <zip-path>`. See the [Validation guide](../validation.md) for more information.
 
 ## Releasing the extension
 
@@ -47,7 +47,7 @@ After the automatic review completes, check the version status in your Shopware 
 
 Two things are worth keeping in mind:
 
-- A first submission requires additional review. A brand-new extension also goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store review and quality](../../../../guides/development/testing/store/index.md).
+- A first submission requires additional review. A brand-new extension also goes through Shopware's functional test and manual code review before it appears in the Store. See [Shopware Store Review and Quality guide](../../../../guides/development/testing/store/index.md).
 - The automatic review is not the full Store review. Passing the automatic code review does not guarantee final Store approval. See the [Validation guide](../validation.md) for what the automated checks do and do not cover. 
 
 You can verify the state at any time in your Shopware Account under the extension's version overview, which shows the version status, the analyses that ran (basic extension analysis, code quality analysis), and the most recent review result.


### PR DESCRIPTION
## Summary

Gives more details to this CLI docs page.

## Related links

Closes https://github.com/shopware/shopware-cli/issues/1259.

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
