### PR TITLE
chore: unique paas native application names

### DIFF
--- a/products/paas/shopware/fundamentals/applications.md
+++ b/products/paas/shopware/fundamentals/applications.md
@@ -36,6 +36,10 @@ Create a new application to a project:
 sw-paas application create
 ```
 
+:::warning
+Application names must be unique within a project and can only be used once. After an application is deleted, its name remains reserved and cannot be reused for another application in the same project.
+:::
+
 ## Build your application
 
 To trigger a new build for the application via CLI, use the following command:


### PR DESCRIPTION
## Summary

PaaS Native application names are unique and cannot be reused.

## Related links

<!-- Link related issues, pull requests, commits, or source references. -->

## Checklist

- [ ] I reviewed affected links, code samples, and cross-references, including `PageRef` references where relevant.
- [ ] I added or updated redirects in `.gitbook.yaml` if pages were moved, renamed, or deleted.
- [ ] I updated `.wordlist.txt` (and sorted it) if spellcheck flags new legitimate terms.
- [ ] Any required dependent changes in downstream modules have already been merged and published.
- [x] This pull request is ready for review.

## Notes

<!-- Add anything that helps review this change quickly. -->
