### PR TITLE
docs: backfill min_version frontmatter for 9 whole-page "available since" files (E45S20)

### DIFF
--- a/concepts/framework/in-app-purchases.md
+++ b/concepts/framework/in-app-purchases.md
@@ -2,6 +2,7 @@
 nav:
   title: In-App Purchases
   position: 90
+min_version: "6.6.9.0"
 
 ---
 

--- a/guides/development/monetization/in-app-purchases.md
+++ b/guides/development/monetization/in-app-purchases.md
@@ -2,6 +2,7 @@
 nav:
   title: In-App Purchases (IAP)
   position: 50
+min_version: "6.6.9.0"
 
 ---
 

--- a/guides/hosting/configurations/shopware/static-system-config.md
+++ b/guides/hosting/configurations/shopware/static-system-config.md
@@ -2,6 +2,7 @@
 nav:
   title: Static System Configuration
   position: 30
+min_version: "6.6.4.0"
 
 ---
 

--- a/guides/plugins/apps/gateways/in-app-purchase/in-app-purchase-gateway.md
+++ b/guides/plugins/apps/gateways/in-app-purchase/in-app-purchase-gateway.md
@@ -2,6 +2,7 @@
 nav:
   title: In-App Purchase Gateway
   position: 50
+min_version: "6.6.9.0"
 ---
 
 # In-App Purchase Gateway

--- a/guides/plugins/plugins/content/media/remote-thumbnail-generation.md
+++ b/guides/plugins/plugins/content/media/remote-thumbnail-generation.md
@@ -2,6 +2,7 @@
 nav:
   title: Remote Thumbnail Generation
   position: 40
+min_version: "6.6.4.0"
 
 ---
 

--- a/guides/plugins/plugins/in-app-purchases.md
+++ b/guides/plugins/plugins/in-app-purchases.md
@@ -2,6 +2,7 @@
 nav:
   title: In-App Purchases (IAP)
   position: 60
+min_version: "6.6.9.0"
 
 ---
 

--- a/guides/plugins/plugins/storefront/templates/agentic-files.md
+++ b/guides/plugins/plugins/storefront/templates/agentic-files.md
@@ -2,6 +2,7 @@
 nav:
   title: Agentic Files
   position: 15
+min_version: "6.7.12.0"
 
 ---
 

--- a/products/extensions/b2b-components/individual-pricing/index.md
+++ b/products/extensions/b2b-components/individual-pricing/index.md
@@ -2,6 +2,7 @@
 nav:
   title: Individual Pricing
   position: 40
+min_version: "6.7.8.0"
 
 ---
 

--- a/products/extensions/subscriptions/guides/mixed-checkout.md
+++ b/products/extensions/subscriptions/guides/mixed-checkout.md
@@ -2,6 +2,7 @@
 nav:
   title: Mixed checkout
   position: 20
+min_version: "6.7.4.0"
 
 ---
 # Mixed subscription checkout


### PR DESCRIPTION
## What
Formalizes the existing informal "available since X.Y" authoring convention (used across ~24 files) as a real `min_version` frontmatter key, and backfills it for the 9 files where the version note genuinely describes the page's own primary subject.

## Why
Recommended by `E46S56`, designed in detail by `E46S59` (both in the `dev-ai-cp` planning workspace) as a defense-in-depth signal for version-scoped retrieval and synthesis in the Shopware docs chatbot.

## Why only 9 of the ~24 files
Of the 24 files using the informal "available since" pattern, only 9 are genuinely whole-page/single-topic documents where the note describes the page's own subject. The other 15 have the version note scoped to one narrow subsection of an otherwise general page (e.g. one shard-config detail inside a much longer Elasticsearch setup guide) — backfilling those as a page-level `min_version` would have introduced a misleading claim, so they were deliberately left alone rather than guessed at.

**Note**: this does not address the separately-tracked `ISSUE-015` (`customize-header-footer.md`) — that page was never part of the informal "available since" set, so no frontmatter convention here retroactively flags it. That needs its own dedicated docs-team edit.

## Companion PR
Pipeline-consumption side (parsing this frontmatter and propagating it into the docs Qdrant payloads) is `shopware/ai-mcp-infra#175`.

Sprint: E45S20 (`.builder/sprints/E45S20-docs-min-version-frontmatter-convention-and-backfill.mdc` in `dev-ai-cp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)