### PR TITLE
fix: reject PageRef paths that name an index file

### DIFF
--- a/.github/scripts/broken-pageref.js
+++ b/.github/scripts/broken-pageref.js
@@ -1,12 +1,24 @@
 // deno run --allow-read .github/scripts/broken-pageref.js
 
-import { resolve, dirname, fromFileUrl } from "https://deno.land/std/path/mod.ts";
+import { resolve, dirname } from "https://deno.land/std/path/mod.ts";
 import { walk } from "https://deno.land/std/fs/mod.ts";
 
 const rootDir = resolve(Deno.cwd());
 
-async function findBrokenLinks() {
+function indexFormSuggestion(relativePath) {
+  const segments = relativePath.split('/');
+  const lastSegment = segments.pop();
+
+  if (!['index', 'index.md', 'index.html'].includes(lastSegment)) {
+    return null;
+  }
+
+  return segments.length ? `${segments.join('/')}/` : './';
+}
+
+async function findPageRefIssues() {
   const brokenLinks = [];
+  const indexLinks = [];
 
   for await (const entry of walk(rootDir, { exts: ['.md'], followSymlinks: true })) {
     if (entry.isFile) {
@@ -14,21 +26,22 @@ async function findBrokenLinks() {
       const matches = [...content.matchAll(/<PageRef page="([^"]+)"/g)];
 
       for (const match of matches) {
-        let relativePath = match[1];
+        const page = match[1];
 
-        if (relativePath.startsWith('http')) {
+        if (page.startsWith('http')) {
           continue
         }
 
-        if (relativePath.includes('#')) {
-          relativePath = relativePath.split('#')[0]
+        let relativePath = page.includes('#') ? page.split('#')[0] : page;
+
+        const suggestion = indexFormSuggestion(relativePath);
+        if (suggestion) {
+          indexLinks.push({ file: entry.path, page, suggestion });
         }
 
         if (relativePath.endsWith('/')) {
-          relativePath = `${relativePath}/index.md`
-        }
-
-        if (relativePath.endsWith('.html')) {
+          relativePath = `${relativePath}index.md`
+        } else if (relativePath.endsWith('.html')) {
           relativePath = `${relativePath.substring(0, relativePath.length - '.html'.length)}.md`
         } else if (!relativePath.endsWith('.md')) {
           relativePath = `${relativePath}.md`
@@ -45,10 +58,11 @@ async function findBrokenLinks() {
     }
   }
 
-  return brokenLinks;
+  return { brokenLinks, indexLinks };
 }
 
-const brokenLinks = await findBrokenLinks();
+const { brokenLinks, indexLinks } = await findPageRefIssues();
+
 if (brokenLinks.length) {
   console.log('Broken links found:');
   brokenLinks.forEach(link => {
@@ -57,6 +71,19 @@ if (brokenLinks.length) {
     console.log(`Resolved Path: ${link.resolvedPath}`);
     console.log('---');
   });
+}
+
+if (indexLinks.length) {
+  console.log('PageRef links naming an index file found (use the directory form so the card resolves the target title):');
+  indexLinks.forEach(link => {
+    console.log(`File: ${link.file}`);
+    console.log(`Found: <PageRef page="${link.page}" />`);
+    console.log(`Use: <PageRef page="${link.suggestion}" />`);
+    console.log('---');
+  });
+}
+
+if (brokenLinks.length || indexLinks.length) {
   Deno.exit(1)
 }
 

--- a/.github/scripts/broken-pageref.js
+++ b/.github/scripts/broken-pageref.js
@@ -32,11 +32,13 @@ async function findPageRefIssues() {
           continue
         }
 
-        let relativePath = page.includes('#') ? page.split('#')[0] : page;
+        const hashIndex = page.indexOf('#');
+        const fragment = hashIndex === -1 ? '' : page.slice(hashIndex);
+        let relativePath = hashIndex === -1 ? page : page.slice(0, hashIndex);
 
         const suggestion = indexFormSuggestion(relativePath);
         if (suggestion) {
-          indexLinks.push({ file: entry.path, page, suggestion });
+          indexLinks.push({ file: entry.path, page, suggestion: `${suggestion}${fragment}` });
         }
 
         if (relativePath.endsWith('/')) {

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 CLAUDE.md
 .cursor/
 .venv-spellcheck
+
+# Deno (broken-pageref.js)
+/deno.lock

--- a/guides/development/testing/index.md
+++ b/guides/development/testing/index.md
@@ -20,7 +20,7 @@ Playwright provides:
 * API clients
 * Test data helpers
 
-<PageRef page="../testing/e2e-playwright/index" title="E2E playwright" />
+<PageRef page="../testing/e2e-playwright/" />
 
 ## Unit testing
 
@@ -56,7 +56,7 @@ To publish your extension in the Shopware Store, follow the testing criteria use
 
 Detailed Shopware Store QA topics (scope, code quality, storefront, SEO, cookies, content, installation):
 
-<PageRef page="../testing/store/index" title="Store" />
+<PageRef page="../testing/store/" />
 
 For the official publication requirements, legal conditions, and compliance rules, see:
 

--- a/guides/development/testing/store/index.md
+++ b/guides/development/testing/store/index.md
@@ -56,4 +56,4 @@ For submission logistics, timelines, and readiness questions that do not fit a s
 
 For automated and manual testing strategies to complement your Store submission, see the broader testing section:
 
-<PageRef page="../index" title="Testing" />
+<PageRef page="../" />

--- a/guides/plugins/apps/rule-builder/add-custom-rule-conditions.md
+++ b/guides/plugins/apps/rule-builder/add-custom-rule-conditions.md
@@ -23,11 +23,11 @@ If you're not familiar with the app system, please take a look at the concept fi
 
 You should also be familiar with the general concept of the Rule Builder.
 
-<PageRef page="../../../../concepts/framework/rule-system/index.md" />
+<PageRef page="../../../../concepts/framework/rule-system/" />
 
 For the attached logic of your custom conditions, you'll use [Twig files](https://twig.symfony.com/). Please refer to the App Scripts guide for a general introduction.
 
-<PageRef page="../app-scripts/index.md" />
+<PageRef page="../app-scripts/" />
 
 ## Definition
 


### PR DESCRIPTION
Two cards on the [Add Custom Rule Conditions](https://developer.shopware.com/docs/guides/plugins/apps/rule-builder/add-custom-rule-conditions.html) guide render as bare arrows with no label:

<img width="803" height="291" alt="image" src="https://github.com/user-attachments/assets/9a935a86-4c13-421b-92da-6bc742bf1304" />

The updated script catches those, see https://github.com/shopware/docs/actions/runs/33760132753/job/100664103263?pr=2498:

```
PageRef links naming an index file found (use the directory form so the card resolves the target title):
File: /home/runner/work/docs/docs/guides/plugins/apps/rule-builder/add-custom-rule-conditions.md
Found: <PageRef page="../../../../concepts/framework/rule-system/index.md" />
Use: <PageRef page="../../../../concepts/framework/rule-system/" />
---
File: /home/runner/work/docs/docs/guides/plugins/apps/rule-builder/add-custom-rule-conditions.md
Found: <PageRef page="../app-scripts/index.md" />
Use: <PageRef page="../app-scripts/" />
---
File: /home/runner/work/docs/docs/guides/development/testing/store/index.md
Found: <PageRef page="../index" />
Use: <PageRef page="../" />
---
File: /home/runner/work/docs/docs/guides/development/testing/index.md
Found: <PageRef page="../testing/e2e-playwright/index" />
Use: <PageRef page="../testing/e2e-playwright/" />
---
File: /home/runner/work/docs/docs/guides/development/testing/index.md
Found: <PageRef page="../testing/store/index" />
Use: <PageRef page="../testing/store/" />
---
```