### PR TITLE
docs(storefront): use ProductListingCollectSortingEvent for runtime sortings

### DIFF
--- a/guides/plugins/plugins/storefront/howto/add-custom-sorting-product-listing.md
+++ b/guides/plugins/plugins/storefront/howto/add-custom-sorting-product-listing.md
@@ -101,7 +101,7 @@ This event is available since Shopware 6.7.15.0.
 While possible, it is not recommended adding an individual sorting at runtime. If you just wish for your individual sorting to be not editable by users in the Administration, create a migration and set the parameter `locked` to be `true`.
 :::
 
-Here's an example how your subscriber could look like:
+Here's an example of what your subscriber could look like:
 
 ```php
 // <plugin root>/src/Subscriber/ExampleListingSubscriber.php
@@ -148,4 +148,4 @@ class ExampleListingSubscriber implements EventSubscriberInterface
 
 ## Next steps
 
-To [add a custom filter](./add-listing-filters.md) to your listing in the Storefront head over to the corresponding guide.
+To [add a custom filter](./add-listing-filters.md) to your listing in the Storefront, head over to the corresponding guide.

--- a/guides/plugins/plugins/storefront/howto/add-custom-sorting-product-listing.md
+++ b/guides/plugins/plugins/storefront/howto/add-custom-sorting-product-listing.md
@@ -91,7 +91,11 @@ class Migration1615470599ExampleSorting extends MigrationStep
 
 ## Create individual sorting at runtime
 
-You can subscribe to the `ProductListingCriteriaEvent` to add a `ProductSortingEntity` as available sorting on the fly. If you don't know how to do this, head over to our [Listening to events](../../framework/event/listening-to-events.md) guide.
+You can subscribe to the `ProductListingCollectSortingEvent` to add a `ProductSortingEntity` as an available sorting on the fly. If you don't know how to do this, head over to our [Listening to events](../../framework/event/listening-to-events.md) guide.
+
+::: info
+This event is available since Shopware 6.7.15.0.
+:::
 
 ::: info
 While possible, it is not recommended adding an individual sorting at runtime. If you just wish for your individual sorting to be not editable by users in the Administration, create a migration and set the parameter `locked` to be `true`.
@@ -105,8 +109,7 @@ Here's an example how your subscriber could look like:
 
 namespace Swag\BasicExample\Subscriber;
 
-use Shopware\Core\Content\Product\Events\ProductListingCriteriaEvent;
-use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingCollection;
+use Shopware\Core\Content\Product\Events\ProductListingCollectSortingEvent;
 use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingEntity;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -117,17 +120,12 @@ class ExampleListingSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            // be sure to subscribe with high priority to add you sorting before the default shopware logic applies
-            // otherwise storefront will throw a ProductSortingNotFoundException
-            ProductListingCriteriaEvent::class => ['addMyCustomSortingToStorefront', 500],
+            ProductListingCollectSortingEvent::class => 'addMyCustomSortingToStorefront',
         ];
     }
 
-    public function addMyCustomSortingToStorefront(ProductListingCriteriaEvent $event): void
+    public function addMyCustomSortingToStorefront(ProductListingCollectSortingEvent $event): void
     {
-        /** @var ProductSortingCollection $availableSortings */
-        $availableSortings = $event->getCriteria()->getExtension('sortings') ?? new ProductSortingCollection();
-
         $myCustomSorting = new ProductSortingEntity();
         $myCustomSorting->setId(Uuid::randomHex());
         $myCustomSorting->setActive(true);
@@ -143,9 +141,7 @@ class ExampleListingSubscriber implements EventSubscriberInterface
             ],
         ]);
 
-        $availableSortings->add($myCustomSorting);
-
-        $event->getCriteria()->addExtension('sortings', $availableSortings);
+        $event->getSortings()->add($myCustomSorting);
     }
 }
 ```


### PR DESCRIPTION
## Summary

The "Create individual sorting at runtime" recipe on the [custom sorting guide](https://developer.shopware.com/docs/guides/plugins/plugins/storefront/add-custom-sorting-product-listing.html#create-individual-sorting-at-runtime) does not work and has not worked since v6.6.

It tells you to add a `ProductSortingEntity` to the `sortings` criteria extension from `ProductListingCriteriaEvent`, subscribing with `priority => 500` "to add your sorting before the default shopware logic applies". That was accurate while the sorting logic lived in `ProductListingFeaturesSubscriber`, a listener on the same event. Since shopware/shopware@588c40d51c5 removed that subscriber, `SortingListingProcessor::prepare()` runs before the event is dispatched, so no listener priority can precede it. Following the guide today produces a sorting that appears in the Storefront dropdown but never orders the products — see shopware/shopware#6072.

This updates the section to the new `ProductListingCollectSortingEvent`, which is dispatched before the requested sorting is resolved:

- subscribe to `ProductListingCollectSortingEvent` instead, without the priority workaround and without the stale `ProductSortingNotFoundException` warning
- add the entity via `$event->getSortings()->add(...)` instead of reading and re-writing the `sortings` criteria extension
- drop the now-unused `ProductSortingCollection` import
- note that the event is available since 6.7.15.0, and what the old recipe actually did on earlier versions

## Related links

- Adds the event: shopware/shopware#16213
- Fixes the reported behaviour: shopware/shopware#6072
- Jira: https://shopware.atlassian.net/browse/NEXT-40220

## Checklist

- [x] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [x] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [x] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

The dependent-changes box is unchecked because shopware/shopware#16213 is still open. Please merge this only once that lands, so the guide does not document an event that does not exist yet.

No page was moved or renamed, so no redirect is needed. No wordlist entry is needed either: the new identifiers appear only inside code spans and code blocks, the same way `ProductListingCriteriaEvent` did before.

Verified locally with `avtodev/markdown-lint:v1.5` against `markdown-style-config.yml` — no findings.
