### PR TITLE
docs: document `postinstall` copy-out workaround for shopware-cli #1466

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -2185,6 +2185,7 @@ vue
 vuex
 walkthrough
 wav
+webfonts
 webhook
 webhooks
 webkit

--- a/guides/plugins/plugins/dependencies/using-npm-dependencies.md
+++ b/guides/plugins/plugins/dependencies/using-npm-dependencies.md
@@ -126,6 +126,93 @@ Build the Storefront using:
 shopware-cli project storefront-build
 ```
 
+## Using npm packages in a pure-SCSS theme (no JS entry point)
+
+If your plugin is a **theme** and only consumes npm packages from SCSS (for example `@fortawesome/fontawesome-free` or any other package referenced via `@import` in your `theme.json` `style` entries), you will run into a chicken-and-egg problem with `shopware-cli project storefront-build`:
+
+* `shopware-cli` only runs `npm install` for a storefront extension when it has a JavaScript entry point (`src/Resources/app/storefront/src/main.js`).
+* Even when a `main.js` is present, `shopware-cli` runs the asset build (webpack) first and **then deletes the storefront-root `node_modules` directory** before `theme:compile` runs.
+
+The result is that a `theme.json`/`SCSS` `@import` like `app/storefront/node_modules/@fortawesome/fontawesome-free/scss/fontawesome` cannot be resolved, and `theme:compile` aborts with:
+
+```text
+Unable to compile the theme "MyTheme". Unable to resolve file
+"Resources/app/storefront/node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss".
+```
+
+### Workaround: copy required assets out via `postinstall`
+
+Because the `postinstall` script of a storefront extension's `package.json` runs **before** the root `node_modules` directory is deleted, you can copy the parts of the package that `theme:compile` needs into a persistent (git-ignored) folder inside the theme. After that, the SCSS imports and `theme.json` `style` entries must point at that folder instead of `node_modules`.
+
+The nested folder must contain a `node_modules` path segment, because `shopware-cli project format` / `validate` only ignore the storefront-**root** `node_modules` and `shopware-cli` only deletes that one level. A nested copy survives both steps.
+
+#### 1. Provide an empty JS entry point
+
+Add an empty `src/Resources/app/storefront/src/main.js` so `shopware-cli` installs the theme's npm dependencies and runs its lifecycle scripts:
+
+```javascript
+// <plugin root>/src/Resources/app/storefront/src/main.js
+// Intentionally empty. Present so shopware-cli installs this theme's npm
+// dependencies and runs the package.json "postinstall" below.
+```
+
+#### 2. Copy the needed files out of `node_modules` in `postinstall`
+
+```json
+// <plugin root>/src/Resources/app/storefront/package.json
+{
+    "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.1.1"
+    },
+    "scripts": {
+        "postinstall": "rm -rf .vendor && mkdir -p .vendor/node_modules/@fortawesome/fontawesome-free && cp -R node_modules/@fortawesome/fontawesome-free/scss .vendor/node_modules/@fortawesome/fontawesome-free/ && mkdir -p ../../public/static/fonts && cp node_modules/@fortawesome/fontawesome-free/webfonts/fa-* ../../public/static/fonts/"
+    }
+}
+```
+
+The script does three things:
+
+* Copies the package's **SCSS** into `.vendor/node_modules/@fortawesome/fontawesome-free/scss/` so `theme:compile` can still resolve it after the root `node_modules` is removed.
+* Copies the package's **webfonts** into `public/static/fonts/` so the compiled theme can serve the font files at runtime.
+* Keeps the copy nested under a `node_modules` path segment so the format/validate check does not flag the copied files.
+
+#### 3. Update the theme to reference the copied files
+
+```jsonc
+// <plugin root>/src/Resources/theme.json
+{
+    "style": [
+        "app/storefront/.vendor/node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss",
+        "app/storefront/src/scss/base.scss"
+    ]
+}
+```
+
+```scss
+// <plugin root>/src/Resources/app/storefront/src/scss/base.scss
+@import '../../.vendor/node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
+```
+
+If the package ships runtime assets (webfonts, images, …) that you previously exposed through the `asset` block in `theme.json` via a `node_modules/...` path, point those entries at the `public/static/...` copy instead.
+
+#### 4. Ignore the generated files
+
+Add the generated folders to your `.gitignore`:
+
+```gitignore
+/.vendor/
+/public/static/fonts/fa-*
+```
+
+### Why this works and what to expect
+
+* `shopware-cli project storefront-build` runs `npm install` for the theme (because `main.js` exists), which triggers `postinstall` and copies the files into `.vendor/` and `public/static/fonts/`.
+* The webpack build runs, the storefront-root `node_modules` is deleted, and then `theme:compile` runs against the persistent `.vendor/node_modules/...` copy. The build exits 0.
+* `shopware-cli project format` / `validate` do not flag the copied files because they live under a nested `node_modules/` path.
+* The webfonts end up under `public/bundles/<theme>/static/fonts/` after compilation, which is what the SCSS expects at runtime.
+
+This workaround is known to be fragile: it depends on `shopware-cli` running npm lifecycle scripts and on the cleanup deleting only the storefront-root `node_modules`. If you do not need npm packages in your theme, prefer keeping the theme free of `node_modules` imports. A longer-term fix (installing npm dependencies for a JS-less theme and deferring the `node_modules` cleanup until after `theme:compile`) is being discussed in [shopware/shopware-cli#1466](https://github.com/shopware/shopware-cli/issues/1466).
+
 ## Next steps
 
 Now that you know how to include new `npm` dependencies you might want to create a service with them. Learn how to do that in this guide: [How to add a custom-service](../administration/services-utilities/add-custom-service.md)

--- a/guides/plugins/plugins/dependencies/using-npm-dependencies.md
+++ b/guides/plugins/plugins/dependencies/using-npm-dependencies.md
@@ -29,8 +29,9 @@ Since Shopware 6.7, the Administration build system has been migrated from Webpa
 
 You can import npm packages directly in your code without any additional build configuration:
 
-```javascript
-// <plugin root>/src/Resources/app/administration/src/example-component.js
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/administration/src/example-component.js]
 import { log } from 'missionlog';
 
 // Initializing the logger
@@ -39,10 +40,13 @@ log.init({ initializer: 'INFO' }, (level, tag, msg, params) => {
 });
 ```
 
+:::
+
 If you need custom Vite configuration (for example, path aliases), create a `vite.config.mts` file in the `<plugin root>/src/Resources/app/administration/src/` directory (alongside your entry file, e.g., `main.js`). Note that `package.json` stays in `<plugin root>/src/Resources/app/administration/`:
 
-```typescript
-// <plugin root>/src/Resources/app/administration/src/vite.config.mts
+::: code-group
+
+```typescript [PLUGIN_ROOT/src/Resources/app/administration/src/vite.config.mts]
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -53,6 +57,8 @@ export default defineConfig({
     },
 });
 ```
+
+:::
 
 Build the Administration using:
 
@@ -66,8 +72,9 @@ For more information on migrating from Webpack to Vite, see the [Webpack to Vite
 
 The Storefront build system continues to use [Webpack](https://webpack.js.org/). To make Webpack aware of the npm packages installed in your plugin, create a `webpack.config.js` file in the `<plugin root>/src/Resources/app/storefront/build/` directory:
 
-```javascript
-// <plugin root>/src/Resources/app/storefront/build/webpack.config.js
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/storefront/build/webpack.config.js]
 module.exports = (params) => {
     return {
         resolve: {
@@ -79,14 +86,17 @@ module.exports = (params) => {
 }
 ```
 
+:::
+
 This tells Webpack to also search for modules in your plugin's `node_modules` folder, in addition to Shopware's own `node_modules`.
 
 ### Using the dependency in the Storefront
 
 Once you have installed all the dependencies and registered the plugin's `node_modules` path in the build system, you can import and use the package in your code:
 
-```javascript
-// <plugin root>/src/Resources/app/storefront/src/example.plugin.js
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/storefront/src/example.plugin.js]
 const { PluginBaseClass } = window;
 
 // Import logger
@@ -108,10 +118,13 @@ export default class ExamplePlugin extends PluginBaseClass {
 }
 ```
 
+:::
+
 Register the plugin in your `main.js` file so it can be loaded by the plugin system:
 
-```javascript
-// <plugin root>/src/Resources/app/storefront/src/main.js
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/storefront/src/main.js]
 import ExamplePlugin from './example.plugin';
 
 PluginManager.register(
@@ -119,6 +132,8 @@ PluginManager.register(
     ExamplePlugin
 );
 ```
+
+:::
 
 Build the Storefront using:
 
@@ -150,16 +165,20 @@ The nested folder must contain a `node_modules` path segment, because `shopware-
 
 Add an empty `src/Resources/app/storefront/src/main.js` so `shopware-cli` installs the theme's npm dependencies and runs its lifecycle scripts:
 
-```javascript
-// <plugin root>/src/Resources/app/storefront/src/main.js
+::: code-group
+
+```javascript [PLUGIN_ROOT/src/Resources/app/storefront/src/main.js]
 // Intentionally empty. Present so shopware-cli installs this theme's npm
 // dependencies and runs the package.json "postinstall" below.
 ```
 
-#### 2. Copy the needed files out of `node_modules` in `postinstall`
+:::
 
-```json
-// <plugin root>/src/Resources/app/storefront/package.json
+#### 2. Copy the necessary files out of `node_modules` in `postinstall`
+
+::: code-group
+
+```json [PLUGIN_ROOT/src/Resources/app/storefront/package.json]
 {
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.1.1"
@@ -170,6 +189,8 @@ Add an empty `src/Resources/app/storefront/src/main.js` so `shopware-cli` instal
 }
 ```
 
+:::
+
 The script does three things:
 
 * Copies the package's **SCSS** into `.vendor/node_modules/@fortawesome/fontawesome-free/scss/` so `theme:compile` can still resolve it after the root `node_modules` is removed.
@@ -178,8 +199,9 @@ The script does three things:
 
 #### 3. Update the theme to reference the copied files
 
-```jsonc
-// <plugin root>/src/Resources/theme.json
+::: code-group
+
+```json [PLUGIN_ROOT/src/Resources/theme.json]
 {
     "style": [
         "app/storefront/.vendor/node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss",
@@ -188,10 +210,11 @@ The script does three things:
 }
 ```
 
-```scss
-// <plugin root>/src/Resources/app/storefront/src/scss/base.scss
+```scss [PLUGIN_ROOT/src/Resources/app/storefront/src/scss/base.scss]
 @import '../../.vendor/node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
 ```
+
+:::
 
 If the package ships runtime assets (webfonts, images, …) that you previously exposed through the `asset` block in `theme.json` via a `node_modules/...` path, point those entries at the `public/static/...` copy instead.
 
@@ -199,10 +222,14 @@ If the package ships runtime assets (webfonts, images, …) that you previously 
 
 Add the generated folders to your `.gitignore`:
 
-```gitignore
+::: code-group
+
+```gitignore [PLUGIN_ROOT/.gitignore]
 /.vendor/
 /public/static/fonts/fa-*
 ```
+
+:::
 
 ### Why this works and what to expect
 

--- a/guides/plugins/plugins/dependencies/using-npm-dependencies.md
+++ b/guides/plugins/plugins/dependencies/using-npm-dependencies.md
@@ -211,6 +211,7 @@ The script does three things:
 ```
 
 ```scss [PLUGIN_ROOT/src/Resources/app/storefront/src/scss/base.scss]
+$fa-font-path: "../static/fonts";
 @import '../../.vendor/node_modules/@fortawesome/fontawesome-free/scss/fontawesome';
 ```
 

--- a/guides/plugins/themes/styling/add-css-js-to-theme.md
+++ b/guides/plugins/themes/styling/add-css-js-to-theme.md
@@ -123,6 +123,10 @@ composer run watch:storefront
 
 This command starts a NodeJS web server on port `9998`. If you open the Storefront of your Shopware installation on `localhost:9998`, this page will be automatically updated when you make changes to your theme.
 
+### Referencing npm packages in SCSS
+
+If you need to consume an npm package directly from your theme's SCSS (for example `@fortawesome/fontawesome-free`), `shopware-cli project storefront-build` will not install it for you unless the theme also has a JavaScript entry point, and even then the storefront-root `node_modules` is removed before `theme:compile` runs. See [Using npm packages in a pure-SCSS theme](../../plugins/dependencies/using-npm-dependencies.md#using-npm-packages-in-a-pure-scss-theme-no-js-entry-point) for the `postinstall` copy-out workaround.
+
 ## Next steps
 
 Now that you know how to customize the styling via SCSS and add JavaScript, here is a list of things you can do.


### PR DESCRIPTION
Documents the known workaround from [shopware/shopware-cli#1466](https://github.com/shopware/shopware-cli/issues/1466) so theme authors can keep using npm packages (e.g. `@fortawesome/fontawesome-free`) from SCSS while the upstream fix is still open.

### Problem

`shopware-cli project storefront-build` fails for a pure-SCSS theme that imports from `node_modules` because:

* it only runs `npm install` for storefront extensions with a JS entry point, and
* even with a `main.js`, the storefront-root `node_modules` is removed before `theme:compile` runs.

### Changes

* New section **"Using npm packages in a pure-SCSS theme (no JS entry point)"** in `guides/plugins/plugins/dependencies/using-npm-dependencies.md` describing the `postinstall` copy-out workaround: empty `main.js`, `package.json` `postinstall` that copies SCSS into `.vendor/node_modules/...` and webfonts into `public/static/fonts/`, updated `theme.json`/`SCSS` paths, and `.gitignore` entries.
* Short pointer with anchor link from `guides/plugins/themes/styling/add-css-js-to-theme.md` so theme authors find the workaround from the theme styling guide.
* Added `webfonts` to `.wordlist.txt`.

### Quality

* `make spellcheck` passes.
* `make fix` (markdown lint) passes.

Refs shopware/shopware-cli#1466.