### PR TITLE
fix(paas-native): add php supported versions

### DIFF
--- a/products/paas/shopware/fundamentals/application-yaml.md
+++ b/products/paas/shopware/fundamentals/application-yaml.md
@@ -72,6 +72,14 @@ app:
     version: "8.3"
 ```
 
+#### PHP supported versions:
+
+- `8.1`
+- `8.2`
+- `8.3`
+- `8.4`
+- `8.5`
+
 ### `app.php.extensions`
 
 The PHP extensions to install during build time. We use [this](https://github.com/mlocati/docker-php-extension-installer) installer to install extensions.
@@ -116,7 +124,7 @@ For more details, see the [Environment variables](./environment-variables.md) pa
 
 ### `services.mysql`
 
-Configures the managed MySQL database. Shopware PaaS Native supports MySQL versions `8.0` and `8.4`.
+Configures the managed MySQL database. 
 
 ```yaml
 services:
@@ -124,7 +132,14 @@ services:
     version: "8.4"
 ```
 
+#### MySQL supported versions:
+
+- `8.0`
+- `8.4`
+
+::: warning
 Once MySQL `8.4` has been configured, downgrading to MySQL `8.0` is not possible.
+:::
 
 ### `services.opensearch`
 

--- a/products/paas/shopware/fundamentals/application-yaml.md
+++ b/products/paas/shopware/fundamentals/application-yaml.md
@@ -74,7 +74,6 @@ app:
 
 #### PHP supported versions
 
-- `8.1`
 - `8.2`
 - `8.3`
 - `8.4`

--- a/products/paas/shopware/fundamentals/application-yaml.md
+++ b/products/paas/shopware/fundamentals/application-yaml.md
@@ -72,7 +72,7 @@ app:
     version: "8.3"
 ```
 
-#### PHP supported versions:
+#### PHP supported versions
 
 - `8.1`
 - `8.2`
@@ -124,7 +124,7 @@ For more details, see the [Environment variables](./environment-variables.md) pa
 
 ### `services.mysql`
 
-Configures the managed MySQL database. 
+Configures the managed MySQL database.
 
 ```yaml
 services:
@@ -132,7 +132,7 @@ services:
     version: "8.4"
 ```
 
-#### MySQL supported versions:
+#### MySQL supported versions
 
 - `8.0`
 - `8.4`


### PR DESCRIPTION
## Summary

- Add supported PHP versions for PaaS Native
- Fix styling for MySQL supported versions

## Related links

- [List](https://github.com/shopware/paas-backend/blob/main/internal/application/domain/shop.go#L88) of supported versions

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [ ] This pull request is ready for review.

## Notes

