### PR TITLE
docs: configuration of update hints

### DIFF
--- a/products/tools/cli/configuration.md
+++ b/products/tools/cli/configuration.md
@@ -7,8 +7,7 @@ nav:
 
 # Configuration
 
-You can configure Shopware CLI to match your workflow. This page explains how to customize CLI behavior using command flags and
-environment variables.
+You can configure Shopware CLI to match your workflow. This page explains how to customize CLI behavior using command flags and environment variables.
 
 ## Update notifications
 

--- a/products/tools/cli/configuration.md
+++ b/products/tools/cli/configuration.md
@@ -1,0 +1,31 @@
+---
+nav:
+  title: Configuration
+  position: 30
+
+---
+
+# Configuration
+
+You can configure Shopware CLI to match your workflow. This page explains how to customize CLI behavior using command flags and
+environment variables.
+
+## Update notifications
+
+Shopware CLI displays update notifications when a newer version is available. You can silence these notifications for a single command by adding the `--no-update-hint` flag:
+
+```bash
+shopware-cli --no-update-hint <command>
+```
+
+:::info CI environments
+Shopware CLI automatically detects CI environments and suppresses update notifications there. You do not need to add the `--no-update-hint` flag or set an environment variable when running the CLI in CI.
+:::
+
+To silence update notifications for the current shell session, set the `SHOPWARE_CLI_NO_UPDATE_NOTIFICATION` environment variable:
+
+```bash
+export SHOPWARE_CLI_NO_UPDATE_NOTIFICATION=true
+```
+
+To make this setting persistent, add the `export` command to your shell profile, such as `~/.bashrc` or `~/.zshrc`.


### PR DESCRIPTION
## Summary

- Adds a new Configuration chapter for Shopware CLI configuration topics.
- Documents how to disable update notifications for a single command using the --no-update-hint flag.
- Documents how to disable update notifications persistently using an environment variable.
- Notes that update notifications are automatically suppressed in CI environments.

## Related links

This documentation covers the changes introduced in shopware/shopware-cli#1091
(https://github.com/shopware/shopware-cli/issues/1091).

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [x] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.